### PR TITLE
Removed aztro from resources and Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1505,7 +1505,6 @@
 |---|---|---|---|---|
 | [4chan](https://github.com/4chan/4chan-API) | Simple image-based bulletin board dedicated to a variety of topics | No | Yes | Yes |
 | [Ayrshare](https://www.ayrshare.com) | Social media APIs to post, get analytics, and manage multiple users social media accounts | `apiKey` | Yes | Yes |
-| [aztro](https://aztro.sameerkumar.website/) | Daily horoscope info for yesterday, today, and tomorrow | No | Yes | Unknown |
 | [Blogger](https://developers.google.com/blogger/) | The Blogger APIs allows client applications to view and update Blogger content | `OAuth`| Yes | Unknown |
 | [Discord](https://discord.com/developers/docs/intro) | Make bots for Discord, integrate Discord onto an external platform | `OAuth`| Yes | Unknown |
 | [Disqus](https://disqus.com/api/docs/auth/) | Communicate with Disqus data | `OAuth`| Yes | Unknown |

--- a/db/resources.json
+++ b/db/resources.json
@@ -10541,15 +10541,6 @@
         "Category": "Social"
     },
     {
-        "API": "aztro",
-        "Description": "Daily horoscope info for yesterday, today, and tomorrow",
-        "Auth": "",
-        "HTTPS": true,
-        "Cors": "unknown",
-        "Link": "https://aztro.sameerkumar.website/",
-        "Category": "Social"
-    },
-    {
         "API": "Blogger",
         "Description": "The Blogger APIs allows client applications to view and update Blogger content",
         "Auth": "OAuth",


### PR DESCRIPTION
This PR deprecates the Aztro API by removing it from the public-apis repo's resources and updating the Readme to reflect its removal.
No additional changes.