### PR TITLE
Remove Dune API - deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@
 <br/>
 <br/>
 
-
 <div align="center">
     <a href="API.md">API</a> •
     <a href="CONTRIBUTING.md">Contributing Guide</a> •
@@ -35,1775 +34,1826 @@
 </div>
 
 ## Index
-* [Animals](#animals)
-* [Anime](#anime)
-* [Anti-Malware](#anti-malware)
-* [Art & Design](#art--design)
-* [Authentication & Authorization](#authentication--authorization)
-* [Blockchain](#blockchain)
-* [Books](#books)
-* [Business](#business)
-* [Calendar](#calendar)
-* [Cloud Storage & File Sharing](#cloud-storage--file-sharing)
-* [Continuous Integration](#continuous-integration)
-* [Cryptocurrency](#cryptocurrency)
-* [Currency Exchange](#currency-exchange)
-* [Data Validation](#data-validation)
-* [Development](#development)
-* [Dictionaries](#dictionaries)
-* [Documents & Productivity](#documents--productivity)
-* [Email](#email)
-* [Entertainment](#entertainment)
-* [Environment](#environment)
-* [Events](#events)
-* [Finance](#finance)
-* [Food & Drink](#food--drink)
-* [Games & Comics](#games--comics)
-* [Geocoding](#geocoding)
-* [Government](#government)
-* [Health](#health)
-* [Jobs](#jobs)
-* [Machine Learning](#machine-learning)
-* [Music](#music)
-* [News](#news)
-* [Open Data](#open-data)
-* [Open Source Projects](#open-source-projects)
-* [Patent](#patent)
-* [Personality](#personality)
-* [Phone](#phone)
-* [Photography](#photography)
-* [Podcasts](#podcasts)
-* [Programming](#programming)
-* [Science & Math](#science--math)
-* [Security](#security)
-* [Shopping](#shopping)
-* [Social](#social)
-* [Sports & Fitness](#sports--fitness)
-* [Test Data](#test-data)
-* [Text Analysis](#text-analysis)
-* [Tracking](#tracking)
-* [Transportation](#transportation)
-* [URL Shorteners](#url-shorteners)
-* [Vehicle](#vehicle)
-* [Video](#video)
-* [Weather](#weather)
+
+- [Animals](#animals)
+- [Anime](#anime)
+- [Anti-Malware](#anti-malware)
+- [Art & Design](#art--design)
+- [Authentication & Authorization](#authentication--authorization)
+- [Blockchain](#blockchain)
+- [Books](#books)
+- [Business](#business)
+- [Calendar](#calendar)
+- [Cloud Storage & File Sharing](#cloud-storage--file-sharing)
+- [Continuous Integration](#continuous-integration)
+- [Cryptocurrency](#cryptocurrency)
+- [Currency Exchange](#currency-exchange)
+- [Data Validation](#data-validation)
+- [Development](#development)
+- [Dictionaries](#dictionaries)
+- [Documents & Productivity](#documents--productivity)
+- [Email](#email)
+- [Entertainment](#entertainment)
+- [Environment](#environment)
+- [Events](#events)
+- [Finance](#finance)
+- [Food & Drink](#food--drink)
+- [Games & Comics](#games--comics)
+- [Geocoding](#geocoding)
+- [Government](#government)
+- [Health](#health)
+- [Jobs](#jobs)
+- [Machine Learning](#machine-learning)
+- [Music](#music)
+- [News](#news)
+- [Open Data](#open-data)
+- [Open Source Projects](#open-source-projects)
+- [Patent](#patent)
+- [Personality](#personality)
+- [Phone](#phone)
+- [Photography](#photography)
+- [Podcasts](#podcasts)
+- [Programming](#programming)
+- [Science & Math](#science--math)
+- [Security](#security)
+- [Shopping](#shopping)
+- [Social](#social)
+- [Sports & Fitness](#sports--fitness)
+- [Test Data](#test-data)
+- [Text Analysis](#text-analysis)
+- [Tracking](#tracking)
+- [Transportation](#transportation)
+- [URL Shorteners](#url-shorteners)
+- [Vehicle](#vehicle)
+- [Video](#video)
+- [Weather](#weather)
 
 ### Animals
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/) | Daily cat facts | No | Yes | No |
-| [Cataas](https://cataas.com/) | Cat as a service (cats pictures and gifs) | No | Yes | No |
-| [Cats](https://developers.thecatapi.com/) | Pictures of cats from Tumblr | `apiKey` | Yes | No |
-| [Dog Pics](https://dog.ceo/dog-api/) | Pictures of dogs based on the Stanford Dogs Dataset | No | Yes | Yes |
-| [Dogs](https://dogapi.dog/docs/api-v2) | Random facts and breed information about dogs | No | Yes | Yes |
-| [eBird](https://documenter.getpostman.com/view/664302/S1ENwy59) | Retrieve recent or notable birding observations within a region | `apiKey` | Yes | No |
-| [Foxes](https://foxes.cool) | Random fox images with multiple different tags | No | Yes | Yes |
-| [HTTP Cat](https://http.cat/) | Cat for every HTTP Status | No | Yes | Yes |
-| [HTTP Dog](https://http.dog/) | Dogs for every HTTP response status code | No | Yes | Yes |
-| [IUCN](http://apiv3.iucnredlist.org/api/v3/docs) | IUCN Red List of Threatened Species | `apiKey` | No | No |
-| [MeowFacts](https://github.com/wh-iterabb-it/meowfacts) | Get random cat facts | No | Yes | No |
-| [Movebank](https://github.com/movebank/movebank-api-doc) | Movement and Migration data of animals | No | Yes | Yes |
-| [Petfinder](https://www.petfinder.com/developers/) | Petfinder is dedicated to helping pets find homes, another resource to get pets adopted | `apiKey` | Yes | Yes |
-| [PlaceBear](https://placebear.com/) | Placeholder bear pictures | No | Yes | Yes |
-| [PlaceDog](https://place.dog) | Placeholder Dog pictures | No | Yes | Yes |
-| [RandomDog](https://random.dog/woof.json) | Random pictures of dogs | No | Yes | Yes |
-| [RandomDuck](https://random-d.uk/api) | Random pictures of ducks | No | Yes | No |
-| [RandomFox](https://randomfox.ca/floof/) | Random pictures of foxes | No | Yes | No |
-| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | Adoption | No | Yes | Unknown |
-| [The Dog](https://thedogapi.com/) | A public service all about Dogs, free to use when making your fancy new App, Website or Service | `apiKey` | Yes | No |
-| [xeno-canto](https://xeno-canto.org/explore/api) | Bird recordings | No | Yes | Unknown |
+
+| API                                                                                        | Description                                                                                     | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Cat Facts](https://alexwohlbruck.github.io/cat-facts/)                                    | Daily cat facts                                                                                 | No       | Yes   | No      |
+| [Cataas](https://cataas.com/)                                                              | Cat as a service (cats pictures and gifs)                                                       | No       | Yes   | No      |
+| [Cats](https://developers.thecatapi.com/)                                                  | Pictures of cats from Tumblr                                                                    | `apiKey` | Yes   | No      |
+| [Dog Pics](https://dog.ceo/dog-api/)                                                       | Pictures of dogs based on the Stanford Dogs Dataset                                             | No       | Yes   | Yes     |
+| [Dogs](https://dogapi.dog/docs/api-v2)                                                     | Random facts and breed information about dogs                                                   | No       | Yes   | Yes     |
+| [eBird](https://documenter.getpostman.com/view/664302/S1ENwy59)                            | Retrieve recent or notable birding observations within a region                                 | `apiKey` | Yes   | No      |
+| [Foxes](https://foxes.cool)                                                                | Random fox images with multiple different tags                                                  | No       | Yes   | Yes     |
+| [HTTP Cat](https://http.cat/)                                                              | Cat for every HTTP Status                                                                       | No       | Yes   | Yes     |
+| [HTTP Dog](https://http.dog/)                                                              | Dogs for every HTTP response status code                                                        | No       | Yes   | Yes     |
+| [IUCN](http://apiv3.iucnredlist.org/api/v3/docs)                                           | IUCN Red List of Threatened Species                                                             | `apiKey` | No    | No      |
+| [MeowFacts](https://github.com/wh-iterabb-it/meowfacts)                                    | Get random cat facts                                                                            | No       | Yes   | No      |
+| [Movebank](https://github.com/movebank/movebank-api-doc)                                   | Movement and Migration data of animals                                                          | No       | Yes   | Yes     |
+| [Petfinder](https://www.petfinder.com/developers/)                                         | Petfinder is dedicated to helping pets find homes, another resource to get pets adopted         | `apiKey` | Yes   | Yes     |
+| [PlaceBear](https://placebear.com/)                                                        | Placeholder bear pictures                                                                       | No       | Yes   | Yes     |
+| [PlaceDog](https://place.dog)                                                              | Placeholder Dog pictures                                                                        | No       | Yes   | Yes     |
+| [RandomDog](https://random.dog/woof.json)                                                  | Random pictures of dogs                                                                         | No       | Yes   | Yes     |
+| [RandomDuck](https://random-d.uk/api)                                                      | Random pictures of ducks                                                                        | No       | Yes   | No      |
+| [RandomFox](https://randomfox.ca/floof/)                                                   | Random pictures of foxes                                                                        | No       | Yes   | No      |
+| [RescueGroups](https://userguide.rescuegroups.org/display/APIDG/API+Developers+Guide+Home) | Adoption                                                                                        | No       | Yes   | Unknown |
+| [The Dog](https://thedogapi.com/)                                                          | A public service all about Dogs, free to use when making your fancy new App, Website or Service | `apiKey` | Yes   | No      |
+| [xeno-canto](https://xeno-canto.org/explore/api)                                           | Bird recordings                                                                                 | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Anime
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AniDB](https://wiki.anidb.net/HTTP_API_Definition) | Anime Database | `apiKey` | No | Yes |
-| [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs) | Anime discovery & tracking | `OAuth`| Yes | Unknown |
-| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | Anime industry news | No | Yes | Yes |
-| [Danbooru Anime](https://danbooru.donmai.us/wiki_pages/help:api) | Thousands of anime artist database to find good anime art | `apiKey` | Yes | Yes |
-| [Dattebayo API](https://api-dattebayo.vercel.app/) | Dattebayo: Your Ultimate Naruto Anime API | No | Yes | No |
-| [Jikan](https://jikan.moe) | Unofficial MyAnimeList API | No | Yes | Yes |
-| [Kitsu](https://kitsu.docs.apiary.io/) | Anime discovery platform | `OAuth`| Yes | Yes |
-| [MangaDex](https://api.mangadex.org/docs/) | Manga Database and Community | `apiKey` | Yes | Unknown |
-| [Mangapi](https://rapidapi.com/pierre.carcellermeunier/api/mangapi3/) | Translate manga pages from one language to another | `apiKey` | Yes | Unknown |
-| [MyAnimeList](https://myanimelist.net/clubs.php?cid=13727) | Anime and Manga Database and Community | `OAuth`| Yes | Unknown |
-| [Nekos API](https://nekosapi.com/docs) | Anime images with lots of metadata | `OAuth` | Yes | Yes |
-| [NekosBest](https://docs.nekos.best) | Neko Images & Anime roleplaying GIFs | No | Yes | Yes |
-| [NekosPro](https://documentation.nekos.pro) | Neko images, roleplaying GIFs, & NSFW content | No | Yes | Yes |
-| [Shikimori](https://shikimori.one/api/doc) | Anime discovery, tracking, forum, rates | `OAuth`| Yes | Unknown |
-| [Trace Moe](https://soruly.github.io/trace.moe-api/#/) | A useful tool to get the exact scene of an anime from a screenshot | No | Yes | No |
-| [Waifu.im](https://waifu.im/docs) | Get waifu pictures from an archive of over 4000 images and multiple tags | No | Yes | Yes |
-| [Waifu.it](https://docs.waifu.it) | Free RESTful API for Anime Quotes, Facts, Emotes, Gifs, Nekos, Waifus and More! | `apiKey` | Yes | Yes |
-| [Waifu.pics](https://waifu.pics/docs) | Image sharing platform for anime images | No | Yes | No |
-| [Wibu API](https://wibu-api.eu.org) | Anime, Donghua, Manga, Manhua, Manhwa, J-Drama, Genshin Impact. All-in-one weebs related stuff api. | No | Yes | Yes |
+
+| API                                                                       | Description                                                                                         | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [AniDB](https://wiki.anidb.net/HTTP_API_Definition)                       | Anime Database                                                                                      | `apiKey` | No    | Yes     |
+| [AniList](https://github.com/AniList/ApiV2-GraphQL-Docs)                  | Anime discovery & tracking                                                                          | `OAuth`  | Yes   | Unknown |
+| [AnimeNewsNetwork](https://www.animenewsnetwork.com/encyclopedia/api.php) | Anime industry news                                                                                 | No       | Yes   | Yes     |
+| [Danbooru Anime](https://danbooru.donmai.us/wiki_pages/help:api)          | Thousands of anime artist database to find good anime art                                           | `apiKey` | Yes   | Yes     |
+| [Dattebayo API](https://api-dattebayo.vercel.app/)                        | Dattebayo: Your Ultimate Naruto Anime API                                                           | No       | Yes   | No      |
+| [Jikan](https://jikan.moe)                                                | Unofficial MyAnimeList API                                                                          | No       | Yes   | Yes     |
+| [Kitsu](https://kitsu.docs.apiary.io/)                                    | Anime discovery platform                                                                            | `OAuth`  | Yes   | Yes     |
+| [MangaDex](https://api.mangadex.org/docs/)                                | Manga Database and Community                                                                        | `apiKey` | Yes   | Unknown |
+| [Mangapi](https://rapidapi.com/pierre.carcellermeunier/api/mangapi3/)     | Translate manga pages from one language to another                                                  | `apiKey` | Yes   | Unknown |
+| [MyAnimeList](https://myanimelist.net/clubs.php?cid=13727)                | Anime and Manga Database and Community                                                              | `OAuth`  | Yes   | Unknown |
+| [Nekos API](https://nekosapi.com/docs)                                    | Anime images with lots of metadata                                                                  | `OAuth`  | Yes   | Yes     |
+| [NekosBest](https://docs.nekos.best)                                      | Neko Images & Anime roleplaying GIFs                                                                | No       | Yes   | Yes     |
+| [NekosPro](https://documentation.nekos.pro)                               | Neko images, roleplaying GIFs, & NSFW content                                                       | No       | Yes   | Yes     |
+| [Shikimori](https://shikimori.one/api/doc)                                | Anime discovery, tracking, forum, rates                                                             | `OAuth`  | Yes   | Unknown |
+| [Trace Moe](https://soruly.github.io/trace.moe-api/#/)                    | A useful tool to get the exact scene of an anime from a screenshot                                  | No       | Yes   | No      |
+| [Waifu.im](https://waifu.im/docs)                                         | Get waifu pictures from an archive of over 4000 images and multiple tags                            | No       | Yes   | Yes     |
+| [Waifu.it](https://docs.waifu.it)                                         | Free RESTful API for Anime Quotes, Facts, Emotes, Gifs, Nekos, Waifus and More!                     | `apiKey` | Yes   | Yes     |
+| [Waifu.pics](https://waifu.pics/docs)                                     | Image sharing platform for anime images                                                             | No       | Yes   | No      |
+| [Wibu API](https://wibu-api.eu.org)                                       | Anime, Donghua, Manga, Manhua, Manhwa, J-Drama, Genshin Impact. All-in-one weebs related stuff api. | No       | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Anti-Malware
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AbuseIPDB](https://docs.abuseipdb.com/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
-| [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
-| [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html) | Malware execution and analysis | `apiKey` | Yes | Unknown |
-| [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google Link/Domain Flagging | `apiKey` | Yes | Unknown |
-| [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Yes | Unknown |
-| [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | Yes | No |
-| [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Yes | Unknown |
-| [Metacert](https://metacert.com/) | Metacert Link Flagging | `apiKey` | Yes | Unknown |
-| [Phisherman](https://phisherman.gg/) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
-| [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes | Yes |
-| [URLhaus](https://urlhaus-api.abuse.ch/) | Bulk queries and Download Malware Samples | No | Yes | Yes |
-| [URLScan.io](https://urlscan.io/about-api/) | Scan and Analyse URLs | `apiKey` | Yes | Unknown |
-| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/) | VirusTotal File/URL Analysis | `apiKey` | Yes | Unknown |
-| [Web of Trust](https://support.mywot.com/hc/en-us/sections/360004477734-API-) | IP/domain/URL reputation | `apiKey` | Yes | Unknown |
+
+| API                                                                           | Description                                                                         | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [AbuseIPDB](https://docs.abuseipdb.com/)                                      | IP/domain/URL reputation                                                            | `apiKey` | Yes   | Unknown |
+| [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api)       | IP/domain/URL reputation                                                            | `apiKey` | Yes   | Unknown |
+| [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html)         | Malware execution and analysis                                                      | `apiKey` | Yes   | Unknown |
+| [Google Safe Browsing](https://developers.google.com/safe-browsing/)          | Google Link/Domain Flagging                                                         | `apiKey` | Yes   | Unknown |
+| [MalDatabase](https://maldatabase.com/api-doc.html)                           | Provide malware datasets and threat intelligence feeds                              | `apiKey` | Yes   | Unknown |
+| [MalShare](https://malshare.com/doc.php)                                      | Malware Archive / file sourcing                                                     | `apiKey` | Yes   | No      |
+| [MalwareBazaar](https://bazaar.abuse.ch/api/)                                 | Collect and share malware samples                                                   | `apiKey` | Yes   | Unknown |
+| [Metacert](https://metacert.com/)                                             | Metacert Link Flagging                                                              | `apiKey` | Yes   | Unknown |
+| [Phisherman](https://phisherman.gg/)                                          | IP/domain/URL reputation                                                            | `apiKey` | Yes   | Unknown |
+| [Scanii](https://docs.scanii.com/)                                            | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes   | Yes     |
+| [URLhaus](https://urlhaus-api.abuse.ch/)                                      | Bulk queries and Download Malware Samples                                           | No       | Yes   | Yes     |
+| [URLScan.io](https://urlscan.io/about-api/)                                   | Scan and Analyse URLs                                                               | `apiKey` | Yes   | Unknown |
+| [VirusTotal](https://www.virustotal.com/en/documentation/public-api/)         | VirusTotal File/URL Analysis                                                        | `apiKey` | Yes   | Unknown |
+| [Web of Trust](https://support.mywot.com/hc/en-us/sections/360004477734-API-) | IP/domain/URL reputation                                                            | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Art & Design
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
-| [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
-| [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | Yes | Unknown |
-| [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
-| [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth`| Yes | Unknown |
-| [EmojiHub](https://github.com/cheatsnake/emojihub) | Get emojis by categories and groups | No | Yes | Yes |
-| [Europeana](https://pro.europeana.eu/resources/apis/search) | European Museum and Galleries content | `apiKey` | Yes | Unknown |
-| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art | `apiKey` | No | Unknown |
-| [Icon Horse](https://icon.horse/usage) | Favicons for any website, with fallbacks | No | Yes | Yes |
-| [Iconfinder](https://developer.iconfinder.com) | Icons | `apiKey` | Yes | Unknown |
-| [Icons8](https://img.icons8.com/) | Icons (find "search icon" hyperlink in page) | No | Yes | Unknown |
-| [Lordicon](https://lordicon.com/) | Icons with predone Animations | No | Yes | Yes |
-| [Metropolitan Museum of Art](https://metmuseum.github.io/) | Met Museum of Art | No | Yes | No |
-| [Noun Project](http://api.thenounproject.com/index.html) | Icons | `OAuth`| No | Unknown |
-| [PHP-Noise](https://php-noise.com/) | Noise Background Image Generator | No | Yes | Yes |
-| [Pika](https://pika.style/image-generation-api) | Image Generation API | `apiKey` | Yes | Yes |
-| [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/) | RijksMuseum Data | `apiKey` | Yes | Unknown |
-| [The Color](https://www.thecolorapi.com/) | Swiss army knife for color | No | No | Unknown |
-| [Word Cloud](https://wordcloudapi.com/) | Easily create word clouds | `apiKey` | Yes | Unknown |
-| [xColors](https://github.com/cheatsnake/xColors-api) | Generate & convert colors | No | Yes | Yes |
+
+| API                                                                  | Description                                    | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------- | ---------------------------------------------- | -------- | ----- | ------- |
+| [Art Institute of Chicago](https://api.artic.edu/docs/)              | Art                                            | No       | Yes   | Yes     |
+| [Colormind](http://colormind.io/api-access/)                         | Color scheme generator                         | No       | No    | Unknown |
+| [ColourLovers](http://www.colourlovers.com/api)                      | Get various patterns, palettes and images      | No       | Yes   | Unknown |
+| [Cooper Hewitt](https://collection.cooperhewitt.org/api)             | Smithsonian Design Museum                      | `apiKey` | Yes   | Unknown |
+| [Dribbble](https://developer.dribbble.com)                           | Discover the world’s top designers & creatives | `OAuth`  | Yes   | Unknown |
+| [EmojiHub](https://github.com/cheatsnake/emojihub)                   | Get emojis by categories and groups            | No       | Yes   | Yes     |
+| [Europeana](https://pro.europeana.eu/resources/apis/search)          | European Museum and Galleries content          | `apiKey` | Yes   | Unknown |
+| [Harvard Art Museums](https://github.com/harvardartmuseums/api-docs) | Art                                            | `apiKey` | No    | Unknown |
+| [Icon Horse](https://icon.horse/usage)                               | Favicons for any website, with fallbacks       | No       | Yes   | Yes     |
+| [Iconfinder](https://developer.iconfinder.com)                       | Icons                                          | `apiKey` | Yes   | Unknown |
+| [Icons8](https://img.icons8.com/)                                    | Icons (find "search icon" hyperlink in page)   | No       | Yes   | Unknown |
+| [Lordicon](https://lordicon.com/)                                    | Icons with predone Animations                  | No       | Yes   | Yes     |
+| [Metropolitan Museum of Art](https://metmuseum.github.io/)           | Met Museum of Art                              | No       | Yes   | No      |
+| [Noun Project](http://api.thenounproject.com/index.html)             | Icons                                          | `OAuth`  | No    | Unknown |
+| [PHP-Noise](https://php-noise.com/)                                  | Noise Background Image Generator               | No       | Yes   | Yes     |
+| [Pika](https://pika.style/image-generation-api)                      | Image Generation API                           | `apiKey` | Yes   | Yes     |
+| [Rijksmuseum](https://data.rijksmuseum.nl/object-metadata/api/)      | RijksMuseum Data                               | `apiKey` | Yes   | Unknown |
+| [The Color](https://www.thecolorapi.com/)                            | Swiss army knife for color                     | No       | No    | Unknown |
+| [Word Cloud](https://wordcloudapi.com/)                              | Easily create word clouds                      | `apiKey` | Yes   | Unknown |
+| [xColors](https://github.com/cheatsnake/xColors-api)                 | Generate & convert colors                      | No       | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Authentication & Authorization
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Auth0](https://auth0.com) | Easy to implement, adaptable authentication and authorization platform | `apiKey` | Yes | Yes |
-| [Clerk](https://clerk.com) | Drop-in React components for authentication and authorization | `apiKey` | Yes | Yes |
-| [Corbado](https://corbado.com) | Passkey-first authentication | `apiKey` | Yes | Yes |
-| [GetOTP](https://otp.dev/en/docs/) | Implement OTP flow quickly | `apiKey` | Yes | No |
-| [Kinde](https://kinde.com) | Authentication for modern applications. Integrates in minutes and free up to 7,500 MAU | `OAuth` | Yes | No |
-| [MojoAuth](https://mojoauth.com) | Secure and modern passwordless authentication platform | `apiKey` | Yes | Yes |
-| [Stytch](https://stytch.com/) | User infrastructure for modern applications | `apiKey` | Yes | No |
-| [Warrant](https://docs.warrant.dev/) | APIs for authorization and access control | `apiKey` | Yes | Yes |
+
+| API                                  | Description                                                                            | Auth     | HTTPS | CORS |
+| ------------------------------------ | -------------------------------------------------------------------------------------- | -------- | ----- | ---- |
+| [Auth0](https://auth0.com)           | Easy to implement, adaptable authentication and authorization platform                 | `apiKey` | Yes   | Yes  |
+| [Clerk](https://clerk.com)           | Drop-in React components for authentication and authorization                          | `apiKey` | Yes   | Yes  |
+| [Corbado](https://corbado.com)       | Passkey-first authentication                                                           | `apiKey` | Yes   | Yes  |
+| [GetOTP](https://otp.dev/en/docs/)   | Implement OTP flow quickly                                                             | `apiKey` | Yes   | No   |
+| [Kinde](https://kinde.com)           | Authentication for modern applications. Integrates in minutes and free up to 7,500 MAU | `OAuth`  | Yes   | No   |
+| [MojoAuth](https://mojoauth.com)     | Secure and modern passwordless authentication platform                                 | `apiKey` | Yes   | Yes  |
+| [Stytch](https://stytch.com/)        | User infrastructure for modern applications                                            | `apiKey` | Yes   | No   |
+| [Warrant](https://docs.warrant.dev/) | APIs for authorization and access control                                              | `apiKey` | Yes   | Yes  |
 
 **[⬆ Back to Index](#index)**
 
 ### Blockchain
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Bitquery](https://graphql.bitquery.io/ide) | Onchain GraphQL APIs & DEX APIs | `apiKey` | Yes | Yes |
-| [Bscscan](https://bscscan.com/apis) | Binance Smart Chain explorer API | `apiKey` | Yes | Yes |
-| [Chainlink](https://chain.link/developer-resources) | Build hybrid smart contracts with Chainlink | No | Yes | Unknown |
-| [Chainpoint](https://tierion.com/chainpoint/) | Chainpoint is a global network for anchoring data to the Bitcoin blockchain | No | Yes | Unknown |
-| [Covalent](https://www.covalenthq.com/docs/api/) | Multi-blockchain data aggregator platform | `apiKey` | Yes | Unknown |
-| [Etherscan](https://etherscan.io/apis) | Ethereum explorer API | `apiKey` | Yes | Yes |
-| [GetBlock](https://getblock.io/) | Blockchain RPC Node provider that supports over 50 multiple blockchains | `apiKey` | Yes | Unknown |
-| [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No | Yes | Unknown |
-| [Nownodes](https://nownodes.io/) | Blockchain-as-a-service solution that provides high-quality connection via API | `apiKey` | Yes | Unknown |
-| [Steem](https://developers.steem.io/) | Blockchain-based blogging and social media website | No | No | No |
-| [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
-| [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
+
+| API                                                            | Description                                                                                          | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Bitquery](https://graphql.bitquery.io/ide)                    | Onchain GraphQL APIs & DEX APIs                                                                      | `apiKey` | Yes   | Yes     |
+| [Bscscan](https://bscscan.com/apis)                            | Binance Smart Chain explorer API                                                                     | `apiKey` | Yes   | Yes     |
+| [Chainlink](https://chain.link/developer-resources)            | Build hybrid smart contracts with Chainlink                                                          | No       | Yes   | Unknown |
+| [Chainpoint](https://tierion.com/chainpoint/)                  | Chainpoint is a global network for anchoring data to the Bitcoin blockchain                          | No       | Yes   | Unknown |
+| [Covalent](https://www.covalenthq.com/docs/api/)               | Multi-blockchain data aggregator platform                                                            | `apiKey` | Yes   | Unknown |
+| [Etherscan](https://etherscan.io/apis)                         | Ethereum explorer API                                                                                | `apiKey` | Yes   | Yes     |
+| [GetBlock](https://getblock.io/)                               | Blockchain RPC Node provider that supports over 50 multiple blockchains                              | `apiKey` | Yes   | Unknown |
+| [Helium](https://docs.helium.com/api/blockchain/introduction/) | Helium is a global, distributed network of Hotspots that create public, long-range wireless coverage | No       | Yes   | Unknown |
+| [Nownodes](https://nownodes.io/)                               | Blockchain-as-a-service solution that provides high-quality connection via API                       | `apiKey` | Yes   | Unknown |
+| [Steem](https://developers.steem.io/)                          | Blockchain-based blogging and social media website                                                   | No       | No    | No      |
+| [The Graph](https://thegraph.com)                              | Indexing protocol for querying networks like Ethereum with GraphQL                                   | `apiKey` | Yes   | Unknown |
+| [Watchdata](https://docs.watchdata.io)                         | Provide simple and reliable API access to Ethereum blockchain                                        | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Books
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [A Bíblia Digital](https://www.abibliadigital.com.br/en) | Do not worry about managing the multiple versions of the Bible | `apiKey` | Yes | No |
-| [Bhagavad Gita](https://bhagavadgita.io/api) | Bhagavad Gita text | `OAuth`| Yes | Yes |
-| [Bhagavad Gita telugu](https://gita-api.vercel.app) | Bhagavad Gita API in telugu and odia languages | No | Yes | Yes |
-| [Bible-api](https://bible-api.com/) | Free Bible API with multiple languages | No | Yes | Yes |
-| [Crossref Metadata Search](https://github.com/CrossRef/rest-api-doc) | Books & Articles Metadata | No | Yes | Unknown |
-| [Ganjoor](https://api.ganjoor.net) | Classic Persian poetry works including access to related manuscripts, recitations and music tracks | `OAuth`| Yes | Yes |
-| [Google Books](https://developers.google.com/books/) | Books | `OAuth`| Yes | Unknown |
-| [Gutendex](https://gutendex.com/) | Web-API for fetching data from Project Gutenberg Books Library | No | Yes | Unknown |
-| [Harry Potter](https://github.com/fedeperin/potterapi) | API to get data from Harry Potter books, movies and characters | No | Yes | Yes |
-| [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | No |
-| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Yes |
-| [PoetryDB](https://github.com/thundercomb/poetrydb#readme) | Enables you to get instant data from our vast poetry collection | No | Yes | Yes |
-| [Quran](https://quran.api-docs.io/) | RESTful Quran API with multiple languages | No | Yes | Yes |
-| [Quran Cloud](https://alquran.cloud/api) | A RESTful Quran API to retrieve an Ayah, Surah, Juz or the entire Holy Quran | No | Yes | Yes |
-| [Quran-api](https://github.com/fawazahmed0/quran-api#readme) | Free Quran API Service with 90+ different languages and 400+ translations | No | Yes | Yes |
-| [Stephen King](https://stephen-king-api.onrender.com/) | The varied works and characters of the prolific author Stephen King | No | Yes | Unknown |
-| [The Bible](https://docs.api.bible) | Everything you need from the Bible in one discoverable place | `apiKey` | Yes | Unknown |
-| [Thirukkural](https://api-thirukkural.web.app/) | 1330 Thirukkural poems and explanation in Tamil and English | No | Yes | Yes |
-| [Wizard World](https://wizard-world-api.herokuapp.com/swagger/index.html) | Get information from the Harry Potter universe | No | Yes | Yes |
-| [Wolne Lektury](https://wolnelektury.pl/api/) | API for obtaining information about e-books available on the WolneLektury.pl website | No | Yes | Unknown |
+
+| API                                                                       | Description                                                                                        | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [A Bíblia Digital](https://www.abibliadigital.com.br/en)                  | Do not worry about managing the multiple versions of the Bible                                     | `apiKey` | Yes   | No      |
+| [Bhagavad Gita](https://bhagavadgita.io/api)                              | Bhagavad Gita text                                                                                 | `OAuth`  | Yes   | Yes     |
+| [Bhagavad Gita telugu](https://gita-api.vercel.app)                       | Bhagavad Gita API in telugu and odia languages                                                     | No       | Yes   | Yes     |
+| [Bible-api](https://bible-api.com/)                                       | Free Bible API with multiple languages                                                             | No       | Yes   | Yes     |
+| [Crossref Metadata Search](https://github.com/CrossRef/rest-api-doc)      | Books & Articles Metadata                                                                          | No       | Yes   | Unknown |
+| [Ganjoor](https://api.ganjoor.net)                                        | Classic Persian poetry works including access to related manuscripts, recitations and music tracks | `OAuth`  | Yes   | Yes     |
+| [Google Books](https://developers.google.com/books/)                      | Books                                                                                              | `OAuth`  | Yes   | Unknown |
+| [Gutendex](https://gutendex.com/)                                         | Web-API for fetching data from Project Gutenberg Books Library                                     | No       | Yes   | Unknown |
+| [Harry Potter](https://github.com/fedeperin/potterapi)                    | API to get data from Harry Potter books, movies and characters                                     | No       | Yes   | Yes     |
+| [Open Library](https://openlibrary.org/developers/api)                    | Books, book covers and related data                                                                | No       | Yes   | No      |
+| [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data                                                                | No       | Yes   | Yes     |
+| [PoetryDB](https://github.com/thundercomb/poetrydb#readme)                | Enables you to get instant data from our vast poetry collection                                    | No       | Yes   | Yes     |
+| [Quran](https://quran.api-docs.io/)                                       | RESTful Quran API with multiple languages                                                          | No       | Yes   | Yes     |
+| [Quran Cloud](https://alquran.cloud/api)                                  | A RESTful Quran API to retrieve an Ayah, Surah, Juz or the entire Holy Quran                       | No       | Yes   | Yes     |
+| [Quran-api](https://github.com/fawazahmed0/quran-api#readme)              | Free Quran API Service with 90+ different languages and 400+ translations                          | No       | Yes   | Yes     |
+| [Stephen King](https://stephen-king-api.onrender.com/)                    | The varied works and characters of the prolific author Stephen King                                | No       | Yes   | Unknown |
+| [The Bible](https://docs.api.bible)                                       | Everything you need from the Bible in one discoverable place                                       | `apiKey` | Yes   | Unknown |
+| [Thirukkural](https://api-thirukkural.web.app/)                           | 1330 Thirukkural poems and explanation in Tamil and English                                        | No       | Yes   | Yes     |
+| [Wizard World](https://wizard-world-api.herokuapp.com/swagger/index.html) | Get information from the Harry Potter universe                                                     | No       | Yes   | Yes     |
+| [Wolne Lektury](https://wolnelektury.pl/api/)                             | API for obtaining information about e-books available on the WolneLektury.pl website               | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Business
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Apache Superset](https://superset.apache.org/docs/api) | API to manage your BI dashboards and data sources on Superset | `apiKey` | Yes | Yes |
-| [ArvanCloud](https://www.arvancloud.ir/en/dev/sdk) | Enables you to use ArvanCloud services | `apiKey` | Yes | No |
-| [Charity Search](http://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | No | Unknown |
-| [Clearbit Logo](https://clearbit.com/docs#logo-api) | Search for company logos and embed them in your projects | `apiKey` | Yes | Unknown |
-| [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | Yes | No |
-| [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth`| Yes | Unknown |
-| [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth`| Yes | Unknown |
-| [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth`| Yes | Unknown |
-| [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
-| [Mailchimp](https://mailchimp.com/developer/) | Send marketing campaigns and transactional mails | `apiKey` | Yes | Unknown |
-| [mailjet](https://www.mailjet.com/) | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API | `apiKey` | Yes | Unknown |
-| [markerapi](https://markerapi.com) | Trademark Search | No | No | Unknown |
-| [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
-| [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth`| Yes | No |
-| [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth`| Yes | Unknown |
-| [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes | Unknown |
-| [Tenders in Hungary](https://tenders.guru/hu/api) | Get data for procurements in Hungary in JSON format | No | Yes | Unknown |
-| [Tenders in Poland](https://tenders.guru/pl/api) | Get data for procurements in Poland in JSON format | No | Yes | Unknown |
-| [Tenders in Romania](https://tenders.guru/ro/api) | Get data for procurements in Romania in JSON format | No | Yes | Unknown |
-| [Tenders in Spain](https://tenders.guru/es/api) | Get data for procurements in Spain in JSON format | No | Yes | Unknown |
-| [Tenders in Ukraine](https://tenders.guru/ua/api) | Get data for procurements in Ukraine in JSON format | No | Yes | Unknown |
-| [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes | Yes |
-| [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth`| Yes | Unknown |
+
+| API                                                                                                                 | Description                                                                                  | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Apache Superset](https://superset.apache.org/docs/api)                                                             | API to manage your BI dashboards and data sources on Superset                                | `apiKey` | Yes   | Yes     |
+| [ArvanCloud](https://www.arvancloud.ir/en/dev/sdk)                                                                  | Enables you to use ArvanCloud services                                                       | `apiKey` | Yes   | No      |
+| [Charity Search](http://charityapi.orghunter.com/)                                                                  | Non-profit charity data                                                                      | `apiKey` | No    | Unknown |
+| [Clearbit Logo](https://clearbit.com/docs#logo-api)                                                                 | Search for company logos and embed them in your projects                                     | `apiKey` | Yes   | Unknown |
+| [Domainsdb.info](https://domainsdb.info/)                                                                           | Registered Domain Names Search                                                               | No       | Yes   | No      |
+| [Freelancer](https://developers.freelancer.com)                                                                     | Hire freelancers to get work done                                                            | `OAuth`  | Yes   | Unknown |
+| [Gmail](https://developers.google.com/gmail/api/)                                                                   | Flexible, RESTful access to the user's inbox                                                 | `OAuth`  | Yes   | Unknown |
+| [Google Analytics](https://developers.google.com/analytics/)                                                        | Collect, configure and analyze your data to reach the right audience                         | `OAuth`  | Yes   | Unknown |
+| [Instatus](https://instatus.com/help/api)                                                                           | Post to and update maintenance and incidents on your status page through an HTTP REST API    | `apiKey` | Yes   | Unknown |
+| [Mailchimp](https://mailchimp.com/developer/)                                                                       | Send marketing campaigns and transactional mails                                             | `apiKey` | Yes   | Unknown |
+| [mailjet](https://www.mailjet.com/)                                                                                 | Marketing email can be sent and mail templates made in MJML or HTML can be sent using API    | `apiKey` | Yes   | Unknown |
+| [markerapi](https://markerapi.com)                                                                                  | Trademark Search                                                                             | No       | No    | Unknown |
+| [Redash](https://redash.io/help/user-guide/integrations-and-api/api)                                                | Access your queries and dashboards on Redash                                                 | `apiKey` | Yes   | Yes     |
+| [Smartsheet](https://smartsheet.redoc.ly/)                                                                          | Allows you to programmatically access and Smartsheet data and account information            | `OAuth`  | Yes   | No      |
+| [Square](https://developer.squareup.com/reference/square)                                                           | Easy way to take payments, manage refunds, and help customers checkout online                | `OAuth`  | Yes   | Unknown |
+| [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes   | Unknown |
+| [Tenders in Hungary](https://tenders.guru/hu/api)                                                                   | Get data for procurements in Hungary in JSON format                                          | No       | Yes   | Unknown |
+| [Tenders in Poland](https://tenders.guru/pl/api)                                                                    | Get data for procurements in Poland in JSON format                                           | No       | Yes   | Unknown |
+| [Tenders in Romania](https://tenders.guru/ro/api)                                                                   | Get data for procurements in Romania in JSON format                                          | No       | Yes   | Unknown |
+| [Tenders in Spain](https://tenders.guru/es/api)                                                                     | Get data for procurements in Spain in JSON format                                            | No       | Yes   | Unknown |
+| [Tenders in Ukraine](https://tenders.guru/ua/api)                                                                   | Get data for procurements in Ukraine in JSON format                                          | No       | Yes   | Unknown |
+| [Tomba email finder](https://tomba.io/api)                                                                          | Email Finder for B2B sales and email marketing and email verifier                            | `apiKey` | Yes   | Yes     |
+| [Trello](https://developers.trello.com/)                                                                            | Boards, lists and cards to help you organize and prioritize your projects                    | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Calendar
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Abstract Public Holidays](https://www.abstractapi.com/holidays-api) | Data on national, regional, and religious holidays via API | `apiKey` | Yes | Yes |
-| [Calendarific](https://calendarific.com/) | Worldwide Holidays | `apiKey` | Yes | Unknown |
-| [Church Calendar](http://calapi.inadiutorium.cz/) | Catholic liturgical calendar | No | No | Unknown |
-| [Czech Namedays Calendar](https://svatky.adresa.info) | Lookup for a name and returns nameday date | No | No | Unknown |
-| [DigiDates](https://digidates.de/en/) | Various date and time calculations | No | Yes | Yes |
-| [Festivo Public Holidays](https://docs.getfestivo.com/docs/products/public-holidays-api/intro) | Fastest and most advanced public holiday and observance service on the market | `apiKey` | Yes | Yes |
-| [Generate iCAL](https://apyhub.com/utility/generator-ical) | Generates iCal calendar events that can be used across calendar applications | `apiKey` | Yes | Yes |
-| [Google Calendar](https://developers.google.com/google-apps/calendar/) | Display, create and modify Google calendar events | `OAuth`| Yes | Unknown |
-| [Hebrew Calendar](https://www.hebcal.com/home/developer-apis) | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc | No | No | Unknown |
-| [Holidays](https://holidayapi.com/) | Historical data regarding holidays | `apiKey` | Yes | Unknown |
-| [LectServe](http://www.lectserve.com) | Protestant liturgical calendar | No | No | Unknown |
-| [Nager.Date](https://date.nager.at) | Public holidays for more than 90 countries | No | Yes | No |
-| [Namedays Calendar](https://nameday.abalin.net) | Provides namedays for multiple countries | No | Yes | Yes |
-| [Non-Working Days](https://github.com/gadael/icsdb) | Database of ICS files for non working days | No | Yes | Unknown |
-| [Non-Working Days](https://isdayoff.ru) | Simple REST API for checking working, non-working or short days for Russia, CIS, USA and other | No | Yes | Yes |
-| [OpenHolidays API](https://www.openholidaysapi.org/) | Public and school holidays for many countries via an open REST API | No | Yes | Yes |
-| [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | Yes | No |
-| [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | Bank holidays in England and Wales, Scotland and Northern Ireland | No | Yes | Unknown |
+
+| API                                                                                            | Description                                                                                    | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Abstract Public Holidays](https://www.abstractapi.com/holidays-api)                           | Data on national, regional, and religious holidays via API                                     | `apiKey` | Yes   | Yes     |
+| [Calendarific](https://calendarific.com/)                                                      | Worldwide Holidays                                                                             | `apiKey` | Yes   | Unknown |
+| [Church Calendar](http://calapi.inadiutorium.cz/)                                              | Catholic liturgical calendar                                                                   | No       | No    | Unknown |
+| [Czech Namedays Calendar](https://svatky.adresa.info)                                          | Lookup for a name and returns nameday date                                                     | No       | No    | Unknown |
+| [DigiDates](https://digidates.de/en/)                                                          | Various date and time calculations                                                             | No       | Yes   | Yes     |
+| [Festivo Public Holidays](https://docs.getfestivo.com/docs/products/public-holidays-api/intro) | Fastest and most advanced public holiday and observance service on the market                  | `apiKey` | Yes   | Yes     |
+| [Generate iCAL](https://apyhub.com/utility/generator-ical)                                     | Generates iCal calendar events that can be used across calendar applications                   | `apiKey` | Yes   | Yes     |
+| [Google Calendar](https://developers.google.com/google-apps/calendar/)                         | Display, create and modify Google calendar events                                              | `OAuth`  | Yes   | Unknown |
+| [Hebrew Calendar](https://www.hebcal.com/home/developer-apis)                                  | Convert between Gregorian and Hebrew, fetch Shabbat and Holiday times, etc                     | No       | No    | Unknown |
+| [Holidays](https://holidayapi.com/)                                                            | Historical data regarding holidays                                                             | `apiKey` | Yes   | Unknown |
+| [LectServe](http://www.lectserve.com)                                                          | Protestant liturgical calendar                                                                 | No       | No    | Unknown |
+| [Nager.Date](https://date.nager.at)                                                            | Public holidays for more than 90 countries                                                     | No       | Yes   | No      |
+| [Namedays Calendar](https://nameday.abalin.net)                                                | Provides namedays for multiple countries                                                       | No       | Yes   | Yes     |
+| [Non-Working Days](https://github.com/gadael/icsdb)                                            | Database of ICS files for non working days                                                     | No       | Yes   | Unknown |
+| [Non-Working Days](https://isdayoff.ru)                                                        | Simple REST API for checking working, non-working or short days for Russia, CIS, USA and other | No       | Yes   | Yes     |
+| [OpenHolidays API](https://www.openholidaysapi.org/)                                           | Public and school holidays for many countries via an open REST API                             | No       | Yes   | Yes     |
+| [Russian Calendar](https://github.com/egno/work-calendar)                                      | Check if a date is a Russian holiday or not                                                    | No       | Yes   | No      |
+| [UK Bank Holidays](https://www.gov.uk/bank-holidays.json)                                      | Bank holidays in England and Wales, Scotland and Northern Ireland                              | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Cloud Storage & File Sharing
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth`| Yes | Unknown |
-| [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown |
-| [Dropbox](https://www.dropbox.com/developers) | File Sharing and Storage | `OAuth`| Yes | Unknown |
-| [File.io](https://www.file.io) | Super simple file sharing, convenient, anonymous and secure | No | Yes | Unknown |
-| [Gcore Storage](https://docs.gcore.com/storage) | S3-Compatible Object Storage is a fast and scalable cloud storage system by Gcore that gives you an opportunity to store and retrieve any amount of data at any time. High-performance storage for use as a CDN origin. | `apiKey` | Yes | Yes |
-| [GoFile](https://gofile.io/api) | Unlimited size file uploads for free | `apiKey` | Yes | Unknown |
-| [Google Drive](https://developers.google.com/drive/) | File Sharing and Storage | `OAuth`| Yes | Unknown |
-| [Gyazo](https://gyazo.com/api/docs) | Save & Share screen captures instantly | `apiKey` | Yes | Unknown |
-| [Imgbb](https://api.imgbb.com/) | Simple and quick private image sharing | `apiKey` | Yes | Unknown |
-| [OneDrive](https://developer.microsoft.com/onedrive) | File Sharing and Storage | `OAuth`| Yes | Unknown |
-| [Pastebin](https://pastebin.com/doc_api) | Plain Text Storage | `apiKey` | Yes | Unknown |
-| [Pinata](https://docs.pinata.cloud/) | IPFS Pinning Services API | `apiKey` | Yes | Unknown |
-| [Quip](https://quip.com/dev/automation/documentation) | File Sharing and Storage for groups | `apiKey` | Yes | Yes |
-| [Smash](https://api.fromsmash.com/) | Upload large files on websites, mobile apps, SaaS solutions and custom workflows | `apiKey` | Yes | Yes |
-| [Storj](https://docs.storj.io/dcs/) | Decentralized Open-Source Cloud Storage | `apiKey` | Yes | Unknown |
-| [The Null Pointer](https://0x0.st) | No-bullshit file hosting and URL shortening service | No | Yes | Unknown |
-| [Web3 Storage](https://web3.storage/) | File Sharing and Storage for Free with 1TB Space | `apiKey` | Yes | Yes |
+
+| API                                                   | Description                                                                                                                                                                                                             | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Box](https://developer.box.com/)                     | File Sharing and Storage                                                                                                                                                                                                | `OAuth`  | Yes   | Unknown |
+| [ddownload](https://ddownload.com/api)                | File Sharing and Storage                                                                                                                                                                                                | `apiKey` | Yes   | Unknown |
+| [Dropbox](https://www.dropbox.com/developers)         | File Sharing and Storage                                                                                                                                                                                                | `OAuth`  | Yes   | Unknown |
+| [File.io](https://www.file.io)                        | Super simple file sharing, convenient, anonymous and secure                                                                                                                                                             | No       | Yes   | Unknown |
+| [Gcore Storage](https://docs.gcore.com/storage)       | S3-Compatible Object Storage is a fast and scalable cloud storage system by Gcore that gives you an opportunity to store and retrieve any amount of data at any time. High-performance storage for use as a CDN origin. | `apiKey` | Yes   | Yes     |
+| [GoFile](https://gofile.io/api)                       | Unlimited size file uploads for free                                                                                                                                                                                    | `apiKey` | Yes   | Unknown |
+| [Google Drive](https://developers.google.com/drive/)  | File Sharing and Storage                                                                                                                                                                                                | `OAuth`  | Yes   | Unknown |
+| [Gyazo](https://gyazo.com/api/docs)                   | Save & Share screen captures instantly                                                                                                                                                                                  | `apiKey` | Yes   | Unknown |
+| [Imgbb](https://api.imgbb.com/)                       | Simple and quick private image sharing                                                                                                                                                                                  | `apiKey` | Yes   | Unknown |
+| [OneDrive](https://developer.microsoft.com/onedrive)  | File Sharing and Storage                                                                                                                                                                                                | `OAuth`  | Yes   | Unknown |
+| [Pastebin](https://pastebin.com/doc_api)              | Plain Text Storage                                                                                                                                                                                                      | `apiKey` | Yes   | Unknown |
+| [Pinata](https://docs.pinata.cloud/)                  | IPFS Pinning Services API                                                                                                                                                                                               | `apiKey` | Yes   | Unknown |
+| [Quip](https://quip.com/dev/automation/documentation) | File Sharing and Storage for groups                                                                                                                                                                                     | `apiKey` | Yes   | Yes     |
+| [Smash](https://api.fromsmash.com/)                   | Upload large files on websites, mobile apps, SaaS solutions and custom workflows                                                                                                                                        | `apiKey` | Yes   | Yes     |
+| [Storj](https://docs.storj.io/dcs/)                   | Decentralized Open-Source Cloud Storage                                                                                                                                                                                 | `apiKey` | Yes   | Unknown |
+| [The Null Pointer](https://0x0.st)                    | No-bullshit file hosting and URL shortening service                                                                                                                                                                     | No       | Yes   | Unknown |
+| [Web3 Storage](https://web3.storage/)                 | File Sharing and Storage for Free with 1TB Space                                                                                                                                                                        | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Continuous Integration
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Azure DevOps Health](https://docs.microsoft.com/en-us/rest/api/resourcehealth) | Resource health helps you diagnose and get support when an Azure issue impacts your resources | `apiKey` | No | No |
-| [Bitrise](https://api-docs.bitrise.io/) | Build tool and processes integrations to create efficient development pipelines | `apiKey` | Yes | Unknown |
-| [Buddy](https://buddy.works/docs/api/getting-started/overview) | The fastest continuous integration and continuous delivery platform | `OAuth`| Yes | Unknown |
-| [CircleCI](https://circleci.com/docs/api/v1-reference/) | Automate the software development process using continuous integration and continuous delivery | `apiKey` | Yes | Unknown |
-| [Codeship](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/api-overview/) | Codeship is a Continuous Integration Platform in the cloud | `apiKey` | Yes | Unknown |
-| [Travis CI](https://docs.travis-ci.com/api/) | Sync your GitHub projects with Travis CI to test your code in minutes | `apiKey` | Yes | Unknown |
+
+| API                                                                                 | Description                                                                                    | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Azure DevOps Health](https://docs.microsoft.com/en-us/rest/api/resourcehealth)     | Resource health helps you diagnose and get support when an Azure issue impacts your resources  | `apiKey` | No    | No      |
+| [Bitrise](https://api-docs.bitrise.io/)                                             | Build tool and processes integrations to create efficient development pipelines                | `apiKey` | Yes   | Unknown |
+| [Buddy](https://buddy.works/docs/api/getting-started/overview)                      | The fastest continuous integration and continuous delivery platform                            | `OAuth`  | Yes   | Unknown |
+| [CircleCI](https://circleci.com/docs/api/v1-reference/)                             | Automate the software development process using continuous integration and continuous delivery | `apiKey` | Yes   | Unknown |
+| [Codeship](https://docs.cloudbees.com/docs/cloudbees-codeship/latest/api-overview/) | Codeship is a Continuous Integration Platform in the cloud                                     | `apiKey` | Yes   | Unknown |
+| [Travis CI](https://docs.travis-ci.com/api/)                                        | Sync your GitHub projects with Travis CI to test your code in minutes                          | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Cryptocurrency
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [1inch](https://1inch.io/page-api/) | API for querying decentralize exchange | No | Yes | Unknown |
-| [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes | Yes |
-| [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Yes | Unknown |
-| [BitcoinAverage](https://apiv2.bitcoinaverage.com/) | Digital Asset Price Data for the blockchain industry | `apiKey` | Yes | Unknown |
-| [Bitfinex](https://docs.bitfinex.com/docs) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [Bitmex](https://www.bitmex.com/app/apiOverview) | Real-Time Cryptocurrency derivatives trading platform based in Hong Kong | `apiKey` | Yes | Unknown |
-| [Block](https://block.io/docs/basic) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Yes | Unknown |
-| [BlockBee](https://docs.blockbee.io/) | Cryptocurrency Payment Processor | `apiKey` | Yes | Unknown |
-| [Blockchain](https://www.blockchain.com/api) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Yes | Unknown |
-| [blockfrost Cardano](https://blockfrost.io/) | Interaction with the Cardano mainnet and several testnets | `apiKey` | Yes | Unknown |
-| [Brave NewCoin](https://bravenewcoin.com/developers) | Real-time and historic crypto data from more than 200+ exchanges | `apiKey` | Yes | Unknown |
-| [BtcTurk](https://docs.btcturk.com/) | Real-time cryptocurrency data, graphs and API that allows buy&sell | `apiKey` | Yes | Yes |
-| [Bybit](https://bybit-exchange.github.io/docs) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |
-| [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
-| [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
-| [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [CoinCap](https://docs.coincap.io/) | Real time Cryptocurrency prices through a RESTful API | No | Yes | Unknown |
-| [CoinDCX](https://docs.coindcx.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [CoinGecko](http://www.coingecko.com/api) | Cryptocurrency Price, Market, and Developer/Social Data | No | Yes | Yes |
-| [Coinigy](https://coinigy.docs.apiary.io) | Interacting with Coinigy Accounts and Exchange Directly | `apiKey` | Yes | Unknown |
-| [Coinlib](https://coinlib.io/apidocs) | Crypto Currency Prices | `apiKey` | Yes | Unknown |
-| [Coinlore](https://www.coinlore.com/cryptocurrency-data-api) | Cryptocurrencies prices, volume and more | No | Yes | Unknown |
-| [CoinMarketCap](https://coinmarketcap.com/api/) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
-| [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
-| [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
-| [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |
-| [CoinStats](https://documenter.getpostman.com/view/5734027/RzZ6Hzr3?version=latest) | Crypto Tracker | No | Yes | Unknown |
-| [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
-| [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
-| [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
-| [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
-| [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
-| [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |
-| [Gateio](https://www.gate.io/api2) | API provides spot, margin and futures trading operations | `apiKey` | Yes | Unknown |
-| [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |
-| [Huobi](https://huobiapi.github.io/docs/spot/v1/en/) | Seychelles based cryptocurrency exchange | `apiKey` | Yes | Unknown |
-| [Indodax](https://github.com/btcid/indodax-official-api-docs) | Trade your Bitcoin and other assets with rupiah | `apiKey` | Yes | Unknown |
-| [INFURA Ethereum](https://www.infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes | Yes |
-| [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Yes | Unknown |
-| [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
-| [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
-| [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
-| [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
-| [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
-| [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
-| [OKEx](https://okx.com/okx-api) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
-| [OpenSea](https://docs.opensea.io/reference/api-overview) | The Largest NFT Marketplace | `apiKey` | Yes | No |
-| [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
-| [Sellgate](https://sellgate.io/docs/checkout/create) | Cryptocurrency checkout creator | No | Yes | Unknown |
-| [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
-| [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
-| [Trading View](https://www.tradingview.com/rest-api-spec/) | Market price, data, graph for brokers and traders | `OAuth` | Yes | Unknown |
-| [Tron Network](https://developers.tron.network/reference/api-key) | Provides various endpoints to interact with the Tron Blockchain | No | Yes | Unknown |
-| [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
-| [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
-| [ZMOK](https://docs.zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
+
+| API                                                                                 | Description                                                                                     | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [1inch](https://1inch.io/page-api/)                                                 | API for querying decentralize exchange                                                          | No       | Yes   | Unknown |
+| [Alchemy Ethereum](https://docs.alchemy.com/alchemy/)                               | Ethereum Node-as-a-Service Provider                                                             | `apiKey` | Yes   | Yes     |
+| [Binance](https://github.com/binance/binance-spot-api-docs)                         | Exchange for Trading Cryptocurrencies based in China                                            | `apiKey` | Yes   | Unknown |
+| [BitcoinAverage](https://apiv2.bitcoinaverage.com/)                                 | Digital Asset Price Data for the blockchain industry                                            | `apiKey` | Yes   | Unknown |
+| [Bitfinex](https://docs.bitfinex.com/docs)                                          | Cryptocurrency Trading Platform                                                                 | `apiKey` | Yes   | Unknown |
+| [Bitmex](https://www.bitmex.com/app/apiOverview)                                    | Real-Time Cryptocurrency derivatives trading platform based in Hong Kong                        | `apiKey` | Yes   | Unknown |
+| [Block](https://block.io/docs/basic)                                                | Bitcoin Payment, Wallet & Transaction Data                                                      | `apiKey` | Yes   | Unknown |
+| [BlockBee](https://docs.blockbee.io/)                                               | Cryptocurrency Payment Processor                                                                | `apiKey` | Yes   | Unknown |
+| [Blockchain](https://www.blockchain.com/api)                                        | Bitcoin Payment, Wallet & Transaction Data                                                      | `apiKey` | Yes   | Unknown |
+| [blockfrost Cardano](https://blockfrost.io/)                                        | Interaction with the Cardano mainnet and several testnets                                       | `apiKey` | Yes   | Unknown |
+| [Brave NewCoin](https://bravenewcoin.com/developers)                                | Real-time and historic crypto data from more than 200+ exchanges                                | `apiKey` | Yes   | Unknown |
+| [BtcTurk](https://docs.btcturk.com/)                                                | Real-time cryptocurrency data, graphs and API that allows buy&sell                              | `apiKey` | Yes   | Yes     |
+| [Bybit](https://bybit-exchange.github.io/docs)                                      | Cryptocurrency data feed and algorithmic trading                                                | `apiKey` | Yes   | Unknown |
+| [CoinAPI](https://docs.coinapi.io/)                                                 | All Currency Exchanges integrate under a single api                                             | `apiKey` | Yes   | No      |
+| [Coinbase](https://developers.coinbase.com)                                         | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices                                             | `apiKey` | Yes   | Unknown |
+| [Coinbase Pro](https://docs.pro.coinbase.com/#api)                                  | Cryptocurrency Trading Platform                                                                 | `apiKey` | Yes   | Unknown |
+| [CoinCap](https://docs.coincap.io/)                                                 | Real time Cryptocurrency prices through a RESTful API                                           | No       | Yes   | Unknown |
+| [CoinDCX](https://docs.coindcx.com/)                                                | Cryptocurrency Trading Platform                                                                 | `apiKey` | Yes   | Unknown |
+| [CoinGecko](http://www.coingecko.com/api)                                           | Cryptocurrency Price, Market, and Developer/Social Data                                         | No       | Yes   | Yes     |
+| [Coinigy](https://coinigy.docs.apiary.io)                                           | Interacting with Coinigy Accounts and Exchange Directly                                         | `apiKey` | Yes   | Unknown |
+| [Coinlib](https://coinlib.io/apidocs)                                               | Crypto Currency Prices                                                                          | `apiKey` | Yes   | Unknown |
+| [Coinlore](https://www.coinlore.com/cryptocurrency-data-api)                        | Cryptocurrencies prices, volume and more                                                        | No       | Yes   | Unknown |
+| [CoinMarketCap](https://coinmarketcap.com/api/)                                     | Cryptocurrencies Prices                                                                         | `apiKey` | Yes   | Unknown |
+| [Coinpaprika](https://api.coinpaprika.com)                                          | Cryptocurrencies prices, volume and more                                                        | No       | Yes   | Yes     |
+| [CoinRanking](https://developers.coinranking.com/api/documentation)                 | Live Cryptocurrency data                                                                        | `apiKey` | Yes   | Unknown |
+| [Coinremitter](https://coinremitter.com/docs)                                       | Cryptocurrencies Payment & Prices                                                               | `apiKey` | Yes   | Unknown |
+| [CoinStats](https://documenter.getpostman.com/view/5734027/RzZ6Hzr3?version=latest) | Crypto Tracker                                                                                  | No       | Yes   | Unknown |
+| [CryptAPI](https://docs.cryptapi.io/)                                               | Cryptocurrency Payment Processor                                                                | No       | Yes   | Unknown |
+| [CryptoCompare](https://www.cryptocompare.com/api#)                                 | Cryptocurrencies Comparison                                                                     | No       | Yes   | Unknown |
+| [CryptoMarket](https://api.exchange.cryptomkt.com/)                                 | Cryptocurrencies Trading platform                                                               | `apiKey` | Yes   | Yes     |
+| [dYdX](https://docs.dydx.exchange/)                                                 | Decentralized cryptocurrency exchange                                                           | `apiKey` | Yes   | Unknown |
+| [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API)               | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes   | Unknown |
+| [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi)                    | Cryptocurrencies exchange based in UK                                                           | `apiKey` | Yes   | Unknown |
+| [Gateio](https://www.gate.io/api2)                                                  | API provides spot, margin and futures trading operations                                        | `apiKey` | Yes   | Unknown |
+| [Gemini](https://docs.gemini.com/rest-api/)                                         | Cryptocurrencies Exchange                                                                       | No       | Yes   | Unknown |
+| [Huobi](https://huobiapi.github.io/docs/spot/v1/en/)                                | Seychelles based cryptocurrency exchange                                                        | `apiKey` | Yes   | Unknown |
+| [Indodax](https://github.com/btcid/indodax-official-api-docs)                       | Trade your Bitcoin and other assets with rupiah                                                 | `apiKey` | Yes   | Unknown |
+| [INFURA Ethereum](https://www.infura.io/product/ethereum)                           | Interaction with the Ethereum mainnet and several testnets                                      | `apiKey` | Yes   | Yes     |
+| [Kraken](https://docs.kraken.com/rest/)                                             | Cryptocurrencies Exchange                                                                       | `apiKey` | Yes   | Unknown |
+| [KuCoin](https://docs.kucoin.com/)                                                  | Cryptocurrency Trading Platform                                                                 | `apiKey` | Yes   | Unknown |
+| [Mempool](https://mempool.space/api)                                                | Bitcoin API Service focusing on the transaction fee                                             | No       | Yes   | No      |
+| [MercadoBitcoin](https://www.mercadobitcoin.com.br/api-doc/)                        | Brazilian Cryptocurrency Information                                                            | No       | Yes   | Unknown |
+| [Messari](https://messari.io/api)                                                   | Provides API endpoints for thousands of crypto assets                                           | No       | Yes   | Unknown |
+| [Nexchange](https://nexchange2.docs.apiary.io/)                                     | Automated cryptocurrency exchange service                                                       | No       | No    | Yes     |
+| [NovaDax](https://doc.novadax.com/en-US/#introduction)                              | NovaDAX API to access all market data, trading management endpoints                             | `apiKey` | Yes   | Unknown |
+| [OKEx](https://okx.com/okx-api)                                                     | Cryptocurrency exchange based in Seychelles                                                     | `apiKey` | Yes   | Unknown |
+| [OpenSea](https://docs.opensea.io/reference/api-overview)                           | The Largest NFT Marketplace                                                                     | `apiKey` | Yes   | No      |
+| [Poloniex](https://docs.poloniex.com)                                               | US based digital asset exchange                                                                 | `apiKey` | Yes   | Unknown |
+| [Sellgate](https://sellgate.io/docs/checkout/create)                                | Cryptocurrency checkout creator                                                                 | No       | Yes   | Unknown |
+| [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api)           | Provides various endpoints to interact with the Solana Blockchain                               | No       | Yes   | Unknown |
+| [Technical Analysis](https://technical-analysis-api.com)                            | Cryptocurrency prices and technical analysis                                                    | `apiKey` | Yes   | No      |
+| [Trading View](https://www.tradingview.com/rest-api-spec/)                          | Market price, data, graph for brokers and traders                                               | `OAuth`  | Yes   | Unknown |
+| [Tron Network](https://developers.tron.network/reference/api-key)                   | Provides various endpoints to interact with the Tron Blockchain                                 | No       | Yes   | Unknown |
+| [VALR](https://docs.valr.com/)                                                      | Cryptocurrency Exchange based in South Africa                                                   | `apiKey` | Yes   | Unknown |
+| [WorldCoinIndex](https://www.worldcoinindex.com/apiservice)                         | Cryptocurrencies Prices                                                                         | `apiKey` | Yes   | Unknown |
+| [ZMOK](https://docs.zmok.io)                                                        | Ethereum JSON RPC API and Web3 provider                                                         | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Currency Exchange
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [1Forge](https://1forge.com/forex-data-api/api-documentation) | Forex currency market data | `apiKey` | Yes | Unknown |
-| [Amdoren](https://www.amdoren.com/currency-api/) | Free currency API with over 150 currencies | `apiKey` | Yes | Unknown |
-| [Bank of Russia](https://www.cbr.ru/development/SXML/) | Exchange rates and currency conversion | No | Yes | Unknown |
-| [BCV (Banco Central de Venezuela) Exchange rate](https://bcv-api.rafnixg.dev/docs) | Exchange rates of the BCV (Central Bank of Venezuela) API | `apiKey` | Yes | No |
-| [Currencyapi](https://currencyapi.com) | Currency Conversion API and cryptocurrency prices, updated minutely | `apiKey` | Yes | Yes |
-| [Currency-api](https://github.com/fawazahmed0/currency-api#readme) | Free Currency Exchange Rates API with 150+ Currencies & No Rate Limits | No | Yes | Yes |
-| [CurrencyFreaks](https://currencyfreaks.com/) | Provides current and historical currency exchange rates with free plan 1K requests/month | `apiKey` | Yes | Yes |
-| [CurrencyScoop](https://currencyscoop.com/api-documentation) | Real-time and historical currency rates JSON API | `apiKey` | Yes | Yes |
-| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates | No | Yes | Unknown |
-| [Economia.Awesome](https://docs.awesomeapi.com.br/api-de-moedas) | Portuguese free currency prices and conversion with no rate limits | No | Yes | Unknown |
-| [ExchangeRate-API](https://www.exchangerate-api.com) | Free currency conversion | `apiKey` | Yes | Yes |
-| [Exchangerate.host](https://exchangerate.host) | Free foreign exchange & crypto rates API | `apiKey` | Yes | Unknown |
-| [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |
-| [FreeForexAPI](https://freeforexapi.com/Home/Api) | Real-time foreign exchange rates for major currency pairs | `apiKey` | Yes | No |
-| [FxRatesAPI](https://fxratesapi.com/) | Real-time exchange rates, historical rates and currency conversion | No | Yes | No |
-| [FyGraph](https://fygraph.com) | GraphQL API of latest 1.000+ crypto and 167+ fiat updated every minute | `apiKey` | Yes | Yes |
-| [Manyapis](https://manyapis.com/products/currency/usd-to-eur-rate) | Exchange rates and currency conversion with free plan 50 requests/day | `apiKey` | Yes | Yes |
-| [MetalpriceAPI](https://metalpriceapi.com) | Real-time and historical exchange rates and currency conversion API | `apiKey` | Yes | Unknown |
-| [National Bank of Poland](http://api.nbp.pl/en.html) | A collection of currency exchange rates (data in XML and JSON) | No | Yes | Yes |
-| [VATComply.com](https://www.vatcomply.com/documentation) | Exchange rates, geolocation and VAT number validation | No | Yes | Yes |
-| [Convert Currency to Multiple Currencies](https://apyhub.com/utility/currency-conversion-multiple) | Convert currencies from a source currency to multiple target currencies. | `apiKey` | Yes | Yes |
+
+| API                                                                                                          | Description                                                                              | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [1Forge](https://1forge.com/forex-data-api/api-documentation)                                                | Forex currency market data                                                               | `apiKey` | Yes   | Unknown |
+| [Amdoren](https://www.amdoren.com/currency-api/)                                                             | Free currency API with over 150 currencies                                               | `apiKey` | Yes   | Unknown |
+| [Bank of Russia](https://www.cbr.ru/development/SXML/)                                                       | Exchange rates and currency conversion                                                   | No       | Yes   | Unknown |
+| [BCV (Banco Central de Venezuela) Exchange rate](https://bcv-api.rafnixg.dev/docs)                           | Exchange rates of the BCV (Central Bank of Venezuela) API                                | `apiKey` | Yes   | No      |
+| [Currencyapi](https://currencyapi.com)                                                                       | Currency Conversion API and cryptocurrency prices, updated minutely                      | `apiKey` | Yes   | Yes     |
+| [Currency-api](https://github.com/fawazahmed0/currency-api#readme)                                           | Free Currency Exchange Rates API with 150+ Currencies & No Rate Limits                   | No       | Yes   | Yes     |
+| [CurrencyFreaks](https://currencyfreaks.com/)                                                                | Provides current and historical currency exchange rates with free plan 1K requests/month | `apiKey` | Yes   | Yes     |
+| [CurrencyScoop](https://currencyscoop.com/api-documentation)                                                 | Real-time and historical currency rates JSON API                                         | `apiKey` | Yes   | Yes     |
+| [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates                                                           | No       | Yes   | Unknown |
+| [Economia.Awesome](https://docs.awesomeapi.com.br/api-de-moedas)                                             | Portuguese free currency prices and conversion with no rate limits                       | No       | Yes   | Unknown |
+| [ExchangeRate-API](https://www.exchangerate-api.com)                                                         | Free currency conversion                                                                 | `apiKey` | Yes   | Yes     |
+| [Exchangerate.host](https://exchangerate.host)                                                               | Free foreign exchange & crypto rates API                                                 | `apiKey` | Yes   | Unknown |
+| [Frankfurter](https://www.frankfurter.app/docs)                                                              | Exchange rates, currency conversion and time series                                      | No       | Yes   | Yes     |
+| [FreeForexAPI](https://freeforexapi.com/Home/Api)                                                            | Real-time foreign exchange rates for major currency pairs                                | `apiKey` | Yes   | No      |
+| [FxRatesAPI](https://fxratesapi.com/)                                                                        | Real-time exchange rates, historical rates and currency conversion                       | No       | Yes   | No      |
+| [FyGraph](https://fygraph.com)                                                                               | GraphQL API of latest 1.000+ crypto and 167+ fiat updated every minute                   | `apiKey` | Yes   | Yes     |
+| [Manyapis](https://manyapis.com/products/currency/usd-to-eur-rate)                                           | Exchange rates and currency conversion with free plan 50 requests/day                    | `apiKey` | Yes   | Yes     |
+| [MetalpriceAPI](https://metalpriceapi.com)                                                                   | Real-time and historical exchange rates and currency conversion API                      | `apiKey` | Yes   | Unknown |
+| [National Bank of Poland](http://api.nbp.pl/en.html)                                                         | A collection of currency exchange rates (data in XML and JSON)                           | No       | Yes   | Yes     |
+| [VATComply.com](https://www.vatcomply.com/documentation)                                                     | Exchange rates, geolocation and VAT number validation                                    | No       | Yes   | Yes     |
+| [Convert Currency to Multiple Currencies](https://apyhub.com/utility/currency-conversion-multiple)           | Convert currencies from a source currency to multiple target currencies.                 | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Data Validation
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [API Adresse](https://adresse.data.gouv.fr/api-doc/adresse) | Official French address validation service | No | Yes | Unknown |
-| [Brevo Suit](https://developers.brevo.com/) | Connection for brevo CRM suite | `apiKey` | Yes | Yes |
-| [Lob.com](https://lob.com/) | US Address Verification | `apiKey` | Yes | Unknown |
-| [Postman Echo](https://www.postman-echo.com) | Test api server to receive and return value from HTTP method | No | Yes | Unknown |
-| [PurgoMalum](http://www.purgomalum.com) | Content validator against profanity & obscenity | No | No | Unknown |
-| [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes | Yes |
-| [US Extract](https://www.smarty.com/products/apis/us-extract-api) | Extract postal addresses from any text including emails | `apiKey` | Yes | Yes |
-| [US Street Address](https://www.smarty.com/docs/cloud/us-street-api) | Validate and append data for any US postal address | `apiKey` | Yes | Yes |
-| [Validate UK Postcodes](https://apyhub.com/utility/data-postcodes-uk) | This API validates postal codes within UK | `apiKey` | Yes | Yes |
-| [VatcheckAPI](https://vatcheckapi.com) | VAT Number Validation & Lookup REST API | `apiKey` | Yes | Yes |
+
+| API                                                                          | Description                                                   | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------- | -------- | ----- | ------- |
+| [API Adresse](https://adresse.data.gouv.fr/api-doc/adresse)                  | Official French address validation service                    | No       | Yes   | Unknown |
+| [Brevo Suit](https://developers.brevo.com/)                                  | Connection for brevo CRM suite                                | `apiKey` | Yes   | Yes     |
+| [Lob.com](https://lob.com/)                                                  | US Address Verification                                       | `apiKey` | Yes   | Unknown |
+| [Postman Echo](https://www.postman-echo.com)                                 | Test api server to receive and return value from HTTP method  | No       | Yes   | Unknown |
+| [PurgoMalum](http://www.purgomalum.com)                                      | Content validator against profanity & obscenity               | No       | No    | Unknown |
+| [US Autocomplete](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | Enter address data quickly with real-time address suggestions | `apiKey` | Yes   | Yes     |
+| [US Extract](https://www.smarty.com/products/apis/us-extract-api)            | Extract postal addresses from any text including emails       | `apiKey` | Yes   | Yes     |
+| [US Street Address](https://www.smarty.com/docs/cloud/us-street-api)         | Validate and append data for any US postal address            | `apiKey` | Yes   | Yes     |
+| [Validate UK Postcodes](https://apyhub.com/utility/data-postcodes-uk)        | This API validates postal codes within UK                     | `apiKey` | Yes   | Yes     |
+| [VatcheckAPI](https://vatcheckapi.com)                                       | VAT Number Validation & Lookup REST API                       | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Development
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
-| [Abstract Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey`| Yes | Yes |
-| [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
-| [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
-| [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
-| [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey`| Yes | Unknown |
-| [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |
-| [ApyHub](https://apyhub.com/catalog) | 110+ APIs to add to your next software application | `apiKey` | Yes | Yes |
-| [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops) | The Azure DevOps basic components of a REST API request/response pair | `apiKey`| Yes | Unknown |
-| [Beeceptor](https://beeceptor.com/) | Build a mock Rest API endpoint in seconds | No | Yes | Yes |
-| [Bitbucket](https://developer.atlassian.com/bitbucket/api/2/reference/) | Bitbucket API | `OAuth` | Yes | Unknown |
-| [Blitapp](https://blitapp.com/api/) | Schedule screenshots of web pages and sync them to your cloud | `apiKey`| Yes | Unknown |
-| [Blynk-Cloud](https://blynkapi.docs.apiary.io/#) | Control IoT Devices from Blynk IoT Cloud | `apiKey`| No | Unknown |
-| [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey`| Yes | Yes |
-| [Brave Search API](https://brave.com/search/api/) | An index of billions of pages in a single call | `apiKey`| Yes | No |
-| [BrowserCat](https://www.browsercat.com/) | Headless browser API for automation, scraping, and more | `apiKey` | Yes | Yes |
-| [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey`| Yes | Yes |
-| [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
-| [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
-| [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
-| [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
-| [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey`| Yes | Yes |
-| [CORS Proxy](https://github.com/burhanuday/cors-proxy) | Get around the dreaded CORS error by using this proxy as a middle man | No | Yes | Yes |
-| [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html) | Service to manage your databricks account,clusters, notebooks, jobs and workspaces | `apiKey`| Yes | Yes |
-| [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
-| [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey`| Yes | Yes |
-| [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
-| [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
-| [Generate Full Webpage Screenshot](https://apyhub.com/utility/generate-webpage-screenshot) | Dynamically capture full page screenshots of websites.| `apiKey` | Yes | Yes |
-| [Gcore CDN](https://docs.gcore.com/cdn) | Make your app fast and responsive for a global audience with Gcore CDN. | `apiKey` | Yes | Yes |
-| [Gcore Cloud](https://docs.gcore.com/cloud) | Scalable, secure, and reliable hybrid cloud services anywhere in the world. | `apiKey` | Yes | Yes |
-| [Gcore DNS](https://docs.gcore.com/dns) | Fast and resilient DNS hosting service by Gcore. Improve the performance and availability of your online business. | `apiKey` | Yes | Yes |
-| [Genderize.io](https://genderize.io) | Estimates a gender from a first name | No | Yes | Yes |
-| [GETPing](https://www.getping.info) | Trigger an email notification with a simple GET request | `apiKey`| Yes | Unknown |
-| [Ghost](https://ghost.org/) | Get Published content into your Website, App or other embedded media | `apiKey`| Yes | Yes |
-| [GitHub](https://docs.github.com/en/free-pro-team@latest/rest) | Make use of GitHub repositories, code and user info programmatically | `OAuth` | Yes | Yes |
-| [Gitlab](https://docs.gitlab.com/ee/api/) | Automate GitLab interaction programmatically | `OAuth` | Yes | Unknown |
-| [Glitterly](https://developers.glitterly.app) | Image generation API | `apiKey`| Yes | Yes |
-| [Google Docs](https://developers.google.com/docs/api/reference/rest) | API to read, write, and format Google Docs documents | `OAuth` | Yes | Unknown |
-| [Google Firebase](https://firebase.google.com/docs) | Google's mobile application development platform that helps build, improve, and grow app | `apiKey`| Yes | Yes |
-| [Google Fonts](https://developers.google.com/fonts/docs/developer_api) | Metadata for all families served by Google Fonts | `apiKey`| Yes | Unknown |
-| [Google Keep](https://developers.google.com/keep/api/reference/rest) | API to read, write, and format Google Keep notes | `OAuth` | Yes | Unknown |
-| [Google Sheets](https://developers.google.com/sheets/api/reference/rest) | API to read, write, and format Google Sheets data | `OAuth` | Yes | Unknown |
-| [Google Slides](https://developers.google.com/slides/api/reference/rest) | API to read, write, and format Google Slides presentations | `OAuth` | Yes | Unknown |
-| [Gorest](https://gorest.co.in/) | Online REST API for Testing and Prototyping | `OAuth` | Yes | Unknown |
-| [Hasura](https://hasura.io/opensource/) | GraphQL and REST API Engine with built in Authorization | `apiKey`| Yes | Yes |
-| [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/) | REST API to programmatically create apps, provision add-ons and perform other task on Heroku | `OAuth` | Yes | Yes |
-| [Hoppscotch](https://hoppscotch.io/) | A lightweight, fast, and customizable app for testing and designing APIs. A free, fast, and beautiful  | No | Yes | Unknown |
-| [Host.io](https://host.io) | Domains Data API for Developers | `apiKey`| Yes | Yes |
-| [HTTP2.Pro](https://http2.pro/doc/api) | Test endpoints for client and server HTTP/2 protocol support | No | Yes | Unknown |
-| [HTTPie](https://httpie.io) | a free command-line HTTP client for the API era | No | Yes | Unknown |
-| [Httpbin](https://httpbin.org/) | A Simple HTTP Request & Response Service | No | Yes | Yes |
-| [Hunter](https://hunter.io/api) | API for domain search, professional email finder, author finder and email verifier | `apiKey`| Yes | Unknown |
-| [IBM Text to Speech](https://cloud.ibm.com/docs/text-to-speech/getting-started.html) | Convert text to speech | `apiKey`| Yes | Yes |
-| [IFTTT](https://platform.ifttt.com/docs/connect_api) | IFTTT Connect API | No | Yes | Unknown |
-| [Image-Charts](https://documentation.image-charts.com/) | Generate charts, QR codes and graph images | No | Yes | Yes |
-| [import.io](http://api.docs.import.io/) | Retrieve structured data from a website or RSS feed | `apiKey`| Yes | Unknown |
-| [Insomnia](https://insomnia.rest/) | A free API client that allows you to design, debug, test, and mock APIs locally, on Git, or cloud. | `OAuth` | Yes | Unknown |
-| [IP2WHOIS Information Lookup](https://www.ip2whois.com/) | WHOIS domain name lookup | `apiKey`| Yes | Unknown |
-| [ipfind.io](https://ipfind.io) | Geographic location of an IP address or any domain name along with some other useful information | `apiKey`| Yes | Yes |
-| [IPify](https://www.ipify.org/) | A simple IP Address API | No | Yes | Unknown |
-| [IPinfo](https://ipinfo.io/developers) | Another simple IP Address API | No | Yes | Unknown |
-| [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com) | Package info and download stats on jsDelivr CDN | No | Yes | Yes |
-| [JSON 2 JSONP](https://json2jsonp.com/) | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript | No | Yes | Unknown |
-| [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey`| Yes | Yes |
-| [JSONsilo.com](https://jsonsilo.com) | Hassle-free JSON hosting. Convert your JSON file to an API in minutes at no cost. | `apiKey` | Yes | Yes | No |
-| [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
-| [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
-| [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
-| [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey`| Yes | Yes |
-| [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
-| [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |
-| [MY IP](https://www.myip.com/api-docs/) | Get IP address information | No | Yes | Unknown |
-| [Nationalize.io](https://nationalize.io) | Estimate the nationality of a first name | No | Yes | Yes |
-| [Netlify](https://docs.netlify.com/api/get-started/) | Netlify is a hosting service for the programmable web | `OAuth` | Yes | Unknown |
-| [NetworkCalc](https://networkcalc.com/api/docs) | Network calculators, including subnets, DNS, binary, and security tools | No | Yes | Yes |
-| [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md) | Query information about your favorite Node.js libraries programmatically | No | Yes | Unknown |
-| [OneSignal](https://documentation.onesignal.com/reference/rest-api-overview) | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App | `apiKey`| Yes | Unknown |
-| [Open Page Rank](https://www.domcop.com/openpagerank/) | API for calculating and comparing metrics of different websites using Page Rank algorithm | `apiKey`| Yes | Unknown |
-| [OpenAPIHub](https://hub.openapihub.com/) | The All-in-one API Platform | `X-Mashape-Key` | Yes | Unknown |
-| [PipeDream](https://docs.pipedream.com) | Pipedream is the fastest way to build powerful applications that connect all the services in your stack | `OAuth`| Yes | Unknown |
-| [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs | `apiKey`| Yes | Unknown |
-| [ProxyCrawl](https://proxycrawl.com) | Scraping and crawling anticaptcha service | `apiKey`| Yes | Unknown |
-| [ProxyKingdom](https://proxykingdom.com) | Rotating Proxy API that produces a working proxy on every request | `apiKey`| Yes | Yes |
-| [Pusher Beams](https://pusher.com/beams) | Push notifications for Android & iOS | `apiKey`| Yes | Unknown |
-| [Pusher Channels](https://pusher.com/channels) | Realtime features | `apiKey`| Yes | Unknown |
-| [QR code](https://www.qrtag.net/api/) | Create an easy to read QR code and URL shortener | No | Yes | Yes |
-| [QR code](http://goqr.me/api/) | Generate and decode / read QR code graphics | No | Yes | Unknown |
-| [QR code Generator](https://docs.openqr.io/) | Static and Dynamic QR code generator with custom and unique QR code design | `apiKey` | Yes | Unknown |
-| [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
-| [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
-| [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey`| Yes | Yes |
-| [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey`| Yes | No |
-| [ReqRes](https://reqres.in/) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |
-| [RSS to JSON](https://github.com/ayusharma/RSS-to-JSON) | Returns RSS feed in JSON format using feed URL | No | Yes | Yes |
-| [ScrapeNinja](https://scrapeninja.net) | Scraping API with Chrome fingerprint and residential proxies | `apiKey`| Yes | Unknown |
-| [ScraperApi](https://www.scraperapi.com) | Easily build scalable web scrapers | `apiKey`| Yes | Unknown |
-| [scraperBox](https://scraperbox.com/) | Undetectable web scraping API | `apiKey`| Yes | Yes |
-| [Scrapfly](https://scrapfly.io) | Scrapfly is an enterprise-grade solution providing Web Scraping API that aims to simplify the scraping process by managing everything: real browser rendering, rotating proxies, and fingerprints (TLS, HTTP, browser) to bypass all major anti-bots. | `apiKey`| Yes | No |
-| [ScrapingAnt](https://scrapingant.com) | Headless Chrome scraping with a simple API | `apiKey`| Yes | Unknown |
-| [ScrapingDog](https://www.scrapingdog.com/) | Proxy API for Web scraping | `apiKey`| Yes | Unknown |
-| [ScreenshotAPI.net](https://screenshotapi.net/) | Create pixel-perfect website screenshots | `apiKey`| Yes | Yes |
-| [Screenshotbase](https://screenshotbase.com/) | Screenshot API, 1000 free requests per month | `apiKey`| Yes | Yes |
-| [ScreenshotOne.com](https://screenshotone.com/) | Convert URLs, HTML, or Markdown into PNG, JPEG, WebP, or PDF with a simple screenshot API | `apiKey`| Yes | Yes |
-| [SearchApi](https://www.searchapi.io/) | Real-Time Google SERP API | `apiKey` | Yes | No |
-| [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |
-| [SerpApi](https://serpapi.com/) | Scrape Google and other search engines  | `apiKey` | Yes | No |
-| [SERP Rank Checker](https://apyhub.com/utility/serp-rank) | Check realtime Google SERP Rank of any keywords. | `apiKey` | Yes | Yes |
-| [Shadify](https://github.com/cheatsnake/shadify) | Service for generating data and executing logic to create various games and puzzles | No | Yes | Yes |
-| [Sheetsu](https://sheetsu.com/) | Easy google sheets integration | `apiKey`| Yes | Unknown |
-| [Sonar](https://github.com/Cgboal/SonarSearch) | Project Sonar DNS Enumeration API | No | Yes | Yes |
-| [SonarQube](https://sonarcloud.io/web_api) | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities | `OAuth` | Yes | Unknown |
-| [StackExchange](https://api.stackexchange.com/) | Q&A forum for developers | `OAuth` | Yes | Unknown |
-| [Statically](https://statically.io/) | A free CDN for developers | No | Yes | Yes |
-| [Supportivekoala](https://developers.supportivekoala.com/) | Autogenerate images with template | `apiKey`| Yes | Yes |
-| [Svix](https://www.svix.com) | Webhooks as a Service | `apiKey` | Yes | Unknown |
-| [Tolgee](https://tolgee.io) | Open-source localization (i18n) platform enabling you to translate you app fast | `apiKey` | Yes | No |
-| [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey`| Yes | Yes |
-| [YADG](https://yadg.cc/api/v2/) | An API that scrapes music release data and renders it using different templates | `apiKey`| Yes | Unknown |
-| [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel/API.md) | Code compiler supporting 35+ languages mentioned at wandbox.org | No | Yes | Unknown |
-| [WebScraping.AI](https://webscraping.ai/) | Web Scraping API with built-in proxies and JS rendering | `apiKey`| Yes | Yes |
-| [ZenRows](https://www.zenrows.com/) | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies | `apiKey`| Yes | Unknown |
+
+| API                                                                                                                                       | Description                                                                                                                                                                                                                                           | Auth            | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- | --- |
+| [24 Pull Requests](https://24pullrequests.com/api)                                                                                        | Project to promote open source collaboration during December                                                                                                                                                                                          | No              | Yes   | Yes     |
+| [Abstract Screenshot](https://www.abstractapi.com/website-screenshot-api)                                                                 | Take programmatic screenshots of web pages from any website                                                                                                                                                                                           | `apiKey`        | Yes   | Yes     |
+| [Agify.io](https://agify.io)                                                                                                              | Estimates the age from a first name                                                                                                                                                                                                                   | No              | Yes   | Yes     |
+| [API Grátis](https://apigratis.com.br/)                                                                                                   | Multiples services and public APIs                                                                                                                                                                                                                    | No              | Yes   | Unknown |
+| [ApicAgent](https://www.apicagent.com)                                                                                                    | Extract device details from user-agent string                                                                                                                                                                                                         | No              | Yes   | Yes     |
+| [ApiFlash](https://apiflash.com/)                                                                                                         | Chrome based screenshot API for developers                                                                                                                                                                                                            | `apiKey`        | Yes   | Unknown |
+| [APIs.guru](https://apis.guru/api-doc/)                                                                                                   | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs                                                                                                                                                                                         | No              | Yes   | Unknown |
+| [ApyHub](https://apyhub.com/catalog)                                                                                                      | 110+ APIs to add to your next software application                                                                                                                                                                                                    | `apiKey`        | Yes   | Yes     |
+| [Azure DevOps](https://docs.microsoft.com/en-us/rest/api/azure/devops)                                                                    | The Azure DevOps basic components of a REST API request/response pair                                                                                                                                                                                 | `apiKey`        | Yes   | Unknown |
+| [Beeceptor](https://beeceptor.com/)                                                                                                       | Build a mock Rest API endpoint in seconds                                                                                                                                                                                                             | No              | Yes   | Yes     |
+| [Bitbucket](https://developer.atlassian.com/bitbucket/api/2/reference/)                                                                   | Bitbucket API                                                                                                                                                                                                                                         | `OAuth`         | Yes   | Unknown |
+| [Blitapp](https://blitapp.com/api/)                                                                                                       | Schedule screenshots of web pages and sync them to your cloud                                                                                                                                                                                         | `apiKey`        | Yes   | Unknown |
+| [Blynk-Cloud](https://blynkapi.docs.apiary.io/#)                                                                                          | Control IoT Devices from Blynk IoT Cloud                                                                                                                                                                                                              | `apiKey`        | No    | Unknown |
+| [Brainshop.ai](https://brainshop.ai/)                                                                                                     | Make A Free A.I Brain                                                                                                                                                                                                                                 | `apiKey`        | Yes   | Yes     |
+| [Brave Search API](https://brave.com/search/api/)                                                                                         | An index of billions of pages in a single call                                                                                                                                                                                                        | `apiKey`        | Yes   | No      |
+| [BrowserCat](https://www.browsercat.com/)                                                                                                 | Headless browser API for automation, scraping, and more                                                                                                                                                                                               | `apiKey`        | Yes   | Yes     |
+| [Browshot](https://browshot.com/api/documentation)                                                                                        | Easily make screenshots of web pages in any screen size, as any device                                                                                                                                                                                | `apiKey`        | Yes   | Yes     |
+| [CDNJS](https://api.cdnjs.com/libraries/jquery)                                                                                           | Library info on CDNJS                                                                                                                                                                                                                                 | No              | Yes   | Unknown |
+| [Ciprand](https://github.com/polarspetroll/ciprand)                                                                                       | Secure random string generator                                                                                                                                                                                                                        | No              | Yes   | No      |
+| [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api)                                                                   | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More                                                                                                                                                       | No              | Yes   | Yes     |
+| [Codex](https://github.com/Jaagrav/CodeX)                                                                                                 | Online Compiler for Various Languages                                                                                                                                                                                                                 | No              | Yes   | Unknown |
+| [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/)                                                    | Used to retrieve and apply transformations to images                                                                                                                                                                                                  | `apiKey`        | Yes   | Yes     |
+| [CORS Proxy](https://github.com/burhanuday/cors-proxy)                                                                                    | Get around the dreaded CORS error by using this proxy as a middle man                                                                                                                                                                                 | No              | Yes   | Yes     |
+| [Databricks](https://docs.databricks.com/dev-tools/api/latest/index.html)                                                                 | Service to manage your databricks account,clusters, notebooks, jobs and workspaces                                                                                                                                                                    | `apiKey`        | Yes   | Yes     |
+| [DigitalOcean Status](https://status.digitalocean.com/api)                                                                                | Status of all DigitalOcean services                                                                                                                                                                                                                   | No              | Yes   | Unknown |
+| [Docker Hub](https://docs.docker.com/docker-hub/api/latest/)                                                                              | Interact with Docker Hub                                                                                                                                                                                                                              | `apiKey`        | Yes   | Yes     |
+| [DomainDb Info](https://api.domainsdb.info/)                                                                                              | Domain name search to find all domains containing particular words/phrases/etc                                                                                                                                                                        | No              | Yes   | Unknown |
+| [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html)                                                                   | A simple JSON store API                                                                                                                                                                                                                               | No              | Yes   | Yes     |
+| [Generate Full Webpage Screenshot](https://apyhub.com/utility/generate-webpage-screenshot)                                                | Dynamically capture full page screenshots of websites.                                                                                                                                                                                                | `apiKey`        | Yes   | Yes     |
+| [Gcore CDN](https://docs.gcore.com/cdn)                                                                                                   | Make your app fast and responsive for a global audience with Gcore CDN.                                                                                                                                                                               | `apiKey`        | Yes   | Yes     |
+| [Gcore Cloud](https://docs.gcore.com/cloud)                                                                                               | Scalable, secure, and reliable hybrid cloud services anywhere in the world.                                                                                                                                                                           | `apiKey`        | Yes   | Yes     |
+| [Gcore DNS](https://docs.gcore.com/dns)                                                                                                   | Fast and resilient DNS hosting service by Gcore. Improve the performance and availability of your online business.                                                                                                                                    | `apiKey`        | Yes   | Yes     |
+| [Genderize.io](https://genderize.io)                                                                                                      | Estimates a gender from a first name                                                                                                                                                                                                                  | No              | Yes   | Yes     |
+| [GETPing](https://www.getping.info)                                                                                                       | Trigger an email notification with a simple GET request                                                                                                                                                                                               | `apiKey`        | Yes   | Unknown |
+| [Ghost](https://ghost.org/)                                                                                                               | Get Published content into your Website, App or other embedded media                                                                                                                                                                                  | `apiKey`        | Yes   | Yes     |
+| [GitHub](https://docs.github.com/en/free-pro-team@latest/rest)                                                                            | Make use of GitHub repositories, code and user info programmatically                                                                                                                                                                                  | `OAuth`         | Yes   | Yes     |
+| [Gitlab](https://docs.gitlab.com/ee/api/)                                                                                                 | Automate GitLab interaction programmatically                                                                                                                                                                                                          | `OAuth`         | Yes   | Unknown |
+| [Glitterly](https://developers.glitterly.app)                                                                                             | Image generation API                                                                                                                                                                                                                                  | `apiKey`        | Yes   | Yes     |
+| [Google Docs](https://developers.google.com/docs/api/reference/rest)                                                                      | API to read, write, and format Google Docs documents                                                                                                                                                                                                  | `OAuth`         | Yes   | Unknown |
+| [Google Firebase](https://firebase.google.com/docs)                                                                                       | Google's mobile application development platform that helps build, improve, and grow app                                                                                                                                                              | `apiKey`        | Yes   | Yes     |
+| [Google Fonts](https://developers.google.com/fonts/docs/developer_api)                                                                    | Metadata for all families served by Google Fonts                                                                                                                                                                                                      | `apiKey`        | Yes   | Unknown |
+| [Google Keep](https://developers.google.com/keep/api/reference/rest)                                                                      | API to read, write, and format Google Keep notes                                                                                                                                                                                                      | `OAuth`         | Yes   | Unknown |
+| [Google Sheets](https://developers.google.com/sheets/api/reference/rest)                                                                  | API to read, write, and format Google Sheets data                                                                                                                                                                                                     | `OAuth`         | Yes   | Unknown |
+| [Google Slides](https://developers.google.com/slides/api/reference/rest)                                                                  | API to read, write, and format Google Slides presentations                                                                                                                                                                                            | `OAuth`         | Yes   | Unknown |
+| [Gorest](https://gorest.co.in/)                                                                                                           | Online REST API for Testing and Prototyping                                                                                                                                                                                                           | `OAuth`         | Yes   | Unknown |
+| [Hasura](https://hasura.io/opensource/)                                                                                                   | GraphQL and REST API Engine with built in Authorization                                                                                                                                                                                               | `apiKey`        | Yes   | Yes     |
+| [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/)                                                                   | REST API to programmatically create apps, provision add-ons and perform other task on Heroku                                                                                                                                                          | `OAuth`         | Yes   | Yes     |
+| [Hoppscotch](https://hoppscotch.io/)                                                                                                      | A lightweight, fast, and customizable app for testing and designing APIs. A free, fast, and beautiful                                                                                                                                                 | No              | Yes   | Unknown |
+| [Host.io](https://host.io)                                                                                                                | Domains Data API for Developers                                                                                                                                                                                                                       | `apiKey`        | Yes   | Yes     |
+| [HTTP2.Pro](https://http2.pro/doc/api)                                                                                                    | Test endpoints for client and server HTTP/2 protocol support                                                                                                                                                                                          | No              | Yes   | Unknown |
+| [HTTPie](https://httpie.io)                                                                                                               | a free command-line HTTP client for the API era                                                                                                                                                                                                       | No              | Yes   | Unknown |
+| [Httpbin](https://httpbin.org/)                                                                                                           | A Simple HTTP Request & Response Service                                                                                                                                                                                                              | No              | Yes   | Yes     |
+| [Hunter](https://hunter.io/api)                                                                                                           | API for domain search, professional email finder, author finder and email verifier                                                                                                                                                                    | `apiKey`        | Yes   | Unknown |
+| [IBM Text to Speech](https://cloud.ibm.com/docs/text-to-speech/getting-started.html)                                                      | Convert text to speech                                                                                                                                                                                                                                | `apiKey`        | Yes   | Yes     |
+| [IFTTT](https://platform.ifttt.com/docs/connect_api)                                                                                      | IFTTT Connect API                                                                                                                                                                                                                                     | No              | Yes   | Unknown |
+| [Image-Charts](https://documentation.image-charts.com/)                                                                                   | Generate charts, QR codes and graph images                                                                                                                                                                                                            | No              | Yes   | Yes     |
+| [import.io](http://api.docs.import.io/)                                                                                                   | Retrieve structured data from a website or RSS feed                                                                                                                                                                                                   | `apiKey`        | Yes   | Unknown |
+| [Insomnia](https://insomnia.rest/)                                                                                                        | A free API client that allows you to design, debug, test, and mock APIs locally, on Git, or cloud.                                                                                                                                                    | `OAuth`         | Yes   | Unknown |
+| [IP2WHOIS Information Lookup](https://www.ip2whois.com/)                                                                                  | WHOIS domain name lookup                                                                                                                                                                                                                              | `apiKey`        | Yes   | Unknown |
+| [ipfind.io](https://ipfind.io)                                                                                                            | Geographic location of an IP address or any domain name along with some other useful information                                                                                                                                                      | `apiKey`        | Yes   | Yes     |
+| [IPify](https://www.ipify.org/)                                                                                                           | A simple IP Address API                                                                                                                                                                                                                               | No              | Yes   | Unknown |
+| [IPinfo](https://ipinfo.io/developers)                                                                                                    | Another simple IP Address API                                                                                                                                                                                                                         | No              | Yes   | Unknown |
+| [jsDelivr](https://github.com/jsdelivr/data.jsdelivr.com)                                                                                 | Package info and download stats on jsDelivr CDN                                                                                                                                                                                                       | No              | Yes   | Yes     |
+| [JSON 2 JSONP](https://json2jsonp.com/)                                                                                                   | Convert JSON to JSONP (on-the-fly) for easy cross-domain data requests using client-side JavaScript                                                                                                                                                   | No              | Yes   | Unknown |
+| [JSONbin.io](https://jsonbin.io)                                                                                                          | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps                                                                                                                                                                   | `apiKey`        | Yes   | Yes     |
+| [JSONsilo.com](https://jsonsilo.com)                                                                                                      | Hassle-free JSON hosting. Convert your JSON file to an API in minutes at no cost.                                                                                                                                                                     | `apiKey`        | Yes   | Yes     | No  |
+| [Kroki](https://kroki.io)                                                                                                                 | Creates diagrams from textual descriptions                                                                                                                                                                                                            | No              | Yes   | Yes     |
+| [License-API](https://github.com/cmccandless/license-api/blob/master/README.md)                                                           | Unofficial REST API for choosealicense.com                                                                                                                                                                                                            | No              | Yes   | No      |
+| [Lua Decompiler](https://lua-decompiler.ferib.dev/)                                                                                       | Online Lua 5.1 Decompiler                                                                                                                                                                                                                             | No              | Yes   | Yes     |
+| [MAC address vendor lookup](https://macaddress.io/api)                                                                                    | Retrieve vendor details and other information regarding a given MAC address or an OUI                                                                                                                                                                 | `apiKey`        | Yes   | Yes     |
+| [MicroENV](https://microenv.com/)                                                                                                         | Fake Rest API for developers                                                                                                                                                                                                                          | No              | Yes   | Unknown |
+| [Mocky](https://designer.mocky.io/)                                                                                                       | Mock user defined test JSON for REST API endpoints                                                                                                                                                                                                    | No              | Yes   | Yes     |
+| [MY IP](https://www.myip.com/api-docs/)                                                                                                   | Get IP address information                                                                                                                                                                                                                            | No              | Yes   | Unknown |
+| [Nationalize.io](https://nationalize.io)                                                                                                  | Estimate the nationality of a first name                                                                                                                                                                                                              | No              | Yes   | Yes     |
+| [Netlify](https://docs.netlify.com/api/get-started/)                                                                                      | Netlify is a hosting service for the programmable web                                                                                                                                                                                                 | `OAuth`         | Yes   | Unknown |
+| [NetworkCalc](https://networkcalc.com/api/docs)                                                                                           | Network calculators, including subnets, DNS, binary, and security tools                                                                                                                                                                               | No              | Yes   | Yes     |
+| [npm Registry](https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md)                                                          | Query information about your favorite Node.js libraries programmatically                                                                                                                                                                              | No              | Yes   | Unknown |
+| [OneSignal](https://documentation.onesignal.com/reference/rest-api-overview)                                                              | Self-serve customer engagement solution for Push Notifications, Email, SMS & In-App                                                                                                                                                                   | `apiKey`        | Yes   | Unknown |
+| [Open Page Rank](https://www.domcop.com/openpagerank/)                                                                                    | API for calculating and comparing metrics of different websites using Page Rank algorithm                                                                                                                                                             | `apiKey`        | Yes   | Unknown |
+| [OpenAPIHub](https://hub.openapihub.com/)                                                                                                 | The All-in-one API Platform                                                                                                                                                                                                                           | `X-Mashape-Key` | Yes   | Unknown |
+| [PipeDream](https://docs.pipedream.com)                                                                                                   | Pipedream is the fastest way to build powerful applications that connect all the services in your stack                                                                                                                                               | `OAuth`         | Yes   | Unknown |
+| [Postman](https://www.postman.com/postman/workspace/postman-public-workspace/documentation/12959542-c8142d51-e97c-46b6-bd77-52bb66712c9a) | Tool for testing APIs                                                                                                                                                                                                                                 | `apiKey`        | Yes   | Unknown |
+| [ProxyCrawl](https://proxycrawl.com)                                                                                                      | Scraping and crawling anticaptcha service                                                                                                                                                                                                             | `apiKey`        | Yes   | Unknown |
+| [ProxyKingdom](https://proxykingdom.com)                                                                                                  | Rotating Proxy API that produces a working proxy on every request                                                                                                                                                                                     | `apiKey`        | Yes   | Yes     |
+| [Pusher Beams](https://pusher.com/beams)                                                                                                  | Push notifications for Android & iOS                                                                                                                                                                                                                  | `apiKey`        | Yes   | Unknown |
+| [Pusher Channels](https://pusher.com/channels)                                                                                            | Realtime features                                                                                                                                                                                                                                     | `apiKey`        | Yes   | Unknown |
+| [QR code](https://www.qrtag.net/api/)                                                                                                     | Create an easy to read QR code and URL shortener                                                                                                                                                                                                      | No              | Yes   | Yes     |
+| [QR code](http://goqr.me/api/)                                                                                                            | Generate and decode / read QR code graphics                                                                                                                                                                                                           | No              | Yes   | Unknown |
+| [QR code Generator](https://docs.openqr.io/)                                                                                              | Static and Dynamic QR code generator with custom and unique QR code design                                                                                                                                                                            | `apiKey`        | Yes   | Unknown |
+| [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/)                                                                     | Integrate custom and unique looking QR codes into your system or workflow                                                                                                                                                                             | No              | Yes   | Unknown |
+| [QuickChart](https://quickchart.io/)                                                                                                      | Generate chart and graph images                                                                                                                                                                                                                       | No              | Yes   | Yes     |
+| [Random Stuff](https://api-docs.pgamerx.com/)                                                                                             | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed                                                                                                                                                                   | `apiKey`        | Yes   | Yes     |
+| [Rejax](https://rejax.io/)                                                                                                                | Reverse AJAX service to notify clients                                                                                                                                                                                                                | `apiKey`        | Yes   | No      |
+| [ReqRes](https://reqres.in/)                                                                                                              | A hosted REST-API ready to respond to your AJAX requests                                                                                                                                                                                              | No              | Yes   | Unknown |
+| [RSS to JSON](https://github.com/ayusharma/RSS-to-JSON)                                                                                   | Returns RSS feed in JSON format using feed URL                                                                                                                                                                                                        | No              | Yes   | Yes     |
+| [ScrapeNinja](https://scrapeninja.net)                                                                                                    | Scraping API with Chrome fingerprint and residential proxies                                                                                                                                                                                          | `apiKey`        | Yes   | Unknown |
+| [ScraperApi](https://www.scraperapi.com)                                                                                                  | Easily build scalable web scrapers                                                                                                                                                                                                                    | `apiKey`        | Yes   | Unknown |
+| [scraperBox](https://scraperbox.com/)                                                                                                     | Undetectable web scraping API                                                                                                                                                                                                                         | `apiKey`        | Yes   | Yes     |
+| [Scrapfly](https://scrapfly.io)                                                                                                           | Scrapfly is an enterprise-grade solution providing Web Scraping API that aims to simplify the scraping process by managing everything: real browser rendering, rotating proxies, and fingerprints (TLS, HTTP, browser) to bypass all major anti-bots. | `apiKey`        | Yes   | No      |
+| [ScrapingAnt](https://scrapingant.com)                                                                                                    | Headless Chrome scraping with a simple API                                                                                                                                                                                                            | `apiKey`        | Yes   | Unknown |
+| [ScrapingDog](https://www.scrapingdog.com/)                                                                                               | Proxy API for Web scraping                                                                                                                                                                                                                            | `apiKey`        | Yes   | Unknown |
+| [ScreenshotAPI.net](https://screenshotapi.net/)                                                                                           | Create pixel-perfect website screenshots                                                                                                                                                                                                              | `apiKey`        | Yes   | Yes     |
+| [Screenshotbase](https://screenshotbase.com/)                                                                                             | Screenshot API, 1000 free requests per month                                                                                                                                                                                                          | `apiKey`        | Yes   | Yes     |
+| [ScreenshotOne.com](https://screenshotone.com/)                                                                                           | Convert URLs, HTML, or Markdown into PNG, JPEG, WebP, or PDF with a simple screenshot API                                                                                                                                                             | `apiKey`        | Yes   | Yes     |
+| [SearchApi](https://www.searchapi.io/)                                                                                                    | Real-Time Google SERP API                                                                                                                                                                                                                             | `apiKey`        | Yes   | No      |
+| [Serialif Color](https://color.serialif.com/)                                                                                             | Color conversion, complementary, grayscale and contrasted text                                                                                                                                                                                        | No              | Yes   | No      |
+| [SerpApi](https://serpapi.com/)                                                                                                           | Scrape Google and other search engines                                                                                                                                                                                                                | `apiKey`        | Yes   | No      |
+| [SERP Rank Checker](https://apyhub.com/utility/serp-rank)                                                                                 | Check realtime Google SERP Rank of any keywords.                                                                                                                                                                                                      | `apiKey`        | Yes   | Yes     |
+| [Shadify](https://github.com/cheatsnake/shadify)                                                                                          | Service for generating data and executing logic to create various games and puzzles                                                                                                                                                                   | No              | Yes   | Yes     |
+| [Sheetsu](https://sheetsu.com/)                                                                                                           | Easy google sheets integration                                                                                                                                                                                                                        | `apiKey`        | Yes   | Unknown |
+| [Sonar](https://github.com/Cgboal/SonarSearch)                                                                                            | Project Sonar DNS Enumeration API                                                                                                                                                                                                                     | No              | Yes   | Yes     |
+| [SonarQube](https://sonarcloud.io/web_api)                                                                                                | SonarQube REST APIs to detect bugs, code smells & security vulnerabilities                                                                                                                                                                            | `OAuth`         | Yes   | Unknown |
+| [StackExchange](https://api.stackexchange.com/)                                                                                           | Q&A forum for developers                                                                                                                                                                                                                              | `OAuth`         | Yes   | Unknown |
+| [Statically](https://statically.io/)                                                                                                      | A free CDN for developers                                                                                                                                                                                                                             | No              | Yes   | Yes     |
+| [Supportivekoala](https://developers.supportivekoala.com/)                                                                                | Autogenerate images with template                                                                                                                                                                                                                     | `apiKey`        | Yes   | Yes     |
+| [Svix](https://www.svix.com)                                                                                                              | Webhooks as a Service                                                                                                                                                                                                                                 | `apiKey`        | Yes   | Unknown |
+| [Tolgee](https://tolgee.io)                                                                                                               | Open-source localization (i18n) platform enabling you to translate you app fast                                                                                                                                                                       | `apiKey`        | Yes   | No      |
+| [Tyk](https://tyk.io/open-source/)                                                                                                        | Api and service management platform                                                                                                                                                                                                                   | `apiKey`        | Yes   | Yes     |
+| [YADG](https://yadg.cc/api/v2/)                                                                                                           | An API that scrapes music release data and renders it using different templates                                                                                                                                                                       | `apiKey`        | Yes   | Unknown |
+| [Wandbox](https://github.com/melpon/wandbox/blob/master/kennel/API.md)                                                                    | Code compiler supporting 35+ languages mentioned at wandbox.org                                                                                                                                                                                       | No              | Yes   | Unknown |
+| [WebScraping.AI](https://webscraping.ai/)                                                                                                 | Web Scraping API with built-in proxies and JS rendering                                                                                                                                                                                               | `apiKey`        | Yes   | Yes     |
+| [ZenRows](https://www.zenrows.com/)                                                                                                       | Web Scraping API that bypasses anti-bot solutions while offering JS rendering, and rotating proxies                                                                                                                                                   | `apiKey`        | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Dictionaries
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Chinese Character Web](http://ccdb.hemiola.com/) | Chinese character definitions and pronunciations | No | No | No |
-| [Chinese Text Project](https://ctext.org/tools/api) | Online open-access digital library for pre-modern Chinese texts | No | Yes | Unknown |
-| [Collins](https://api.collinsdictionary.com/api/v1/documentation/html/) | Bilingual Dictionary and Thesaurus Data | `apiKey` | Yes | Unknown |
-| [Free Dictionary](https://dictionaryapi.dev/) | Definitions, phonetics, pronounciations, parts of speech, examples, synonyms | No | Yes | Unknown |
-| [Lingua Robot](https://www.linguarobot.io) | Word definitions, pronunciations, synonyms, antonyms and others | `apiKey` | Yes | Yes |
-| [Merriam-Webster](https://dictionaryapi.com/) | Dictionary and Thesaurus Data | `apiKey` | Yes | Unknown |
-| [Oxford](https://developer.oxforddictionaries.com/) | Dictionary Data | `apiKey` | Yes | No |
-| [Synonyms](https://www.synonyms.com/synonyms_api.php) | Synonyms, thesaurus and antonyms information for any given word | `apiKey` | Yes | Unknown |
-| [Wiktionary](https://en.wiktionary.org/w/api.php) | Collaborative dictionary data | No | Yes | Yes |
-| [Wordnik](https://developer.wordnik.com) | Dictionary Data | `apiKey` | Yes | Unknown |
-| [Words](https://www.wordsapi.com/docs/) | Definitions and synonyms for more than 150,000 words | `apiKey` | Yes | Unknown |
-| [WordsAPI](https://www.wordsapi.com/docs/) | An API for the English Language. Find definitions, related words, and more | `apiKey` | Yes | Unknown |
+
+| API                                                                     | Description                                                                  | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------- | ---------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Chinese Character Web](http://ccdb.hemiola.com/)                       | Chinese character definitions and pronunciations                             | No       | No    | No      |
+| [Chinese Text Project](https://ctext.org/tools/api)                     | Online open-access digital library for pre-modern Chinese texts              | No       | Yes   | Unknown |
+| [Collins](https://api.collinsdictionary.com/api/v1/documentation/html/) | Bilingual Dictionary and Thesaurus Data                                      | `apiKey` | Yes   | Unknown |
+| [Free Dictionary](https://dictionaryapi.dev/)                           | Definitions, phonetics, pronounciations, parts of speech, examples, synonyms | No       | Yes   | Unknown |
+| [Lingua Robot](https://www.linguarobot.io)                              | Word definitions, pronunciations, synonyms, antonyms and others              | `apiKey` | Yes   | Yes     |
+| [Merriam-Webster](https://dictionaryapi.com/)                           | Dictionary and Thesaurus Data                                                | `apiKey` | Yes   | Unknown |
+| [Oxford](https://developer.oxforddictionaries.com/)                     | Dictionary Data                                                              | `apiKey` | Yes   | No      |
+| [Synonyms](https://www.synonyms.com/synonyms_api.php)                   | Synonyms, thesaurus and antonyms information for any given word              | `apiKey` | Yes   | Unknown |
+| [Wiktionary](https://en.wiktionary.org/w/api.php)                       | Collaborative dictionary data                                                | No       | Yes   | Yes     |
+| [Wordnik](https://developer.wordnik.com)                                | Dictionary Data                                                              | `apiKey` | Yes   | Unknown |
+| [Words](https://www.wordsapi.com/docs/)                                 | Definitions and synonyms for more than 150,000 words                         | `apiKey` | Yes   | Unknown |
+| [WordsAPI](https://www.wordsapi.com/docs/)                              | An API for the English Language. Find definitions, related words, and more   | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Documents & Productivity
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Airtable](https://airtable.com/api) | Integrate with Airtable | `apiKey` | Yes | Unknown |
-| [Api2Convert](https://www.api2convert.com/) | Online File Conversion API | `apiKey` | Yes | Unknown |
-| [Asana](https://developers.asana.com/docs) | Programmatic access to all data in your asana system | `apiKey` | Yes | Yes |
-| [ClickUp](https://clickup.com/api) | ClickUp is a robust, cloud-based project management tool for boosting productivity | `OAuth`| Yes | Unknown |
-| [Clockify](https://clockify.me/developers-api) | Clockify's REST-based API can be used to push/pull data to/from it & integrate it with other systems | `apiKey` | Yes | Unknown |
-| [CloudConvert](https://cloudconvert.com/api/v2) | Online file converter for audio, video, document, ebook, archive, image, spreadsheet, presentation | `apiKey` | Yes | Unknown |
-| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion | `apiKey` | Yes | Yes |
-| [Code::Stats](https://codestats.net/api-docs) | Automatic time tracking for programmers | `apiKey` | Yes | No |
-| [Convert Word to PDF](https://apyhub.com/utility/converter-doc-pdf) | Convert a Word document (doc, docx, or ODF formats) to a PDF document | `apiKey` | Yes | Yes |
-| [Convert RSS to JSON](https://apyhub.com/utility/converter-rss-json) | Transform raw RSS data into structured JSON | `apiKey` | Yes | Yes |
-| [CraftMyPDF](https://craftmypdf.com) | Generate PDF documents from templates with a drop-and-drop editor and a simple API | `apiKey` | Yes | No |
-| [CV / Resume Parsing API](https://apyhub.com/utility/sharpapi-ai-resume-parser) | The Resume Parser API parses a resume (CV) file from multiple formats (PDF/DOC/DOCX/TXT/RTF) and returns an extensive object of data points | `apiKey` | Yes | Yes |
-| [FastApi Simple Calculator](https://fastapi-calculadora.onrender.com/) | Math, Stadistics, Conversions, Currency and more | No | Yes | Unknown |
-| [Flowdash](https://docs.flowdash.com/docs/api-introduction) | Automate business workflows | `apiKey` | Yes | Unknown |
-| [Html2PDF](https://html2pdf.app/) | HTML/URL to PDF | `apiKey` | Yes | Unknown |
-| [iLovePDF](https://developer.ilovepdf.com/) | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month | `apiKey` | Yes | Yes |
-| [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/) | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management | `OAuth`| Yes | Unknown |
-| [Mattermost](https://api.mattermost.com/) | An open source platform for developer collaboration | `OAuth`| Yes | Unknown |
-| [Monday](https://developer.monday.com/) | Programmatically access and update data inside a monday.com account | `apiKey` | Yes | Unknown |
-| [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth`| Yes | Unknown |
-| [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
-| [PDFEndpoint](https://pdfendpoint.com) | HTML and URL to PDF API | `apiKey` | Yes | No |
-| [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth`| Yes | Unknown |
-| [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth`| Yes | Unknown |
-| [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |
-| [RenderPDF.io](https://renderpdf.io) | HTML to PDF crazy fast, 500 pdfs/month + CDN-ready | `apiKey` | Yes | Yes |
-| [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Yes | Unknown |
-| [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth`| Yes | Unknown |
-| [URL to Markdown](https://github.com/macsplit/urltomarkdown) | Convert web page to MarkDown | No | Yes | Yes |
-| [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | Yes | No |
-| [Vertopal](https://www.vertopal.com/en/developer/api/introduction) | Convert your files to a variety of formats using Vertopal API | `apiKey` | Yes | No |
-| [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Yes | Unknown |
-| [WebPDF](https://webpdf.xyz/) | Work with PDF files via API | `apiKey`| Yes | No |
-| [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth`| Yes | Unknown |
+
+| API                                                                               | Description                                                                                                                                 | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Airtable](https://airtable.com/api)                                              | Integrate with Airtable                                                                                                                     | `apiKey` | Yes   | Unknown |
+| [Api2Convert](https://www.api2convert.com/)                                       | Online File Conversion API                                                                                                                  | `apiKey` | Yes   | Unknown |
+| [Asana](https://developers.asana.com/docs)                                        | Programmatic access to all data in your asana system                                                                                        | `apiKey` | Yes   | Yes     |
+| [ClickUp](https://clickup.com/api)                                                | ClickUp is a robust, cloud-based project management tool for boosting productivity                                                          | `OAuth`  | Yes   | Unknown |
+| [Clockify](https://clockify.me/developers-api)                                    | Clockify's REST-based API can be used to push/pull data to/from it & integrate it with other systems                                        | `apiKey` | Yes   | Unknown |
+| [CloudConvert](https://cloudconvert.com/api/v2)                                   | Online file converter for audio, video, document, ebook, archive, image, spreadsheet, presentation                                          | `apiKey` | Yes   | Unknown |
+| [Cloudmersive Document and Data Conversion](https://cloudmersive.com/convert-api) | HTML/URL to PDF/PNG, Office documents to PDF, image conversion                                                                              | `apiKey` | Yes   | Yes     |
+| [Code::Stats](https://codestats.net/api-docs)                                     | Automatic time tracking for programmers                                                                                                     | `apiKey` | Yes   | No      |
+| [Convert Word to PDF](https://apyhub.com/utility/converter-doc-pdf)               | Convert a Word document (doc, docx, or ODF formats) to a PDF document                                                                       | `apiKey` | Yes   | Yes     |
+| [Convert RSS to JSON](https://apyhub.com/utility/converter-rss-json)              | Transform raw RSS data into structured JSON                                                                                                 | `apiKey` | Yes   | Yes     |
+| [CraftMyPDF](https://craftmypdf.com)                                              | Generate PDF documents from templates with a drop-and-drop editor and a simple API                                                          | `apiKey` | Yes   | No      |
+| [CV / Resume Parsing API](https://apyhub.com/utility/sharpapi-ai-resume-parser)   | The Resume Parser API parses a resume (CV) file from multiple formats (PDF/DOC/DOCX/TXT/RTF) and returns an extensive object of data points | `apiKey` | Yes   | Yes     |
+| [FastApi Simple Calculator](https://fastapi-calculadora.onrender.com/)            | Math, Stadistics, Conversions, Currency and more                                                                                            | No       | Yes   | Unknown |
+| [Flowdash](https://docs.flowdash.com/docs/api-introduction)                       | Automate business workflows                                                                                                                 | `apiKey` | Yes   | Unknown |
+| [Html2PDF](https://html2pdf.app/)                                                 | HTML/URL to PDF                                                                                                                             | `apiKey` | Yes   | Unknown |
+| [iLovePDF](https://developer.ilovepdf.com/)                                       | Convert, merge, split, extract text and add page numbers for PDFs. Free for 250 documents/month                                             | `apiKey` | Yes   | Yes     |
+| [JIRA](https://developer.atlassian.com/server/jira/platform/rest-apis/)           | JIRA is a proprietary issue tracking product that allows bug tracking and agile project management                                          | `OAuth`  | Yes   | Unknown |
+| [Mattermost](https://api.mattermost.com/)                                         | An open source platform for developer collaboration                                                                                         | `OAuth`  | Yes   | Unknown |
+| [Monday](https://developer.monday.com/)                                           | Programmatically access and update data inside a monday.com account                                                                         | `apiKey` | Yes   | Unknown |
+| [Notion](https://developers.notion.com/docs/getting-started)                      | Integrate with Notion                                                                                                                       | `OAuth`  | Yes   | Unknown |
+| [PandaDoc](https://developers.pandadoc.com)                                       | DocGen and eSignatures API                                                                                                                  | `apiKey` | Yes   | No      |
+| [PDFEndpoint](https://pdfendpoint.com)                                            | HTML and URL to PDF API                                                                                                                     | `apiKey` | Yes   | No      |
+| [Pocket](https://getpocket.com/developer/)                                        | Bookmarking service                                                                                                                         | `OAuth`  | Yes   | Unknown |
+| [Podio](https://developers.podio.com)                                             | File sharing and productivity                                                                                                               | `OAuth`  | Yes   | Unknown |
+| [PrexView](https://prexview.com)                                                  | Data from XML or JSON to PDF, HTML or Image                                                                                                 | `apiKey` | Yes   | Unknown |
+| [RenderPDF.io](https://renderpdf.io)                                              | HTML to PDF crazy fast, 500 pdfs/month + CDN-ready                                                                                          | `apiKey` | Yes   | Yes     |
+| [Restpack](https://restpack.io/)                                                  | Provides screenshot, HTML to PDF and content extraction APIs                                                                                | `apiKey` | Yes   | Unknown |
+| [Todoist](https://developer.todoist.com)                                          | Todo Lists                                                                                                                                  | `OAuth`  | Yes   | Unknown |
+| [URL to Markdown](https://github.com/macsplit/urltomarkdown)                      | Convert web page to MarkDown                                                                                                                | No       | Yes   | Yes     |
+| [Vector Express v2.0](https://vector.express)                                     | Free vector file converting API                                                                                                             | No       | Yes   | No      |
+| [Vertopal](https://www.vertopal.com/en/developer/api/introduction)                | Convert your files to a variety of formats using Vertopal API                                                                               | `apiKey` | Yes   | No      |
+| [WakaTime](https://wakatime.com/developers)                                       | Automated time tracking leaderboards for programmers                                                                                        | No       | Yes   | Unknown |
+| [WebPDF](https://webpdf.xyz/)                                                     | Work with PDF files via API                                                                                                                 | `apiKey` | Yes   | No      |
+| [Zube](https://zube.io/docs/api)                                                  | Full stack project management                                                                                                               | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Email
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Abstract Email Validation](https://www.abstractapi.com/email-verification-validation-api) | Validate email addresses for deliverability and spam | `apiKey` | Yes | Yes |
-| [Cloudmersive Validate](https://cloudmersive.com/validate-api) | Validate email addresses, phone numbers, VAT numbers and domain names | `apiKey` | Yes | Yes |
-| [Disify](https://www.disify.com/) | Validate and detect disposable and temporary email addresses | No | Yes | Yes |
-| [DropMail](https://dropmail.me/api/#live-demo) | GraphQL API for creating and managing ephemeral e-mail inboxes | No | Yes | Unknown |
-| [Emailvalidation](https://emailvalidation.io/email-validation-api/) | E-Mail address validation | `apiKey` | Yes | Yes |
-| [Enveloop](https://enveloop.com) | Design, host, and send emails and texts. All from one place - with a simple API | `apiKey` | Yes | Yes |
-| [EVA](https://eva.pingutil.com/) | Validate email addresses | No | Yes | Yes |
-| [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html) | Disposable temporary Email addresses | No | Yes | Unknown |
-| [ImprovMX](https://improvmx.com/api) | API for free email forwarding service | `apiKey` | Yes | Unknown |
-| [Kickbox](https://open.kickbox.com/) | Email verification API | No | Yes | Yes |
-| [mail.gw](https://docs.mail.gw) | 10 Minute Mail | No | Yes | Yes |
-| [mail.tm](https://docs.mail.tm) | Temporary Email Service | No | Yes | Yes |
-| [MailboxValidator](https://www.mailboxvalidator.com/api-email-free) | Validate email address to improve deliverability | `apiKey` | Yes | Unknown |
-| [MailCheck.ai](https://www.mailcheck.ai/#documentation) | Prevent users to sign up with temporary email addresses | No | Yes | Unknown |
-| [Mailtrap](https://mailtrap.docs.apiary.io/#) | A service for the safe testing of emails sent from the development and staging environments | `apiKey` | Yes | Unknown |
-| [Notilify](https://documenter.getpostman.com/view/32462468/2s9YsT6ong) | A seamless messaging platform & API to send all types of SMS | `apiKey` | Yes | Yes |
-| [Proweblook Email Checker](https://proweblook.com/email-verifier) | Validate email addresses without sending | `apiKey` | Yes | Yes |
-| [Resend](https://resend.com/docs/) | Email API for developers | `apiKey` | Yes | Yes |
-| [Sendgrid](https://docs.sendgrid.com/api-reference/) | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers | `apiKey` | Yes | Unknown |
-| [Sendinblue](https://developers.sendinblue.com/docs) | A service that provides solutions relating to marketing and/or transactional email and/or SMS | `apiKey` | Yes | Unknown |
-| [Sweego](https://learn.sweego.io/docs/api-intro) | Self-serve multichannel notification platform for transactional email, SMS, push web& mobile, chat, in-app | `apiKey` | Yes | Yes |
-| [Verifier](https://verifier.meetchopra.com/docs#/) | Verifies that a given email is real | `apiKey` | Yes | Yes |
+
+| API                                                                                        | Description                                                                                                | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Abstract Email Validation](https://www.abstractapi.com/email-verification-validation-api) | Validate email addresses for deliverability and spam                                                       | `apiKey` | Yes   | Yes     |
+| [Cloudmersive Validate](https://cloudmersive.com/validate-api)                             | Validate email addresses, phone numbers, VAT numbers and domain names                                      | `apiKey` | Yes   | Yes     |
+| [Disify](https://www.disify.com/)                                                          | Validate and detect disposable and temporary email addresses                                               | No       | Yes   | Yes     |
+| [DropMail](https://dropmail.me/api/#live-demo)                                             | GraphQL API for creating and managing ephemeral e-mail inboxes                                             | No       | Yes   | Unknown |
+| [Emailvalidation](https://emailvalidation.io/email-validation-api/)                        | E-Mail address validation                                                                                  | `apiKey` | Yes   | Yes     |
+| [Enveloop](https://enveloop.com)                                                           | Design, host, and send emails and texts. All from one place - with a simple API                            | `apiKey` | Yes   | Yes     |
+| [EVA](https://eva.pingutil.com/)                                                           | Validate email addresses                                                                                   | No       | Yes   | Yes     |
+| [Guerrilla Mail](https://www.guerrillamail.com/GuerrillaMailAPI.html)                      | Disposable temporary Email addresses                                                                       | No       | Yes   | Unknown |
+| [ImprovMX](https://improvmx.com/api)                                                       | API for free email forwarding service                                                                      | `apiKey` | Yes   | Unknown |
+| [Kickbox](https://open.kickbox.com/)                                                       | Email verification API                                                                                     | No       | Yes   | Yes     |
+| [mail.gw](https://docs.mail.gw)                                                            | 10 Minute Mail                                                                                             | No       | Yes   | Yes     |
+| [mail.tm](https://docs.mail.tm)                                                            | Temporary Email Service                                                                                    | No       | Yes   | Yes     |
+| [MailboxValidator](https://www.mailboxvalidator.com/api-email-free)                        | Validate email address to improve deliverability                                                           | `apiKey` | Yes   | Unknown |
+| [MailCheck.ai](https://www.mailcheck.ai/#documentation)                                    | Prevent users to sign up with temporary email addresses                                                    | No       | Yes   | Unknown |
+| [Mailtrap](https://mailtrap.docs.apiary.io/#)                                              | A service for the safe testing of emails sent from the development and staging environments                | `apiKey` | Yes   | Unknown |
+| [Notilify](https://documenter.getpostman.com/view/32462468/2s9YsT6ong)                     | A seamless messaging platform & API to send all types of SMS                                               | `apiKey` | Yes   | Yes     |
+| [Proweblook Email Checker](https://proweblook.com/email-verifier)                          | Validate email addresses without sending                                                                   | `apiKey` | Yes   | Yes     |
+| [Resend](https://resend.com/docs/)                                                         | Email API for developers                                                                                   | `apiKey` | Yes   | Yes     |
+| [Sendgrid](https://docs.sendgrid.com/api-reference/)                                       | A cloud-based SMTP provider that allows you to send emails without having to maintain email servers        | `apiKey` | Yes   | Unknown |
+| [Sendinblue](https://developers.sendinblue.com/docs)                                       | A service that provides solutions relating to marketing and/or transactional email and/or SMS              | `apiKey` | Yes   | Unknown |
+| [Sweego](https://learn.sweego.io/docs/api-intro)                                           | Self-serve multichannel notification platform for transactional email, SMS, push web& mobile, chat, in-app | `apiKey` | Yes   | Yes     |
+| [Verifier](https://verifier.meetchopra.com/docs#/)                                         | Verifies that a given email is real                                                                        | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Entertainment
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [chucknorris.io](https://api.chucknorris.io) | JSON API for hand curated Chuck Norris jokes | No | Yes | Unknown |
-| [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words | No | Yes | Yes |
-| [elonmu.sh](https://elonmu.sh/) | Get random news article featuring Elon Musk | No | Yes | Unknown |
-| [Fuck Off As A Service](https://foaas.dev/) | FOAAS (Fuck Off As A Service) provides a modern, RESTful, scalable solution to the common problem of telling people to fuck off. | No | Yes | Unknown |
-| [Imgflip](https://imgflip.com/api) | Gets an array of popular memes | No | Yes | Unknown |
-| [JokeAPI](https://jokeapi.dev/) | Jokes in multiple formats | No | Yes | Yes |
-| [Keanu Reeves Whoa](https://whoa.onrender.com/) | JSON API for every "whoa" said by actor Keanu Reeves in his movies | No | Yes | Unknown |
-| [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
-| [Official Joke](https://official-joke-api.appspot.com/) | API for random and programming jokes | No | Yes | Unknown |
-| [Puns](https://punapi.rest/) | Puns and pun based memes. REST API | No | Yes | Yes |
-| [Random Dad Joke](https://icanhazdadjoke.com/) | API for largest selection of dad jokes on the internet | No | Yes | Unknown |
-| [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
-| [Techy](https://techy-api.vercel.app/) | JSON and Plaintext API for tech-savvy sounding phrases | No | Yes | Unknown |
-| [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2) | REST API for Yo Momma Jokes | No | Yes | Unknown |
+
+| API                                                                                 | Description                                                                                                                      | Auth | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ---- | ----- | ------- |
+| [chucknorris.io](https://api.chucknorris.io)                                        | JSON API for hand curated Chuck Norris jokes                                                                                     | No   | Yes   | Unknown |
+| [Corporate Buzz Words](https://github.com/sameerkumar18/corporate-bs-generator-api) | REST API for Corporate Buzz Words                                                                                                | No   | Yes   | Yes     |
+| [elonmu.sh](https://elonmu.sh/)                                                     | Get random news article featuring Elon Musk                                                                                      | No   | Yes   | Unknown |
+| [Fuck Off As A Service](https://foaas.dev/)                                         | FOAAS (Fuck Off As A Service) provides a modern, RESTful, scalable solution to the common problem of telling people to fuck off. | No   | Yes   | Unknown |
+| [Imgflip](https://imgflip.com/api)                                                  | Gets an array of popular memes                                                                                                   | No   | Yes   | Unknown |
+| [JokeAPI](https://jokeapi.dev/)                                                     | Jokes in multiple formats                                                                                                        | No   | Yes   | Yes     |
+| [Keanu Reeves Whoa](https://whoa.onrender.com/)                                     | JSON API for every "whoa" said by actor Keanu Reeves in his movies                                                               | No   | Yes   | Unknown |
+| [Meme Maker](https://mememaker.github.io/API/)                                      | REST API for create your own meme                                                                                                | No   | Yes   | Unknown |
+| [Official Joke](https://official-joke-api.appspot.com/)                             | API for random and programming jokes                                                                                             | No   | Yes   | Unknown |
+| [Puns](https://punapi.rest/)                                                        | Puns and pun based memes. REST API                                                                                               | No   | Yes   | Yes     |
+| [Random Dad Joke](https://icanhazdadjoke.com/)                                      | API for largest selection of dad jokes on the internet                                                                           | No   | Yes   | Unknown |
+| [Random Useless Facts](https://uselessfacts.jsph.pl/)                               | Get useless, but true facts                                                                                                      | No   | Yes   | Unknown |
+| [Techy](https://techy-api.vercel.app/)                                              | JSON and Plaintext API for tech-savvy sounding phrases                                                                           | No   | Yes   | Unknown |
+| [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2)                         | REST API for Yo Momma Jokes                                                                                                      | No   | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Environment
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [BreezoMeter Pollen](https://docs.breezometer.com/api-documentation/pollen-api/v2/) | Daily Forecast pollen conditions data for a specific location | `apiKey` | Yes | Unknown |
-| [Carbon Interface](https://docs.carboninterface.com/) | API to calculate carbon (C02) emissions estimates for common C02 emitting activities | `apiKey` | Yes | Yes |
-| [Climatiq](https://docs.climatiq.io) | Calculate the environmental footprint created by a broad range of emission-generating activities | `apiKey` | Yes | Yes |
-| [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API calculates the impact of common carbon-intensive activities in real time | `apiKey` | Yes | Unknown |
-| [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Yes | Unknown |
-| [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | No | Yes |
-| [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Yes | Unknown |
-| [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Yes | Unknown |
-| [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Yes | Unknown |
-| [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Yes | Unknown |
-| [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Yes | Unknown |
-| [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/) | Energy production photovoltaic (PV) energy systems | `apiKey` | Yes | Unknown |
-| [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | Yes | No |
-| [Thames Water Open Data](https://data.thameswater.co.uk) | Open Data from the UK's largest water and wastewater services company | `apiKey` | Yes | Unknown |
-| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
-| [WattBuy](https://wattbuy.readme.io/reference/getting-started-with-your-api) | Electricity usage estimations, carbon footprint estimations, and utility data | `apiKey` | Yes | Yes |
-| [Website Carbon](https://api.websitecarbon.com/) | API to estimate the carbon footprint of loading web pages | No | Yes | Unknown |
+
+| API                                                                                                    | Description                                                                                      | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [BreezoMeter Pollen](https://docs.breezometer.com/api-documentation/pollen-api/v2/)                    | Daily Forecast pollen conditions data for a specific location                                    | `apiKey` | Yes   | Unknown |
+| [Carbon Interface](https://docs.carboninterface.com/)                                                  | API to calculate carbon (C02) emissions estimates for common C02 emitting activities             | `apiKey` | Yes   | Yes     |
+| [Climatiq](https://docs.climatiq.io)                                                                   | Calculate the environmental footprint created by a broad range of emission-generating activities | `apiKey` | Yes   | Yes     |
+| [Cloverly](https://www.cloverly.com/carbon-offset-documentation)                                       | API calculates the impact of common carbon-intensive activities in real time                     | `apiKey` | Yes   | Unknown |
+| [Danish data service Energi](https://www.energidataservice.dk/)                                        | Open energy data from Energinet to society                                                       | No       | Yes   | Unknown |
+| [GrünstromIndex](https://gruenstromindex.de/)                                                          | Green Power Index for Germany (Grünstromindex/GSI)                                               | No       | No    | Yes     |
+| [IQAir](https://www.iqair.com/air-pollution-data-api)                                                  | Air quality and weather data                                                                     | `apiKey` | Yes   | Unknown |
+| [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/)                                                      | Predicted and actual air quality components for The Netherlands (RIVM)                           | No       | Yes   | Unknown |
+| [National Grid ESO](https://data.nationalgrideso.com/)                                                 | Open data from Great Britain’s Electricity System Operator                                       | No       | Yes   | Unknown |
+| [OpenAQ](https://docs.openaq.org/)                                                                     | Open air quality data                                                                            | `apiKey` | Yes   | Unknown |
+| [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis)                                              | Open low-cost PM2.5 sensor data                                                                  | No       | Yes   | Unknown |
+| [PVWatts](https://developer.nrel.gov/docs/solar/pvwatts/v6/)                                           | Energy production photovoltaic (PV) energy systems                                               | `apiKey` | Yes   | Unknown |
+| [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html)                    | Hourly usage energy report for Srp customers                                                     | `apiKey` | Yes   | No      |
+| [Thames Water Open Data](https://data.thameswater.co.uk)                                               | Open Data from the UK's largest water and wastewater services company                            | `apiKey` | Yes   | Unknown |
+| [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid                   | No       | Yes   | Unknown |
+| [WattBuy](https://wattbuy.readme.io/reference/getting-started-with-your-api)                           | Electricity usage estimations, carbon footprint estimations, and utility data                    | `apiKey` | Yes   | Yes     |
+| [Website Carbon](https://api.websitecarbon.com/)                                                       | API to estimate the carbon footprint of loading web pages                                        | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Events
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Eventbrite](https://www.eventbrite.com/platform/api/) | Find events | `OAuth`| Yes | Unknown |
-| [SeatGeek](https://platform.seatgeek.com/) | Search events, venues and performers | `apiKey` | Yes | Unknown |
-| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | Search events, attractions, or venues | `apiKey` | Yes | Unknown |
+
+| API                                                                                       | Description                           | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------------- | ------------------------------------- | -------- | ----- | ------- |
+| [Eventbrite](https://www.eventbrite.com/platform/api/)                                    | Find events                           | `OAuth`  | Yes   | Unknown |
+| [SeatGeek](https://platform.seatgeek.com/)                                                | Search events, venues and performers  | `apiKey` | Yes   | Unknown |
+| [Ticketmaster](http://developer.ticketmaster.com/products-and-docs/apis/getting-started/) | Search events, attractions, or venues | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Finance
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Abstract VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes | Yes |
-| [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes | Yes |
-| [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown |
-| [Atom Finance](https://atom.finance/) | Atom Finance provides access to market, earnings and news data | `apiKey` | Yes | Yes |
-| [Banco do Brasil](https://developers.bb.com.br) | All Banco do Brasil financial transaction APIs | `OAuth`| Yes | Yes |
-| [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown |
-| [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown |
-| [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown |
-| [Citi](https://sandbox.developerhub.citi.com/api-catalog-list) | All Citigroup account and statement data APIs | `apiKey` | Yes | Unknown |
-| [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes |
-| [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown |
-| [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown |
-| [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Yes | Unknown |
-| [Finnhub](https://finnhub.io/docs/api) | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto | `apiKey` | Yes | Unknown |
-| [FRED](https://fred.stlouisfed.org/docs/api/fred/) | Economic data from the Federal Reserve Bank of St. Louis | `apiKey` | Yes | Yes |
-| [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses | `OAuth`| Yes | Yes |
-| [IEX Cloud](https://iexcloud.io/docs/api/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes |
-| [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown |
-| [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown |
-| [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown |
-| [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/) | Klarna payment and shopping service | `apiKey` | Yes | Unknown |
-| [Kite Connect](https://kite.trade/docs/connect/v3/) | Stock market investment and trading platform | `apiKey` | Yes | No |
-| [MercadoPago](https://www.mercadopago.com.br/developers/es/reference) | Mercado Pago API reference - all the information you need to develop your integrations | `apiKey` | Yes | Unknown |
-| [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Yes | Unknown |
-| [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Yes | Unknown |
-| [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes | Yes |
-| [Plaid](https://plaid.com/) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
-| [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown |
-| [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes |
-| [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown |
-| [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown |
-| [RentCast](https://developers.rentcast.io) | Retrieve real-time property and rental data for real estate in the United States | `apiKey` | Yes | Yes |
-| [Repetiti](https://developers.repetiti.com/) | Repetiti 3d Printer Management Service | `apiKey` | Yes | Yes |
-| [SEC EDGAR Data](https://www.sec.gov/search-filings/edgar-application-programming-interfaces) | API to access annual reports of public US companies | No | Yes | Yes |
-| [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown |
-| [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes |
-| [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth`| Yes | Yes |
-| [Twelve Data](https://twelvedata.com/) | Stock market data (real-time & historical) | `apiKey` | Yes | Unknown |
-| [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/) | WallstreetBets Stock Comments Sentiment Analysis | No | Yes | Unknown |
-| [Validate Swift/BIC ](https://apyhub.com/utility/finance-validator-bic) | Validates BIC/SWIFT code. |  `apiKey` | Yes | Yes |
-| [YNAB](https://api.youneedabudget.com/) | Budgeting & Planning | `OAuth`| Yes | Yes |
-| [Zoho Books](https://www.zoho.com/books/api/v3/) | Online accounting software, built for your business | `OAuth`| Yes | Unknown |
+
+| API                                                                                           | Description                                                                                         | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Abstract VAT Validation](https://www.abstractapi.com/vat-validation-rates-api)               | Validate VAT numbers and calculate VAT rates                                                        | `apiKey` | Yes   | Yes     |
+| [Aletheia](https://aletheiaapi.com/)                                                          | Insider trading data, earnings call analysis, financial statements, and more                        | `apiKey` | Yes   | Yes     |
+| [Alpha Vantage](https://www.alphavantage.co/)                                                 | Realtime and historical stock data                                                                  | `apiKey` | Yes   | Unknown |
+| [Atom Finance](https://atom.finance/)                                                         | Atom Finance provides access to market, earnings and news data                                      | `apiKey` | Yes   | Yes     |
+| [Banco do Brasil](https://developers.bb.com.br)                                               | All Banco do Brasil financial transaction APIs                                                      | `OAuth`  | Yes   | Yes     |
+| [Billplz](https://www.billplz.com/api)                                                        | Payment platform                                                                                    | `apiKey` | Yes   | Unknown |
+| [Binlist](https://binlist.net/)                                                               | Public access to a database of IIN/BIN information                                                  | No       | Yes   | Unknown |
+| [Boleto.Cloud](https://boleto.cloud/)                                                         | A api to generate boletos in Brazil                                                                 | `apiKey` | Yes   | Unknown |
+| [Citi](https://sandbox.developerhub.citi.com/api-catalog-list)                                | All Citigroup account and statement data APIs                                                       | `apiKey` | Yes   | Unknown |
+| [Econdb](https://www.econdb.com/api/)                                                         | Global macroeconomic data                                                                           | No       | Yes   | Yes     |
+| [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/)                            | U.S. Department of the Treasury Data                                                                | No       | Yes   | Unknown |
+| [Finage](https://finage.co.uk)                                                                | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes   | Unknown |
+| [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs)              | Realtime and historical stock data                                                                  | `apiKey` | Yes   | Unknown |
+| [Finnhub](https://finnhub.io/docs/api)                                                        | Real-Time RESTful APIs and Websocket for Stocks, Currencies, and Crypto                             | `apiKey` | Yes   | Unknown |
+| [FRED](https://fred.stlouisfed.org/docs/api/fred/)                                            | Economic data from the Federal Reserve Bank of St. Louis                                            | `apiKey` | Yes   | Yes     |
+| [Front Accounting APIs](https://frontaccounting.com/fawiki/index.php?n=Devel.SimpleAPIModule) | Front accounting is multilingual and multicurrency software for small businesses                    | `OAuth`  | Yes   | Yes     |
+| [IEX Cloud](https://iexcloud.io/docs/api/)                                                    | Realtime & Historical Stock and Market Data                                                         | `apiKey` | Yes   | Yes     |
+| [IG](https://labs.ig.com/gettingstarted)                                                      | Spreadbetting and CFD Market Data                                                                   | `apiKey` | Yes   | Unknown |
+| [Indian Mutual Fund](https://www.mfapi.in/)                                                   | Get complete history of India Mutual Funds Data                                                     | No       | Yes   | Unknown |
+| [Intrinio](https://intrinio.com/)                                                             | A wide selection of financial data feeds                                                            | `apiKey` | Yes   | Unknown |
+| [Klarna](https://docs.klarna.com/klarna-payments/api/payments-api/)                           | Klarna payment and shopping service                                                                 | `apiKey` | Yes   | Unknown |
+| [Kite Connect](https://kite.trade/docs/connect/v3/)                                           | Stock market investment and trading platform                                                        | `apiKey` | Yes   | No      |
+| [MercadoPago](https://www.mercadopago.com.br/developers/es/reference)                         | Mercado Pago API reference - all the information you need to develop your integrations              | `apiKey` | Yes   | Unknown |
+| [Mono](https://mono.co/)                                                                      | Connect with users’ bank accounts and access transaction data in Africa                             | `apiKey` | Yes   | Unknown |
+| [Moov](https://docs.moov.io/api/)                                                             | The Moov API makes it simple for platforms to send, receive, and store money                        | `apiKey` | Yes   | Unknown |
+| [OpenFIGI](https://www.openfigi.com/api)                                                      | Equity, index, futures, options symbology from Bloomberg LP                                         | `apiKey` | Yes   | Yes     |
+| [Plaid](https://plaid.com/)                                                                   | Connect with user's bank accounts and access transaction data                                       | `apiKey` | Yes   | Unknown |
+| [Polygon](https://polygon.io/)                                                                | Historical stock market data                                                                        | `apiKey` | Yes   | Unknown |
+| [Portfolio Optimizer](https://portfoliooptimizer.io/)                                         | Portfolio analysis and optimization                                                                 | No       | Yes   | Yes     |
+| [Razorpay IFSC](https://razorpay.com/docs/)                                                   | Indian Financial Systems Code (Bank Branch Codes)                                                   | No       | Yes   | Unknown |
+| [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/)              | Websocket API to access realtime stock data                                                         | `apiKey` | No    | Unknown |
+| [RentCast](https://developers.rentcast.io)                                                    | Retrieve real-time property and rental data for real estate in the United States                    | `apiKey` | Yes   | Yes     |
+| [Repetiti](https://developers.repetiti.com/)                                                  | Repetiti 3d Printer Management Service                                                              | `apiKey` | Yes   | Yes     |
+| [SEC EDGAR Data](https://www.sec.gov/search-filings/edgar-application-programming-interfaces) | API to access annual reports of public US companies                                                 | No       | Yes   | Yes     |
+| [SmartAPI](https://smartapi.angelbroking.com/)                                                | Gain access to set of <SmartAPI> and create end-to-end broking services                             | `apiKey` | Yes   | Unknown |
+| [StockData](https://www.StockData.org)                                                        | Real-Time, Intraday & Historical Market Data, News and Sentiment API                                | `apiKey` | Yes   | Yes     |
+| [Tradier](https://developer.tradier.com)                                                      | US equity/option market data (delayed, intraday, historical)                                        | `OAuth`  | Yes   | Yes     |
+| [Twelve Data](https://twelvedata.com/)                                                        | Stock market data (real-time & historical)                                                          | `apiKey` | Yes   | Unknown |
+| [WallstreetBets](https://dashboard.nbshare.io/apps/reddit/api/)                               | WallstreetBets Stock Comments Sentiment Analysis                                                    | No       | Yes   | Unknown |
+| [Validate Swift/BIC ](https://apyhub.com/utility/finance-validator-bic)                       | Validates BIC/SWIFT code.                                                                           | `apiKey` | Yes   | Yes     |
+| [YNAB](https://api.youneedabudget.com/)                                                       | Budgeting & Planning                                                                                | `OAuth`  | Yes   | Yes     |
+| [Zoho Books](https://www.zoho.com/books/api/v3/)                                              | Online accounting software, built for your business                                                 | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Food & Drink
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [BaconMockup](https://baconmockup.com/) | Resizable bacon placeholder images | No | Yes | Yes |
-| [Chomp](https://chompthis.com/api/) | Data about various grocery products and foods | `apiKey` | Yes | Unknown |
-| [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
-| [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |
-| [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | Recipe Search | `apiKey` | Yes | Unknown |
-| [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
-| [Fruityvice](https://www.fruityvice.com) | Data about all kinds of fruit | No | Yes | Unknown |
-| [Jelly Belly Wiki](https://jelly-belly-wiki.netlify.app/) | Data about Jelly Belly beans- flavores, facts, history and more endpoints | No | Yes | Yes |
-| [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |
-| [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
-| [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
-| [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
-| [Spoonacular](https://spoonacular.com/food-api) | Recipes, Food Products, and Meal Planning | `apiKey` | Yes | Unknown |
-| [Status Pizza](https://status.pizza) | Pizza for every HTTP Status | No | Yes | Unknown |
-| [TacoFancy](https://github.com/evz/tacofancy-api) | Community-driven taco database | No | No | Unknown |
-| [Tasty](https://rapidapi.com/apidojo/api/tasty/) | API to query data about recipe, plan, ingredients | `apiKey` | Yes | Unknown |
-| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews | No | Yes | Unknown |
-| [TheCocktailDB](https://www.thecocktaildb.com/api.php) | Cocktail Recipes | `apiKey` | Yes | Yes |
-| [TheMealDB](https://www.themealdb.com/api.php) | Meal Recipes | `apiKey` | Yes | Yes |
-| [Untappd](https://untappd.com/api/docs) | Social beer sharing | `OAuth`| Yes | Unknown |
-| [What's on the menu?](http://nypl.github.io/menus-api/) | NYPL human-transcribed historical menu collection | `apiKey` | No | Unknown |
-| [WhiskyHunter](https://whiskyhunter.net/api/) | Past online whisky auctions statistical data | No | Yes | Unknown |
-| [Zestful](https://zestfuldata.com/) | Parse recipe ingredients | `apiKey` | Yes | Yes |
+
+| API                                                                              | Description                                                               | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [BaconMockup](https://baconmockup.com/)                                          | Resizable bacon placeholder images                                        | No       | Yes   | Yes     |
+| [Chomp](https://chompthis.com/api/)                                              | Data about various grocery products and foods                             | `apiKey` | Yes   | Unknown |
+| [Coffee](https://coffee.alexflipnote.dev/)                                       | Random pictures of coffee                                                 | No       | Yes   | Unknown |
+| [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api)       | Nutrition Analysis                                                        | `apiKey` | Yes   | Unknown |
+| [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api)            | Recipe Search                                                             | `apiKey` | Yes   | Unknown |
+| [Foodish](https://github.com/surhud004/Foodish#readme)                           | Random pictures of food dishes                                            | No       | Yes   | Yes     |
+| [Fruityvice](https://www.fruityvice.com)                                         | Data about all kinds of fruit                                             | No       | Yes   | Unknown |
+| [Jelly Belly Wiki](https://jelly-belly-wiki.netlify.app/)                        | Data about Jelly Belly beans- flavores, facts, history and more endpoints | No       | Yes   | Yes     |
+| [Kroger](https://developer.kroger.com/reference)                                 | Supermarket Data                                                          | `apiKey` | Yes   | Unknown |
+| [LCBO](https://lcboapi.com/)                                                     | Alcohol                                                                   | `apiKey` | Yes   | Unknown |
+| [Open Brewery DB](https://www.openbrewerydb.org)                                 | Breweries, Cideries and Craft Beer Bottle Shops                           | No       | Yes   | Yes     |
+| [Open Food Facts](https://world.openfoodfacts.org/data)                          | Food Products Database                                                    | No       | Yes   | Unknown |
+| [Spoonacular](https://spoonacular.com/food-api)                                  | Recipes, Food Products, and Meal Planning                                 | `apiKey` | Yes   | Unknown |
+| [Status Pizza](https://status.pizza)                                             | Pizza for every HTTP Status                                               | No       | Yes   | Unknown |
+| [TacoFancy](https://github.com/evz/tacofancy-api)                                | Community-driven taco database                                            | No       | No    | Unknown |
+| [Tasty](https://rapidapi.com/apidojo/api/tasty/)                                 | API to query data about recipe, plan, ingredients                         | `apiKey` | Yes   | Unknown |
+| [The Report of the Week](https://github.com/andyklimczak/TheReportOfTheWeek-API) | Food & Drink Reviews                                                      | No       | Yes   | Unknown |
+| [TheCocktailDB](https://www.thecocktaildb.com/api.php)                           | Cocktail Recipes                                                          | `apiKey` | Yes   | Yes     |
+| [TheMealDB](https://www.themealdb.com/api.php)                                   | Meal Recipes                                                              | `apiKey` | Yes   | Yes     |
+| [Untappd](https://untappd.com/api/docs)                                          | Social beer sharing                                                       | `OAuth`  | Yes   | Unknown |
+| [What's on the menu?](http://nypl.github.io/menus-api/)                          | NYPL human-transcribed historical menu collection                         | `apiKey` | No    | Unknown |
+| [WhiskyHunter](https://whiskyhunter.net/api/)                                    | Past online whisky auctions statistical data                              | No       | Yes   | Unknown |
+| [Zestful](https://zestfuldata.com/)                                              | Parse recipe ingredients                                                  | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Games & Comics
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AmiiboAPI](https://amiiboapi.com/) | Nintendo Amiibo Information | No | Yes | Yes |
-| [Animal Crossing: New Horizons](http://acnhapi.com/) | API for critters, fossils, art, music, furniture and villagers | No | Yes | Unknown |
-| [Atlas Academy](https://api.atlasacademy.io/docs) | API for Fate/Grand Order game data | No | Yes | Unknown |
-| [Autochess VNG](https://github.com/didadadida93/autochess-vng-api) | Rest Api for Autochess VNG | No | Yes | Yes |
-| [Barter.VG](https://github.com/bartervg/barter.vg/wiki) | Provides information about Game, DLC, Bundles, Giveaways, Trading | No | Yes | Yes |
-| [Battle.net](https://develop.battle.net/documentation/guides/getting-started) | Diablo III, Hearthstone, StarCraft II and World of Warcraft game data APIs | `OAuth` | Yes | Yes |
-| [Blue Archive](https://github.com/arufars/api-blue-archive) | Provides Blue Archive characters information | No | Yes | Yes |
-| [Board Game Geek](https://boardgamegeek.com/wiki/page/BGG_XML_API2) | Board games, RPG and videogames | No | Yes | No |
-| [Brawl Stars](https://developer.brawlstars.com) | Brawl Stars Game Information | `apiKey`| Yes | Unknown |
-| [Call of Duty](https://codapi.dev/) | Unofficial wrapper for the Call of Duty API with multi-language support. | No | Yes | Unknown |
-| [CheapShark](https://www.cheapshark.com/api) | Steam/PC Game Prices and Deals | No | Yes | Yes |
-| [Chess.com](https://www.chess.com/news/view/published-data-api) | Chess.com read-only REST API | No | Yes | Unknown |
-| [Clash of Clans](https://developer.clashofclans.com) | Clash of Clans Game Information | `apiKey`| Yes | Unknown |
-| [Clash Royale](https://developer.clashroyale.com) | Clash Royale Game Information | `apiKey`| Yes | Unknown |
-| [Comic Vine](https://comicvine.gamespot.com/api/documentation) | Comics | No | Yes | Unknown |
-| [Crafatar](https://crafatar.com) | API for Minecraft skins and faces | No | Yes | Yes |
-| [Cross Universe](https://crossuniverse.psychpsyo.com/apiDocs.html) | Cross Universe Card Data | No | Yes | Yes |
-| [CSGO](https://bymykel.github.io/CSGO-API/) | An unofficial JSON API for Counter-Strike: Global Offensive | No | Yes | No |
-| [Deck of Cards](https://deckofcardsapi.com/) | Deck of Cards | No | Yes | Unknown |
-| [Destiny The Game](https://bungie-net.github.io/multi/index.html) | Bungie Platform API | `apiKey`| Yes | Unknown |
-| [Digimon Information](https://digimon-api.vercel.app/) | Provides information about digimon creatures | No | Yes | Unknown |
-| [Digimon TCG](https://documenter.getpostman.com/view/14059948/TzecB4fH) | Search for Digimon cards in digimoncard.io | No | Yes | Unknown |
-| [Disney](https://disneyapi.dev) | Information of Disney characters | No | Yes | Yes |
-| [Dota 2](https://docs.opendota.com/) | Provides information about Player stats, Match stats, Rankings for Dota 2| `apiKey`| Yes | Unknown |
-| [Dungeons and Dragons](https://www.dnd5eapi.co/docs/) | Reference for 5th edition spells, classes, monsters, and more | No | Yes | No |
-| [Dungeons and Dragons (Alternate)](https://open5e.com/) | Includes all monsters and spells from the SRD (System Reference Document) as well as a search API | No | Yes | Yes |
-| [Eve Online](https://esi.evetech.net/ui) | Third-Party Developer Documentation | `OAuth` | Yes | Unknown |
-| [FFXIV Collect](https://ffxivcollect.com/) | Final Fantasy XIV data on collectables | No | Yes | Yes |
-| [Final Fantasy XIV](https://xivapi.com/) | Final Fantasy XIV Game data API | No | Yes | Yes |
-| [FreeToGame](https://www.freetogame.com/api-doc) | Free-To-Play Games Database | No | Yes | Yes |
-| [FunTranslations](https://api.funtranslations.com/) | Translate Text into funny languages | No | Yes | Yes |
-| [GamerPower](https://www.gamerpower.com/api-read) | Game Giveaways Tracker | No | Yes | Yes |
-| [Geek-Jokes](https://github.com/sameerkumar18/geek-joke-api) | Fetch a random geeky/programming related joke for use in all sorts of applications | No | Yes | Yes |
-| [Genshin Impact](https://genshin.dev) | Genshin Impact game data | No | Yes | Yes |
-| [Giant Bomb](https://www.giantbomb.com/api/documentation) | Video Games | `apiKey`| Yes | Unknown |
-| [GraphQL Pokemon](https://github.com/favware/graphql-pokemon) | GraphQL powered Pokemon API. Supports generations 1 through 8 | No | Yes | Yes |
-| [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | Guild Wars 2 Game Information | `apiKey`| Yes | Unknown |
-| [GW2Spidy](https://github.com/rubensayshi/gw2spidy/wiki) | GW2Spidy API, Items data on the Guild Wars 2 Trade Market | No | Yes | Unknown |
-| [Halo](https://developer.haloapi.com/) | Halo 5 and Halo Wars 2 Information | `apiKey`| Yes | Unknown |
-| [Hearthstone](http://hearthstoneapi.com/) | Hearthstone Cards Information | `X-Mashape-Key` | Yes | Unknown |
-| [Humble Bundle](https://rapidapi.com/Ziggoto/api/humble-bundle) | Humble Bundle's current bundles | `apiKey`| Yes | Unknown |
-| [Humor](https://humorapi.com) | Humor, Jokes, and Memes | `apiKey`| Yes | Unknown |
-| [Hypixel](https://api.hypixel.net/) | Hypixel player stats | `apiKey`| Yes | Unknown |
-| [Hyrule Compendium](https://github.com/gadhagod/Hyrule-Compendium-API) | Data on all interactive items from The Legend of Zelda: BOTW | No | Yes | Unknown |
-| [IGDB.com](https://api-docs.igdb.com) | Video Game Database | `apiKey`| Yes | Unknown |
-| [Italian Jokes](https://italian-jokes.vercel.app/) | JSON API for getting jokes about Italians | No | Yes | Unknown |
-| [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes | Yes |
-| [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey`| Yes | Yes |
-| [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
-| [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
-| [Marvel](https://developer.marvel.com) | Marvel Comics | `apiKey`| Yes | Unknown |
-| [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |
-| [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |
-| [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey`| Yes | Unknown |
-| [Mojang](https://wiki.vg/Mojang_API) | Mojang / Minecraft API | `apiKey`| Yes | Unknown |
-| [Monster Hunter World](https://docs.mhw-db.com/) | Monster Hunter World data | No | Yes | Yes |
-| [moogleAPI](https://www.moogleapi.com/) | Final Fantasy franchise data | No | Yes | Unknown |
-| [Open Trivia](https://opentdb.com/api_config.php) | Trivia Questions | No | Yes | Unknown |
-| [PandaScore](https://developers.pandascore.co/) | E-sports games and results | `apiKey`| Yes | Unknown |
-| [Path of Exile](https://www.pathofexile.com/developer/docs) | Path of Exile Game Information | `OAuth` | Yes | Unknown |
-| [PlayerDB](https://playerdb.co/) | Query Minecraft, Steam and XBox Accounts | No | Yes | Unknown |
-| [Pokéapi](https://pokeapi.co) | Pokémon Information | No | Yes | Unknown |
-| [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi) | The Unofficial GraphQL for PokeAPI | No | Yes | Yes |
-| [Pokémon TCG](https://pokemontcg.io) | Pokémon TCG Information | No | Yes | Unknown |
-| [Psychonauts](https://psychonauts-api.netlify.app/) | Psychonauts World Characters Information and PSI Powers | No | Yes | Yes |
-| [PUBG](https://developer.pubg.com/) | Access in-game PUBG data | `apiKey`| Yes | Yes |
-| [Puyo Nexus](https://github.com/deltadex7/puyodb-api-deno) | Puyo Puyo information from Puyo Nexus Wiki | No | Yes | Yes |
-| [quizapi.io](https://quizapi.io/) | Access to various kind of quiz questions | `apiKey`| Yes | Yes |
-| [Raider](https://raider.io/api) | Provides detailed character and guild rankings for Raiding and Mythic+ content in World of Warcraft | No | Yes | Unknown |
-| [RAWG.io](https://rawg.io/apidocs) | 500,000+ games for 50 platforms including mobiles | `apiKey`| Yes | Unknown |
-| [Rick and Morty](https://rickandmortyapi.com) | All the Rick and Morty information, including images | No | Yes | Yes |
-| [Riot Games](https://developer.riotgames.com/) | League of Legends, Teamfight Tactics, Legends of Runetera and Valorant information | `apiKey`| Yes | Unknown |
-| [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
-| [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
-| [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
-| [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
-| [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey`| Yes | No |
-| [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |
-| [TCGdex](https://www.tcgdex.net/docs) | Multi languages Pokémon TCG Information | No | Yes | Yes |
-| [Tebex](https://docs.tebex.io/plugin/) | Tebex API for information about game purchases | `X-Mashape-Key` | Yes | No |
-| [TETR.IO](https://tetr.io/about/api/) | TETR.IO Tetra Channel API | No | Yes | Unknown |
-| [Tronald Dump](https://www.tronalddump.io/) | The dumbest things Donald Trump has ever said | No | Yes | Unknown |
-| [Universalis](https://universalis.app/docs/index.html) | Final Fantasy XIV market board data | No | Yes | Yes |
-| [Valorant (non-official)](https://valorant-api.com) | An extensive API containing data of most Valorant in-game items, assets and more | No | Yes | Unknown |
-| [Warface (non-official)](https://api.wfstats.cf) | Official API proxy with better data structure and more features | No | Yes | No |
-| [Wargaming.net](https://developers.wargaming.net/) | Wargaming.net info and stats | `apiKey`| Yes | No |
-| [When is next MCU film](https://github.com/DiljotSG/MCU-Countdown/blob/develop/docs/API.md) | Upcoming MCU film information | No | Yes | Unknown |
-| [xkcd](https://xkcd.com/json.html) | Retrieve xkcd comics as JSON | No | Yes | No |
-| [Yu-Gi-Oh!](https://db.ygoprodeck.com/api-guide/) | Yu-Gi-Oh! TCG Information | No | Yes | Unknown |
-| [Zelda](https://docs.zelda.fanapis.com/docs) | The Legend of Zelda franchise data | No | Yes | Unknown |
+
+| API                                                                                         | Description                                                                                         | Auth            | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [AmiiboAPI](https://amiiboapi.com/)                                                         | Nintendo Amiibo Information                                                                         | No              | Yes   | Yes     |
+| [Animal Crossing: New Horizons](http://acnhapi.com/)                                        | API for critters, fossils, art, music, furniture and villagers                                      | No              | Yes   | Unknown |
+| [Atlas Academy](https://api.atlasacademy.io/docs)                                           | API for Fate/Grand Order game data                                                                  | No              | Yes   | Unknown |
+| [Autochess VNG](https://github.com/didadadida93/autochess-vng-api)                          | Rest Api for Autochess VNG                                                                          | No              | Yes   | Yes     |
+| [Barter.VG](https://github.com/bartervg/barter.vg/wiki)                                     | Provides information about Game, DLC, Bundles, Giveaways, Trading                                   | No              | Yes   | Yes     |
+| [Battle.net](https://develop.battle.net/documentation/guides/getting-started)               | Diablo III, Hearthstone, StarCraft II and World of Warcraft game data APIs                          | `OAuth`         | Yes   | Yes     |
+| [Blue Archive](https://github.com/arufars/api-blue-archive)                                 | Provides Blue Archive characters information                                                        | No              | Yes   | Yes     |
+| [Board Game Geek](https://boardgamegeek.com/wiki/page/BGG_XML_API2)                         | Board games, RPG and videogames                                                                     | No              | Yes   | No      |
+| [Brawl Stars](https://developer.brawlstars.com)                                             | Brawl Stars Game Information                                                                        | `apiKey`        | Yes   | Unknown |
+| [Call of Duty](https://codapi.dev/)                                                         | Unofficial wrapper for the Call of Duty API with multi-language support.                            | No              | Yes   | Unknown |
+| [CheapShark](https://www.cheapshark.com/api)                                                | Steam/PC Game Prices and Deals                                                                      | No              | Yes   | Yes     |
+| [Chess.com](https://www.chess.com/news/view/published-data-api)                             | Chess.com read-only REST API                                                                        | No              | Yes   | Unknown |
+| [Clash of Clans](https://developer.clashofclans.com)                                        | Clash of Clans Game Information                                                                     | `apiKey`        | Yes   | Unknown |
+| [Clash Royale](https://developer.clashroyale.com)                                           | Clash Royale Game Information                                                                       | `apiKey`        | Yes   | Unknown |
+| [Comic Vine](https://comicvine.gamespot.com/api/documentation)                              | Comics                                                                                              | No              | Yes   | Unknown |
+| [Crafatar](https://crafatar.com)                                                            | API for Minecraft skins and faces                                                                   | No              | Yes   | Yes     |
+| [Cross Universe](https://crossuniverse.psychpsyo.com/apiDocs.html)                          | Cross Universe Card Data                                                                            | No              | Yes   | Yes     |
+| [CSGO](https://bymykel.github.io/CSGO-API/)                                                 | An unofficial JSON API for Counter-Strike: Global Offensive                                         | No              | Yes   | No      |
+| [Deck of Cards](https://deckofcardsapi.com/)                                                | Deck of Cards                                                                                       | No              | Yes   | Unknown |
+| [Destiny The Game](https://bungie-net.github.io/multi/index.html)                           | Bungie Platform API                                                                                 | `apiKey`        | Yes   | Unknown |
+| [Digimon Information](https://digimon-api.vercel.app/)                                      | Provides information about digimon creatures                                                        | No              | Yes   | Unknown |
+| [Digimon TCG](https://documenter.getpostman.com/view/14059948/TzecB4fH)                     | Search for Digimon cards in digimoncard.io                                                          | No              | Yes   | Unknown |
+| [Disney](https://disneyapi.dev)                                                             | Information of Disney characters                                                                    | No              | Yes   | Yes     |
+| [Dota 2](https://docs.opendota.com/)                                                        | Provides information about Player stats, Match stats, Rankings for Dota 2                           | `apiKey`        | Yes   | Unknown |
+| [Dungeons and Dragons](https://www.dnd5eapi.co/docs/)                                       | Reference for 5th edition spells, classes, monsters, and more                                       | No              | Yes   | No      |
+| [Dungeons and Dragons (Alternate)](https://open5e.com/)                                     | Includes all monsters and spells from the SRD (System Reference Document) as well as a search API   | No              | Yes   | Yes     |
+| [Eve Online](https://esi.evetech.net/ui)                                                    | Third-Party Developer Documentation                                                                 | `OAuth`         | Yes   | Unknown |
+| [FFXIV Collect](https://ffxivcollect.com/)                                                  | Final Fantasy XIV data on collectables                                                              | No              | Yes   | Yes     |
+| [Final Fantasy XIV](https://xivapi.com/)                                                    | Final Fantasy XIV Game data API                                                                     | No              | Yes   | Yes     |
+| [FreeToGame](https://www.freetogame.com/api-doc)                                            | Free-To-Play Games Database                                                                         | No              | Yes   | Yes     |
+| [FunTranslations](https://api.funtranslations.com/)                                         | Translate Text into funny languages                                                                 | No              | Yes   | Yes     |
+| [GamerPower](https://www.gamerpower.com/api-read)                                           | Game Giveaways Tracker                                                                              | No              | Yes   | Yes     |
+| [Geek-Jokes](https://github.com/sameerkumar18/geek-joke-api)                                | Fetch a random geeky/programming related joke for use in all sorts of applications                  | No              | Yes   | Yes     |
+| [Genshin Impact](https://genshin.dev)                                                       | Genshin Impact game data                                                                            | No              | Yes   | Yes     |
+| [Giant Bomb](https://www.giantbomb.com/api/documentation)                                   | Video Games                                                                                         | `apiKey`        | Yes   | Unknown |
+| [GraphQL Pokemon](https://github.com/favware/graphql-pokemon)                               | GraphQL powered Pokemon API. Supports generations 1 through 8                                       | No              | Yes   | Yes     |
+| [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main)                                   | Guild Wars 2 Game Information                                                                       | `apiKey`        | Yes   | Unknown |
+| [GW2Spidy](https://github.com/rubensayshi/gw2spidy/wiki)                                    | GW2Spidy API, Items data on the Guild Wars 2 Trade Market                                           | No              | Yes   | Unknown |
+| [Halo](https://developer.haloapi.com/)                                                      | Halo 5 and Halo Wars 2 Information                                                                  | `apiKey`        | Yes   | Unknown |
+| [Hearthstone](http://hearthstoneapi.com/)                                                   | Hearthstone Cards Information                                                                       | `X-Mashape-Key` | Yes   | Unknown |
+| [Humble Bundle](https://rapidapi.com/Ziggoto/api/humble-bundle)                             | Humble Bundle's current bundles                                                                     | `apiKey`        | Yes   | Unknown |
+| [Humor](https://humorapi.com)                                                               | Humor, Jokes, and Memes                                                                             | `apiKey`        | Yes   | Unknown |
+| [Hypixel](https://api.hypixel.net/)                                                         | Hypixel player stats                                                                                | `apiKey`        | Yes   | Unknown |
+| [Hyrule Compendium](https://github.com/gadhagod/Hyrule-Compendium-API)                      | Data on all interactive items from The Legend of Zelda: BOTW                                        | No              | Yes   | Unknown |
+| [IGDB.com](https://api-docs.igdb.com)                                                       | Video Game Database                                                                                 | `apiKey`        | Yes   | Unknown |
+| [Italian Jokes](https://italian-jokes.vercel.app/)                                          | JSON API for getting jokes about Italians                                                           | No              | Yes   | Unknown |
+| [JokeAPI](https://sv443.net/jokeapi/v2/)                                                    | Programming, Miscellaneous and Dark Jokes                                                           | No              | Yes   | Yes     |
+| [Jokes One](https://jokes.one/api/joke/)                                                    | Joke of the day and large category of jokes accessible via REST API                                 | `apiKey`        | Yes   | Yes     |
+| [Lichess](https://lichess.org/api)                                                          | Access to all data of users, games, puzzles and etc on Lichess                                      | `OAuth`         | Yes   | Unknown |
+| [Magic The Gathering](http://magicthegathering.io/)                                         | Magic The Gathering Game Information                                                                | No              | No    | Unknown |
+| [Marvel](https://developer.marvel.com)                                                      | Marvel Comics                                                                                       | `apiKey`        | Yes   | Unknown |
+| [Minecraft Server Status](https://api.mcsrvstat.us)                                         | API to get Information about a Minecraft Server                                                     | No              | Yes   | No      |
+| [MMO Games](https://www.mmobomb.com/api)                                                    | MMO Games Database, News and Giveaways                                                              | No              | Yes   | No      |
+| [mod.io](https://docs.mod.io)                                                               | Cross Platform Mod API                                                                              | `apiKey`        | Yes   | Unknown |
+| [Mojang](https://wiki.vg/Mojang_API)                                                        | Mojang / Minecraft API                                                                              | `apiKey`        | Yes   | Unknown |
+| [Monster Hunter World](https://docs.mhw-db.com/)                                            | Monster Hunter World data                                                                           | No              | Yes   | Yes     |
+| [moogleAPI](https://www.moogleapi.com/)                                                     | Final Fantasy franchise data                                                                        | No              | Yes   | Unknown |
+| [Open Trivia](https://opentdb.com/api_config.php)                                           | Trivia Questions                                                                                    | No              | Yes   | Unknown |
+| [PandaScore](https://developers.pandascore.co/)                                             | E-sports games and results                                                                          | `apiKey`        | Yes   | Unknown |
+| [Path of Exile](https://www.pathofexile.com/developer/docs)                                 | Path of Exile Game Information                                                                      | `OAuth`         | Yes   | Unknown |
+| [PlayerDB](https://playerdb.co/)                                                            | Query Minecraft, Steam and XBox Accounts                                                            | No              | Yes   | Unknown |
+| [Pokéapi](https://pokeapi.co)                                                               | Pokémon Information                                                                                 | No              | Yes   | Unknown |
+| [PokéAPI (GraphQL)](https://github.com/mazipan/graphql-pokeapi)                             | The Unofficial GraphQL for PokeAPI                                                                  | No              | Yes   | Yes     |
+| [Pokémon TCG](https://pokemontcg.io)                                                        | Pokémon TCG Information                                                                             | No              | Yes   | Unknown |
+| [Psychonauts](https://psychonauts-api.netlify.app/)                                         | Psychonauts World Characters Information and PSI Powers                                             | No              | Yes   | Yes     |
+| [PUBG](https://developer.pubg.com/)                                                         | Access in-game PUBG data                                                                            | `apiKey`        | Yes   | Yes     |
+| [Puyo Nexus](https://github.com/deltadex7/puyodb-api-deno)                                  | Puyo Puyo information from Puyo Nexus Wiki                                                          | No              | Yes   | Yes     |
+| [quizapi.io](https://quizapi.io/)                                                           | Access to various kind of quiz questions                                                            | `apiKey`        | Yes   | Yes     |
+| [Raider](https://raider.io/api)                                                             | Provides detailed character and guild rankings for Raiding and Mythic+ content in World of Warcraft | No              | Yes   | Unknown |
+| [RAWG.io](https://rawg.io/apidocs)                                                          | 500,000+ games for 50 platforms including mobiles                                                   | `apiKey`        | Yes   | Unknown |
+| [Rick and Morty](https://rickandmortyapi.com)                                               | All the Rick and Morty information, including images                                                | No              | Yes   | Yes     |
+| [Riot Games](https://developer.riotgames.com/)                                              | League of Legends, Teamfight Tactics, Legends of Runetera and Valorant information                  | `apiKey`        | Yes   | Unknown |
+| [RuneScape](https://runescape.wiki/w/Application_programming_interface)                     | RuneScape and OSRS RPGs information                                                                 | No              | Yes   | No      |
+| [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api)                      | Sakura CardCaptor Cards Information                                                                 | No              | Yes   | Unknown |
+| [Scryfall](https://scryfall.com/docs/api)                                                   | Magic: The Gathering database                                                                       | No              | Yes   | Yes     |
+| [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis)                                     | A playable inter-galactic space trading MMOAPI                                                      | `OAuth`         | Yes   | Yes     |
+| [Steam](https://steamapi.xpaw.me/)                                                          | Steam Web API documentation                                                                         | `apiKey`        | Yes   | No      |
+| [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki)                               | Internal Steam Web API documentation                                                                | No              | Yes   | No      |
+| [TCGdex](https://www.tcgdex.net/docs)                                                       | Multi languages Pokémon TCG Information                                                             | No              | Yes   | Yes     |
+| [Tebex](https://docs.tebex.io/plugin/)                                                      | Tebex API for information about game purchases                                                      | `X-Mashape-Key` | Yes   | No      |
+| [TETR.IO](https://tetr.io/about/api/)                                                       | TETR.IO Tetra Channel API                                                                           | No              | Yes   | Unknown |
+| [Tronald Dump](https://www.tronalddump.io/)                                                 | The dumbest things Donald Trump has ever said                                                       | No              | Yes   | Unknown |
+| [Universalis](https://universalis.app/docs/index.html)                                      | Final Fantasy XIV market board data                                                                 | No              | Yes   | Yes     |
+| [Valorant (non-official)](https://valorant-api.com)                                         | An extensive API containing data of most Valorant in-game items, assets and more                    | No              | Yes   | Unknown |
+| [Warface (non-official)](https://api.wfstats.cf)                                            | Official API proxy with better data structure and more features                                     | No              | Yes   | No      |
+| [Wargaming.net](https://developers.wargaming.net/)                                          | Wargaming.net info and stats                                                                        | `apiKey`        | Yes   | No      |
+| [When is next MCU film](https://github.com/DiljotSG/MCU-Countdown/blob/develop/docs/API.md) | Upcoming MCU film information                                                                       | No              | Yes   | Unknown |
+| [xkcd](https://xkcd.com/json.html)                                                          | Retrieve xkcd comics as JSON                                                                        | No              | Yes   | No      |
+| [Yu-Gi-Oh!](https://db.ygoprodeck.com/api-guide/)                                           | Yu-Gi-Oh! TCG Information                                                                           | No              | Yes   | Unknown |
+| [Zelda](https://docs.zelda.fanapis.com/docs)                                                | The Legend of Zelda franchise data                                                                  | No              | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Geocoding
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Abstract IP Geolocation](https://www.abstractapi.com/ip-geolocation-api) | Geolocate website visitors from their IPs | `apiKey` | Yes | Yes |
-| [Actinia Grass GIS](https://actinia.mundialis.de/api_docs/) | Actinia is an open source REST API for geographical data that uses GRASS GIS | `apiKey` | Yes | Unknown |
-| [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db) | Get all administrative divisions of a country | No | Yes | Yes |
-| [adresse.data.gouv.fr](https://adresse.data.gouv.fr) | Address database of France, geocoding and reverse | No | Yes | Unknown |
-| [Apiip](https://apiip.net/) | Get location information by IP address | `apiKey` | Yes | Yes |
-| [Battuta](http://battuta.medunes.net) | A (country/region/city) in-cascade location API | `apiKey` | No | Unknown |
-| [BigDataCloud's IP Geolocation API](https://www.bigdatacloud.com/ip-geolocation) | Provides fast and accurate IP geolocation APIs along with security checks and confidence area. | `apiKey` | Yes | Yes |
-| [BigDataCloud's Reverse Geocoding API](https://www.bigdatacloud.com/reverse-geocoding) | Get rich locality information from the geographical coordinates. | `apiKey` | Yes | Yes |
-| [BigDataCloud's Phone and Email Verification API](https://www.bigdatacloud.com/phone-email-verification) | Syntax and Format Validation of Phone Number and Email address. | `apiKey` | Yes | Yes |
-| [BigDataCloud's Network Engineering API](https://www.bigdatacloud.com/network-engineering) | Get detailed ASN and Network lookup of an IP address. | `apiKey` | Yes | Yes |
-| [BigDataCloud's Free API](https://www.bigdatacloud.com//free-api) | Get free client-side reverse geocoding API and Client Info API. No account creation and API key required.| No | Yes | Yes |    
-| [Bing Maps](https://www.microsoft.com/maps/) | Create/customize digital maps based on Bing Maps data | `apiKey` | Yes | Unknown |
-| [bng2latlong](https://www.getthedata.com/bng2latlong) | Convert British OSGB36 easting and northing (British National Grid) to WGS84 latitude and longitude | No | Yes | Yes |
-| [Cartes.io](https://github.com/M-Media-Group/Cartes.io/wiki/API) | Create maps and markers for anything | No | Yes | Unknown |
-| [Cep.la](http://cep.la/) | Brazil RESTful API to find information about streets, zip codes, neighborhoods, cities and states | No | No | Unknown |
-| [CitySDK](http://www.citysdk.eu/citysdk-toolkit/) | Open APIs for select European cities | No | Yes | Unknown |
-| [Country](http://country.is/) | Get your visitor's country from their IP | No | Yes | Yes |
-| [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
-| [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
-| [FreeGeoIP](https://freegeoip.app/) | Free geo ip information, no registration required. 15k/hour rate limit | No | Yes | Yes |
-| [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
-| [Geoapify](https://www.geoapify.com/api/geocoding-api/) | Forward and reverse geocoding, address autocomplete | `apiKey` | Yes | Yes |
-| [Geocod.io](https://www.geocod.io/) | Address geocoding / reverse geocoding in bulk | `apiKey` | Yes | Unknown |
-| [Geocode.xyz](https://geocode.xyz/api) | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing | No | Yes | Unknown |
-| [Geocodify.com](https://geocodify.com/) | Worldwide geocoding, geoparsing and autocomplete for addresses | `apiKey` | Yes | Yes |
-| [Geodata.gov.gr](https://geodata.gov.gr/en/) | Open geospatial data and API service for Greece | No | Yes | Unknown |
-| [GeoDataSource](https://www.geodatasource.com/web-service) | Geocoding of city name by using latitude and longitude coordinates | `apiKey` | Yes | Unknown |
-| [GeoDB Cities](http://geodb-cities-api.wirefreethought.com/) | Get global city, region, and country data | `apiKey` | Yes | Unknown |
-| [GeographQL](https://geographql.netlify.app) | A Country, State, and City GraphQL API | No | Yes | Yes |
-| [GeoJS](https://www.geojs.io/) | IP geolocation with ChatOps integration | No | Yes | Yes |
-| [Geokeo](https://geokeo.com) | Geokeo geocoding service- with 2500 free api requests daily | No | Yes | Yes |
-| [GeoNames](http://www.geonames.org/export/web-services.html) | Place names and other geographical data | No | No | Unknown |
-| [geoPlugin](https://www.geoplugin.com) | IP geolocation and currency conversion | No | Yes | Yes |
-| [Google Earth Engine](https://developers.google.com/earth-engine/) | A cloud-based platform for planetary-scale environmental data analysis | `apiKey` | Yes | Unknown |
-| [Google Maps](https://developers.google.com/maps/) | Create/customize digital maps based on Google Maps data | `apiKey` | Yes | Unknown |
-| [Graph Countries](https://github.com/lennertVanSever/graphcountries) | Country-related data like currencies, languages, flags, regions+subregions and bordering countries | No | Yes | Unknown |
-| [HelloSalut](https://fourtonfish.com/project/hellosalut-api/) | Get hello translation following user language | No | Yes | Unknown |
-| [HERE Maps](https://developer.here.com) | Create/customize digital maps based on HERE Maps data | `apiKey` | Yes | Unknown |
-| [Hong Kong GeoData Store](https://geodata.gov.hk/gs/) | API for accessing geo-data of Hong Kong | No | Yes | Unknown |
-| [IBGE](https://servicodados.ibge.gov.br/api/docs/) | Aggregate services of IBGE (Brazilian Institute of Geography and Statistics) | No | Yes | Unknown |
-| [IP 2 Country](https://ip2country.info) | Map an IP to a country | No | Yes | Unknown |
-| [IP Address Details](https://ipinfo.io/) | Find geolocation with ip address | No | Yes | Unknown |
-| [ip-api](https://ip-api.com/docs) | Find location with IP address or domain | No | No | Unknown |
-| [IP2Location](https://www.ip2location.com/web-service/ip2location) | IP geolocation web service to get more than 55 parameters | `apiKey` | Yes | Unknown |
-| [IP2Location.io](https://www.ip2location.io) | Bundle of Free IP geolocation and WHOIS API  | `apiKey` | Yes | Unknown |
-| [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy) | Detect proxy and VPN using IP address | `apiKey` | Yes | Unknown |
-| [ipapi.co](https://ipapi.co/api/#introduction) | Find IP address location information | No | Yes | Yes |
-| [IPGEO](https://api.techniknews.net/ipgeo/) | Unlimited free IP Address API with useful information | No | Yes | Unknown |
-| [ipgeolocation](https://ipgeolocation.io/) | IP Geolocation AP with free plan 30k requests per month | `apiKey` | Yes | Yes |
-| [IPInfoDB](https://www.ipinfodb.com/api) | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address | `apiKey` | Yes | Unknown |
-| [Kakao Maps](https://apis.map.kakao.com) | Kakao Maps provide multiple APIs for Korean maps | `apiKey` | Yes | Unknown |
-| [keycdn IP Location Finder](https://tools.keycdn.com/geo) | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded | `apiKey` | Yes | Unknown |
-| [LocationIQ](https://locationiq.org/docs/) | Provides forward/reverse geocoding and batch geocoding | `apiKey` | Yes | Yes |
-| [Longdo Map](https://map.longdo.com/docs/) | Interactive map with detailed places and information portal in Thailand | `apiKey` | Yes | Yes |
-| [Mapbox](https://docs.mapbox.com/) | Create/customize beautiful digital maps | `apiKey` | Yes | Unknown |
-| [MapQuest](https://developer.mapquest.com/) | To access tools and resources to map the world | `apiKey` | Yes | No |
-| [Mexico](https://github.com/IcaliaLabs/sepomex) | Mexico RESTful zip codes API | No | Yes | Unknown |
-| [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/) | Provides worldwide forward / reverse geocoding | No | Yes | Yes |
-| [One Map, Singapore](https://www.onemap.gov.sg/docs/) | Singapore Land Authority REST API services for Singapore addresses | `apiKey` | Yes | Unknown |
-| [OnWater](https://onwater.io/) | Determine if a lat/lon is on water or land | No | Yes | Unknown |
-| [Open Topo Data](https://www.opentopodata.org) | Elevation and ocean depth for a latitude and longitude | No | Yes | No |
-| [OpenCage](https://opencagedata.com) | Forward and reverse geocoding using open data | `apiKey` | Yes | Yes |
-| [openrouteservice.org](https://openrouteservice.org/) | Directions, POIs, isochrones, geocoding (+reverse), elevation, and more | `apiKey` | Yes | Unknown |
-| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API) | Navigation, geolocation and geographical data | `OAuth`| No | Unknown |
-| [Pinball Map](https://pinballmap.com/api/v1/docs) | A crowdsourced map of public pinball machines | No | Yes | Yes |
-| [Postali](https://postali.app/api) | Mexico Zip Codes API | No | Yes | Yes |
-| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | Provide geolocation data based on postcode for Dutch addresses | No | No | Unknown |
-| [Postcodes.io](https://postcodes.io) | Postcode lookup & Geolocation for the UK | No | Yes | Yes |
-| [Proweblook IP Checker](https://proweblook.com/ipapi) | Proweblook lookup & Geolocation | `apiKey` | Yes | Yes |
-| [REST Countries](https://restcountries.com) | Get information about countries via a RESTful API | No | Yes | Yes |
-| [RoadGoat Cities](https://www.roadgoat.com/business/cities-api) | Cities content & photos API | `apiKey` | Yes | No |
-| [Rwanda Locations](https://rapidapi.com/victorkarangwa4/api/rwanda) | Rwanda Provinces, Districts, Cities, Capital City, Sector, cells, villages and streets | No | Yes | Unknown |
-| [SLF](https://github.com/slftool/slftool.github.io/blob/master/API.md) | German city, country, river, database | No | Yes | Yes |
-| [SpotSense](https://spotsense.io/) | Add location based interactions to your mobile app | `apiKey` | Yes | Unknown |
-| [Telize](https://rapidapi.com/fcambus/api/telize/) | Telize offers location information from any IP address | `apiKey` | Yes | Yes |
-| [TomTom](https://developer.tomtom.com/) | Maps, Directions, Places and Traffic APIs | `apiKey` | Yes | Yes |
-| [Uebermaps](https://uebermaps.com/api/v2) | Discover and share maps with friends | `apiKey` | Yes | Unknown |
-| [US ZipCode](https://www.smarty.com/docs/cloud/us-zipcode-api) | Validate and append data for any US ZipCode | `apiKey` | Yes | Yes |
-| [Utah AGRC](https://api.mapserv.utah.gov) | Utah Web API for geocoding Utah addresses | `apiKey` | Yes | Unknown |
-| [ViaCep](https://viacep.com.br) | Brazil RESTful zip codes API | No | Yes | Unknown |
-| [What3Words](https://what3words.com) | Three words as rememberable and unique coordinates worldwide | `apiKey` | Yes | Unknown |
-| [Yandex.Maps Geocoder](https://yandex.com/dev/maps/geocoder) | Use geocoding to get an object's coordinates from its address | `apiKey` | Yes | Unknown |
-| [ZipCodeAPI](https://www.zipcodeapi.com) | US zip code distance, radius and location API | `apiKey` | Yes | Unknown |
-| [Zippopotam.us](http://www.zippopotam.us) | Get information about place such as country, city, state, etc | No | No | Unknown |
-| [Ziptastic](https://ziptasticapi.com/) | Get the country, state, and city of any US zip-code | No | Yes | Unknown |
-| [Zipcodestack](https://zipcodestack.com/) | Zip Code API - Free Postal Code Validation | `apiKey` | Yes | Unknown |
+
+| API                                                                                                                    | Description                                                                                               | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Abstract IP Geolocation](https://www.abstractapi.com/ip-geolocation-api)                                              | Geolocate website visitors from their IPs                                                                 | `apiKey` | Yes   | Yes     |
+| [Actinia Grass GIS](https://actinia.mundialis.de/api_docs/)                                                            | Actinia is an open source REST API for geographical data that uses GRASS GIS                              | `apiKey` | Yes   | Unknown |
+| [administrative-divisons-db](https://github.com/kamikazechaser/administrative-divisions-db)                            | Get all administrative divisions of a country                                                             | No       | Yes   | Yes     |
+| [adresse.data.gouv.fr](https://adresse.data.gouv.fr)                                                                   | Address database of France, geocoding and reverse                                                         | No       | Yes   | Unknown |
+| [Apiip](https://apiip.net/)                                                                                            | Get location information by IP address                                                                    | `apiKey` | Yes   | Yes     |
+| [Battuta](http://battuta.medunes.net)                                                                                  | A (country/region/city) in-cascade location API                                                           | `apiKey` | No    | Unknown |
+| [BigDataCloud's IP Geolocation API](https://www.bigdatacloud.com/ip-geolocation)                                       | Provides fast and accurate IP geolocation APIs along with security checks and confidence area.            | `apiKey` | Yes   | Yes     |
+| [BigDataCloud's Reverse Geocoding API](https://www.bigdatacloud.com/reverse-geocoding)                                 | Get rich locality information from the geographical coordinates.                                          | `apiKey` | Yes   | Yes     |
+| [BigDataCloud's Phone and Email Verification API](https://www.bigdatacloud.com/phone-email-verification)               | Syntax and Format Validation of Phone Number and Email address.                                           | `apiKey` | Yes   | Yes     |
+| [BigDataCloud's Network Engineering API](https://www.bigdatacloud.com/network-engineering)                             | Get detailed ASN and Network lookup of an IP address.                                                     | `apiKey` | Yes   | Yes     |
+| [BigDataCloud's Free API](https://www.bigdatacloud.com//free-api)                                                      | Get free client-side reverse geocoding API and Client Info API. No account creation and API key required. | No       | Yes   | Yes     |
+| [Bing Maps](https://www.microsoft.com/maps/)                                                                           | Create/customize digital maps based on Bing Maps data                                                     | `apiKey` | Yes   | Unknown |
+| [bng2latlong](https://www.getthedata.com/bng2latlong)                                                                  | Convert British OSGB36 easting and northing (British National Grid) to WGS84 latitude and longitude       | No       | Yes   | Yes     |
+| [Cartes.io](https://github.com/M-Media-Group/Cartes.io/wiki/API)                                                       | Create maps and markers for anything                                                                      | No       | Yes   | Unknown |
+| [Cep.la](http://cep.la/)                                                                                               | Brazil RESTful API to find information about streets, zip codes, neighborhoods, cities and states         | No       | No    | Unknown |
+| [CitySDK](http://www.citysdk.eu/citysdk-toolkit/)                                                                      | Open APIs for select European cities                                                                      | No       | Yes   | Unknown |
+| [Country](http://country.is/)                                                                                          | Get your visitor's country from their IP                                                                  | No       | Yes   | Yes     |
+| [CountryStateCity](https://countrystatecity.in/)                                                                       | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format         | `apiKey` | Yes   | Yes     |
+| [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api)                                           | API explorer that gives a query URL with a JSON response of locations and cities                          | No       | Yes   | No      |
+| [FreeGeoIP](https://freegeoip.app/)                                                                                    | Free geo ip information, no registration required. 15k/hour rate limit                                    | No       | Yes   | Yes     |
+| [GeoApi](https://api.gouv.fr/api/geoapi.html)                                                                          | French geographical data                                                                                  | No       | Yes   | Unknown |
+| [Geoapify](https://www.geoapify.com/api/geocoding-api/)                                                                | Forward and reverse geocoding, address autocomplete                                                       | `apiKey` | Yes   | Yes     |
+| [Geocod.io](https://www.geocod.io/)                                                                                    | Address geocoding / reverse geocoding in bulk                                                             | `apiKey` | Yes   | Unknown |
+| [Geocode.xyz](https://geocode.xyz/api)                                                                                 | Provides worldwide forward/reverse geocoding, batch geocoding and geoparsing                              | No       | Yes   | Unknown |
+| [Geocodify.com](https://geocodify.com/)                                                                                | Worldwide geocoding, geoparsing and autocomplete for addresses                                            | `apiKey` | Yes   | Yes     |
+| [Geodata.gov.gr](https://geodata.gov.gr/en/)                                                                           | Open geospatial data and API service for Greece                                                           | No       | Yes   | Unknown |
+| [GeoDataSource](https://www.geodatasource.com/web-service)                                                             | Geocoding of city name by using latitude and longitude coordinates                                        | `apiKey` | Yes   | Unknown |
+| [GeoDB Cities](http://geodb-cities-api.wirefreethought.com/)                                                           | Get global city, region, and country data                                                                 | `apiKey` | Yes   | Unknown |
+| [GeographQL](https://geographql.netlify.app)                                                                           | A Country, State, and City GraphQL API                                                                    | No       | Yes   | Yes     |
+| [GeoJS](https://www.geojs.io/)                                                                                         | IP geolocation with ChatOps integration                                                                   | No       | Yes   | Yes     |
+| [Geokeo](https://geokeo.com)                                                                                           | Geokeo geocoding service- with 2500 free api requests daily                                               | No       | Yes   | Yes     |
+| [GeoNames](http://www.geonames.org/export/web-services.html)                                                           | Place names and other geographical data                                                                   | No       | No    | Unknown |
+| [geoPlugin](https://www.geoplugin.com)                                                                                 | IP geolocation and currency conversion                                                                    | No       | Yes   | Yes     |
+| [Google Earth Engine](https://developers.google.com/earth-engine/)                                                     | A cloud-based platform for planetary-scale environmental data analysis                                    | `apiKey` | Yes   | Unknown |
+| [Google Maps](https://developers.google.com/maps/)                                                                     | Create/customize digital maps based on Google Maps data                                                   | `apiKey` | Yes   | Unknown |
+| [Graph Countries](https://github.com/lennertVanSever/graphcountries)                                                   | Country-related data like currencies, languages, flags, regions+subregions and bordering countries        | No       | Yes   | Unknown |
+| [HelloSalut](https://fourtonfish.com/project/hellosalut-api/)                                                          | Get hello translation following user language                                                             | No       | Yes   | Unknown |
+| [HERE Maps](https://developer.here.com)                                                                                | Create/customize digital maps based on HERE Maps data                                                     | `apiKey` | Yes   | Unknown |
+| [Hong Kong GeoData Store](https://geodata.gov.hk/gs/)                                                                  | API for accessing geo-data of Hong Kong                                                                   | No       | Yes   | Unknown |
+| [IBGE](https://servicodados.ibge.gov.br/api/docs/)                                                                     | Aggregate services of IBGE (Brazilian Institute of Geography and Statistics)                              | No       | Yes   | Unknown |
+| [IP 2 Country](https://ip2country.info)                                                                                | Map an IP to a country                                                                                    | No       | Yes   | Unknown |
+| [IP Address Details](https://ipinfo.io/)                                                                               | Find geolocation with ip address                                                                          | No       | Yes   | Unknown |
+| [ip-api](https://ip-api.com/docs)                                                                                      | Find location with IP address or domain                                                                   | No       | No    | Unknown |
+| [IP2Location](https://www.ip2location.com/web-service/ip2location)                                                     | IP geolocation web service to get more than 55 parameters                                                 | `apiKey` | Yes   | Unknown |
+| [IP2Location.io](https://www.ip2location.io)                                                                           | Bundle of Free IP geolocation and WHOIS API                                                               | `apiKey` | Yes   | Unknown |
+| [IP2Proxy](https://www.ip2location.com/web-service/ip2proxy)                                                           | Detect proxy and VPN using IP address                                                                     | `apiKey` | Yes   | Unknown |
+| [ipapi.co](https://ipapi.co/api/#introduction)                                                                         | Find IP address location information                                                                      | No       | Yes   | Yes     |
+| [IPGEO](https://api.techniknews.net/ipgeo/)                                                                            | Unlimited free IP Address API with useful information                                                     | No       | Yes   | Unknown |
+| [ipgeolocation](https://ipgeolocation.io/)                                                                             | IP Geolocation AP with free plan 30k requests per month                                                   | `apiKey` | Yes   | Yes     |
+| [IPInfoDB](https://www.ipinfodb.com/api)                                                                               | Free Geolocation tools and APIs for country, region, city and time zone lookup by IP address              | `apiKey` | Yes   | Unknown |
+| [Kakao Maps](https://apis.map.kakao.com)                                                                               | Kakao Maps provide multiple APIs for Korean maps                                                          | `apiKey` | Yes   | Unknown |
+| [keycdn IP Location Finder](https://tools.keycdn.com/geo)                                                              | Get the IP geolocation data through the simple REST API. All the responses are JSON encoded               | `apiKey` | Yes   | Unknown |
+| [LocationIQ](https://locationiq.org/docs/)                                                                             | Provides forward/reverse geocoding and batch geocoding                                                    | `apiKey` | Yes   | Yes     |
+| [Longdo Map](https://map.longdo.com/docs/)                                                                             | Interactive map with detailed places and information portal in Thailand                                   | `apiKey` | Yes   | Yes     |
+| [Mapbox](https://docs.mapbox.com/)                                                                                     | Create/customize beautiful digital maps                                                                   | `apiKey` | Yes   | Unknown |
+| [MapQuest](https://developer.mapquest.com/)                                                                            | To access tools and resources to map the world                                                            | `apiKey` | Yes   | No      |
+| [Mexico](https://github.com/IcaliaLabs/sepomex)                                                                        | Mexico RESTful zip codes API                                                                              | No       | Yes   | Unknown |
+| [Nominatim](https://nominatim.org/release-docs/latest/api/Overview/)                                                   | Provides worldwide forward / reverse geocoding                                                            | No       | Yes   | Yes     |
+| [One Map, Singapore](https://www.onemap.gov.sg/docs/)                                                                  | Singapore Land Authority REST API services for Singapore addresses                                        | `apiKey` | Yes   | Unknown |
+| [OnWater](https://onwater.io/)                                                                                         | Determine if a lat/lon is on water or land                                                                | No       | Yes   | Unknown |
+| [Open Topo Data](https://www.opentopodata.org)                                                                         | Elevation and ocean depth for a latitude and longitude                                                    | No       | Yes   | No      |
+| [OpenCage](https://opencagedata.com)                                                                                   | Forward and reverse geocoding using open data                                                             | `apiKey` | Yes   | Yes     |
+| [openrouteservice.org](https://openrouteservice.org/)                                                                  | Directions, POIs, isochrones, geocoding (+reverse), elevation, and more                                   | `apiKey` | Yes   | Unknown |
+| [OpenStreetMap](http://wiki.openstreetmap.org/wiki/API)                                                                | Navigation, geolocation and geographical data                                                             | `OAuth`  | No    | Unknown |
+| [Pinball Map](https://pinballmap.com/api/v1/docs)                                                                      | A crowdsourced map of public pinball machines                                                             | No       | Yes   | Yes     |
+| [Postali](https://postali.app/api)                                                                                     | Mexico Zip Codes API                                                                                      | No       | Yes   | Yes     |
+| [PostcodeData.nl](http://api.postcodedata.nl/v1/postcode/?postcode=1211EP&streetnumber=60&ref=domeinnaam.nl&type=json) | Provide geolocation data based on postcode for Dutch addresses                                            | No       | No    | Unknown |
+| [Postcodes.io](https://postcodes.io)                                                                                   | Postcode lookup & Geolocation for the UK                                                                  | No       | Yes   | Yes     |
+| [Proweblook IP Checker](https://proweblook.com/ipapi)                                                                  | Proweblook lookup & Geolocation                                                                           | `apiKey` | Yes   | Yes     |
+| [REST Countries](https://restcountries.com)                                                                            | Get information about countries via a RESTful API                                                         | No       | Yes   | Yes     |
+| [RoadGoat Cities](https://www.roadgoat.com/business/cities-api)                                                        | Cities content & photos API                                                                               | `apiKey` | Yes   | No      |
+| [Rwanda Locations](https://rapidapi.com/victorkarangwa4/api/rwanda)                                                    | Rwanda Provinces, Districts, Cities, Capital City, Sector, cells, villages and streets                    | No       | Yes   | Unknown |
+| [SLF](https://github.com/slftool/slftool.github.io/blob/master/API.md)                                                 | German city, country, river, database                                                                     | No       | Yes   | Yes     |
+| [SpotSense](https://spotsense.io/)                                                                                     | Add location based interactions to your mobile app                                                        | `apiKey` | Yes   | Unknown |
+| [Telize](https://rapidapi.com/fcambus/api/telize/)                                                                     | Telize offers location information from any IP address                                                    | `apiKey` | Yes   | Yes     |
+| [TomTom](https://developer.tomtom.com/)                                                                                | Maps, Directions, Places and Traffic APIs                                                                 | `apiKey` | Yes   | Yes     |
+| [Uebermaps](https://uebermaps.com/api/v2)                                                                              | Discover and share maps with friends                                                                      | `apiKey` | Yes   | Unknown |
+| [US ZipCode](https://www.smarty.com/docs/cloud/us-zipcode-api)                                                         | Validate and append data for any US ZipCode                                                               | `apiKey` | Yes   | Yes     |
+| [Utah AGRC](https://api.mapserv.utah.gov)                                                                              | Utah Web API for geocoding Utah addresses                                                                 | `apiKey` | Yes   | Unknown |
+| [ViaCep](https://viacep.com.br)                                                                                        | Brazil RESTful zip codes API                                                                              | No       | Yes   | Unknown |
+| [What3Words](https://what3words.com)                                                                                   | Three words as rememberable and unique coordinates worldwide                                              | `apiKey` | Yes   | Unknown |
+| [Yandex.Maps Geocoder](https://yandex.com/dev/maps/geocoder)                                                           | Use geocoding to get an object's coordinates from its address                                             | `apiKey` | Yes   | Unknown |
+| [ZipCodeAPI](https://www.zipcodeapi.com)                                                                               | US zip code distance, radius and location API                                                             | `apiKey` | Yes   | Unknown |
+| [Zippopotam.us](http://www.zippopotam.us)                                                                              | Get information about place such as country, city, state, etc                                             | No       | No    | Unknown |
+| [Ziptastic](https://ziptasticapi.com/)                                                                                 | Get the country, state, and city of any US zip-code                                                       | No       | Yes   | Unknown |
+| [Zipcodestack](https://zipcodestack.com/)                                                                              | Zip Code API - Free Postal Code Validation                                                                | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Government
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Api Colombia](https://api-colombia.com/) | Community driven API for Colombia Public Data | No | Yes | Unknown |
-| [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/) | Malaysia Central Bank Open Data | No | Yes | Unknown |
-| [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
-| [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |
-| [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
-| [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
-| [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
-| [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |
-| [City, Berlin](https://daten.berlin.de/) | Berlin(DE) City Open Data | No | Yes | Unknown |
-| [City, Gdańsk](https://ckan.multimediagdansk.pl/en) | Gdańsk (PL) City Open Data | No | Yes | Unknown |
-| [City, Gdynia](http://otwartedane.gdynia.pl/en/api_doc.html) | Gdynia (PL) City Open Data | No | No | Unknown |
-| [City, Helsinki](https://hri.fi/en_gb/) | Helsinki(FI) City Open Data | No | Yes | Unknown |
-| [City, Lviv](https://opendata.city-adm.lviv.ua/) | Lviv(UA) City Open Data | No | Yes | Unknown |
-| [City, Nantes Open Data](https://data.nantesmetropole.fr/pages/home/) | Nantes(FR) City Open Data | `apiKey` | Yes | Unknown |
-| [City, New York Open Data](https://opendata.cityofnewyork.us/) | New York (US) City Open Data | No | Yes | Unknown |
-| [City, Toronto Open Data](https://open.toronto.ca/) | Toronto (CA) City Open Data | No | Yes | Yes |
-| [Code.gov](https://code.gov) | The primary platform for Open Source and code sharing for the U.S. Federal Government | `apiKey` | Yes | Unknown |
-| [Colorado Information Marketplace](https://data.colorado.gov/) | Colorado State Government Open Data | No | Yes | Unknown |
-| [Data USA](https://datausa.io/about/api/) | US Public Data | No | Yes | Unknown |
-| [Data.gov](https://api.data.gov/) | US Government Data | `apiKey` | Yes | Unknown |
-| [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members) | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No | No | Unknown |
-| [Deutscher Bundestag DIP](https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf) | This API provides read access to DIP entities (e.g. activities, persons, printed material) | `apiKey` | Yes | Unknown |
-| [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis) | Contains D.C. government public datasets, including crime, GIS, financial data, and so on | No | Yes | Unknown |
-| [EPA](https://www.epa.gov/developers/data-data-products#apis) | Web services and data sets from the US Environmental Protection Agency | No | Yes | Unknown |
-| [FBI Wanted](https://www.fbi.gov/wanted/api) | Access information on the FBI Wanted program | No | Yes | Unknown |
-| [FEC](https://api.open.fec.gov/developers/) | Information on campaign donations in federal elections | `apiKey` | Yes | Unknown |
-| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
-| [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth`| Yes | Unknown |
-| [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
-| [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |
-| [National Park Service, US](https://www.nps.gov/subjects/developer/) | Data from the US National Park Service | `apiKey` | Yes | Yes |
-| [Open Government, ACT](https://www.data.act.gov.au/) | Australian Capital Territory Open Data | No | Yes | Unknown |
-| [Open Government, Argentina](https://datos.gob.ar/) | Argentina Government Open Data | No | Yes | Unknown |
-| [Open Government, Australia](https://www.data.gov.au/) | Australian Government Open Data | No | Yes | Unknown |
-| [Open Government, Austria](https://www.data.gv.at/) | Austria Government Open Data | No | Yes | Unknown |
-| [Open Government, Belgium](https://data.gov.be/) | Belgium Government Open Data | No | Yes | Unknown |
-| [Open Government, Canada](http://open.canada.ca/en) | Canadian Government Open Data | No | No | Unknown |
-| [Open Government, Colombia](https://www.dane.gov.co/) | Colombia Government Open Data | No | No | Unknown |
-| [Open Government, Cyprus](https://data.gov.cy) | Cyprus Government Open Data | No | Yes | Unknown |
-| [Open Government, Czech Republic](https://data.gov.cz/english/) | Czech Republic Government Open Data | No | Yes | Unknown |
-| [Open Government, Denmark](https://www.opendata.dk/) | Denmark Government Open Data | No | Yes | Unknown |
-| [Open Government, Estonia](https://avaandmed.eesti.ee/instructions/opendata-dataset-api) | Estonia Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Finland](https://www.avoindata.fi/en) | Finland Government Open Data | No | Yes | Unknown |
-| [Open Government, France](https://www.data.gouv.fr/) | French Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Germany](https://www.govdata.de/daten/-/details/govdata-metadatenkatalog) | Germany Government Open Data | No | Yes | Unknown |
-| [Open Government, Greece](https://data.gov.gr/) | Greece Government Open Data | `OAuth`| Yes | Unknown |
-| [Open Government, India](https://data.gov.in/) | Indian Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Ireland](https://data.gov.ie/pages/developers) | Ireland Government Open Data | No | Yes | Unknown |
-| [Open Government, Italy](https://www.dati.gov.it/) | Italy Government Open Data | No | Yes | Unknown |
-| [Open Government, Korea](https://www.data.go.kr/) | Korea Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Lithuania](https://data.gov.lt/public/api/1) | Lithuania Government Open Data | No | Yes | Unknown |
-| [Open Government, Luxembourg](https://data.public.lu) | Luxembourgish Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, Mexico](https://www.inegi.org.mx/datos/) | Mexican Statistical Government Open Data | No | Yes | Unknown |
-| [Open Government, Mexico](https://datos.gob.mx/) | Mexico Government Open Data | No | Yes | Unknown |
-| [Open Government, Netherlands](https://data.overheid.nl/en/ondersteuning/data-publiceren/api) | Netherlands Government Open Data | No | Yes | Unknown |
-| [Open Government, New South Wales](https://api.nsw.gov.au/) | New South Wales Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, New Zealand](https://www.data.govt.nz/) | New Zealand Government Open Data | No | Yes | Unknown |
-| [Open Government, Norway](https://data.norge.no/dataservices) | Norwegian Government Open Data | No | Yes | Yes |
-| [Open Government, Poland](https://dane.gov.pl/en) | Poland Government Open Data | No | Yes | Yes |
-| [Open Government, Portugal](https://dados.gov.pt/en/docapi/) | Portugal Government Open Data | `apiKey` | Yes | Yes |
-| [Open Government, Queensland Government](https://www.data.qld.gov.au/) | Queensland Government Open Data | No | Yes | Unknown |
-| [Open Government, Romania](http://data.gov.ro/) | Romania Government Open Data | No | No | Unknown |
-| [Open Government, Saudi Arabia](https://data.gov.sa) | Saudi Arabia Government Open Data | No | Yes | Unknown |
-| [Open Government, Singapore](https://data.gov.sg/developer) | Singapore Government Open Data | No | Yes | Unknown |
-| [Open Government, Slovakia](https://data.gov.sk/en/) | Slovakia Government Open Data | No | Yes | Unknown |
-| [Open Government, Slovenia](https://podatki.gov.si/) | Slovenia Government Open Data | No | Yes | No |
-| [Open Government, South Australian Government](https://data.sa.gov.au/) | South Australian Government Open Data | No | Yes | Unknown |
-| [Open Government, Spain](https://datos.gob.es/en) | Spain Government Open Data | No | Yes | Unknown |
-| [Open Government, Sweden](https://www.dataportal.se/en/dataservice/91_29789/api-for-the-statistical-database) | Sweden Government Open Data | No | Yes | Unknown |
-| [Open Government, Switzerland](https://handbook.opendata.swiss/de/content/nutzen/api-nutzen.html) | Switzerland Government Open Data | No | Yes | Unknown |
-| [Open Government, Taiwan](https://data.gov.tw/) | Taiwan Government Open Data | No | Yes | Unknown |
-| [Open Government, Thailand](https://data.go.th/) | Thailand Government Open Data | `apiKey` | Yes | Unknown |
-| [Open Government, UK](https://data.gov.uk/) | UK Government Open Data | No | Yes | Unknown |
-| [Open Government, USA](https://www.data.gov/) | United States Government Open Data | No | Yes | Unknown |
-| [Open Government, Victoria State Government](https://www.data.vic.gov.au/) | Victoria State Government Open Data | No | Yes | Unknown |
-| [Open Government, West Australia](https://data.wa.gov.au/) | West Australia Open Data | No | Yes | Unknown |
-| [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes | Yes |
-| [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
-| [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth`| Yes | Unknown |
-| [USAspending.gov](https://api.usaspending.gov/) | US federal spending data | No | Yes | Unknown |
+
+| API                                                                                                           | Description                                                                                        | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Api Colombia](https://api-colombia.com/)                                                                     | Community driven API for Colombia Public Data                                                      | No       | Yes   | Unknown |
+| [Bank Negara Malaysia Open Data](https://apikijangportal.bnm.gov.my/)                                         | Malaysia Central Bank Open Data                                                                    | No       | Yes   | Unknown |
+| [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html)                                 | Access to the laws of British Columbia                                                             | No       | No    | Unknown |
+| [Brazil](https://brasilapi.com.br/)                                                                           | Community driven API for Brazil Public Data                                                        | No       | Yes   | Yes     |
+| [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/)                                             | Brazil Central Bank Open Data                                                                      | No       | Yes   | Unknown |
+| [Brazil Receita WS](https://www.receitaws.com.br/)                                                            | Consult companies by CNPJ for Brazilian companies                                                  | No       | Yes   | Unknown |
+| [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html)                | Provides legislative information in Apis XML and JSON, as well as files in various formats         | No       | Yes   | No      |
+| [Census.gov](https://www.census.gov/data/developers/data-sets.html)                                           | The US Census Bureau provides various APIs and data sets on demographics and businesses            | No       | Yes   | Unknown |
+| [City, Berlin](https://daten.berlin.de/)                                                                      | Berlin(DE) City Open Data                                                                          | No       | Yes   | Unknown |
+| [City, Gdańsk](https://ckan.multimediagdansk.pl/en)                                                           | Gdańsk (PL) City Open Data                                                                         | No       | Yes   | Unknown |
+| [City, Gdynia](http://otwartedane.gdynia.pl/en/api_doc.html)                                                  | Gdynia (PL) City Open Data                                                                         | No       | No    | Unknown |
+| [City, Helsinki](https://hri.fi/en_gb/)                                                                       | Helsinki(FI) City Open Data                                                                        | No       | Yes   | Unknown |
+| [City, Lviv](https://opendata.city-adm.lviv.ua/)                                                              | Lviv(UA) City Open Data                                                                            | No       | Yes   | Unknown |
+| [City, Nantes Open Data](https://data.nantesmetropole.fr/pages/home/)                                         | Nantes(FR) City Open Data                                                                          | `apiKey` | Yes   | Unknown |
+| [City, New York Open Data](https://opendata.cityofnewyork.us/)                                                | New York (US) City Open Data                                                                       | No       | Yes   | Unknown |
+| [City, Toronto Open Data](https://open.toronto.ca/)                                                           | Toronto (CA) City Open Data                                                                        | No       | Yes   | Yes     |
+| [Code.gov](https://code.gov)                                                                                  | The primary platform for Open Source and code sharing for the U.S. Federal Government              | `apiKey` | Yes   | Unknown |
+| [Colorado Information Marketplace](https://data.colorado.gov/)                                                | Colorado State Government Open Data                                                                | No       | Yes   | Unknown |
+| [Data USA](https://datausa.io/about/api/)                                                                     | US Public Data                                                                                     | No       | Yes   | Unknown |
+| [Data.gov](https://api.data.gov/)                                                                             | US Government Data                                                                                 | `apiKey` | Yes   | Unknown |
+| [Data.parliament.uk](https://explore.data.parliament.uk/?learnmore=Members)                                   | Contains live datasets including information about petitions, bills, MP votes, attendance and more | No       | No    | Unknown |
+| [Deutscher Bundestag DIP](https://dip.bundestag.de/documents/informationsblatt_zur_dip_api_v01.pdf)           | This API provides read access to DIP entities (e.g. activities, persons, printed material)         | `apiKey` | Yes   | Unknown |
+| [District of Columbia Open Data](http://opendata.dc.gov/pages/using-apis)                                     | Contains D.C. government public datasets, including crime, GIS, financial data, and so on          | No       | Yes   | Unknown |
+| [EPA](https://www.epa.gov/developers/data-data-products#apis)                                                 | Web services and data sets from the US Environmental Protection Agency                             | No       | Yes   | Unknown |
+| [FBI Wanted](https://www.fbi.gov/wanted/api)                                                                  | Access information on the FBI Wanted program                                                       | No       | Yes   | Unknown |
+| [FEC](https://api.open.fec.gov/developers/)                                                                   | Information on campaign donations in federal elections                                             | `apiKey` | Yes   | Unknown |
+| [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api)                  | The Daily Journal of the United States Government                                                  | No       | Yes   | Unknown |
+| [Gazette Data, UK](https://www.thegazette.co.uk/data)                                                         | UK official public record API                                                                      | `OAuth`  | Yes   | Unknown |
+| [Interpol Red Notices](https://interpol.api.bund.dev/)                                                        | Access and search Interpol Red Notices                                                             | No       | Yes   | Unknown |
+| [Istanbul (İBB) Open Data](https://data.ibb.gov.tr)                                                           | Data sets from the İstanbul Metropolitan Municipality (İBB)                                        | No       | Yes   | Unknown |
+| [National Park Service, US](https://www.nps.gov/subjects/developer/)                                          | Data from the US National Park Service                                                             | `apiKey` | Yes   | Yes     |
+| [Open Government, ACT](https://www.data.act.gov.au/)                                                          | Australian Capital Territory Open Data                                                             | No       | Yes   | Unknown |
+| [Open Government, Argentina](https://datos.gob.ar/)                                                           | Argentina Government Open Data                                                                     | No       | Yes   | Unknown |
+| [Open Government, Australia](https://www.data.gov.au/)                                                        | Australian Government Open Data                                                                    | No       | Yes   | Unknown |
+| [Open Government, Austria](https://www.data.gv.at/)                                                           | Austria Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Belgium](https://data.gov.be/)                                                              | Belgium Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Canada](http://open.canada.ca/en)                                                           | Canadian Government Open Data                                                                      | No       | No    | Unknown |
+| [Open Government, Colombia](https://www.dane.gov.co/)                                                         | Colombia Government Open Data                                                                      | No       | No    | Unknown |
+| [Open Government, Cyprus](https://data.gov.cy)                                                                | Cyprus Government Open Data                                                                        | No       | Yes   | Unknown |
+| [Open Government, Czech Republic](https://data.gov.cz/english/)                                               | Czech Republic Government Open Data                                                                | No       | Yes   | Unknown |
+| [Open Government, Denmark](https://www.opendata.dk/)                                                          | Denmark Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Estonia](https://avaandmed.eesti.ee/instructions/opendata-dataset-api)                      | Estonia Government Open Data                                                                       | `apiKey` | Yes   | Unknown |
+| [Open Government, Finland](https://www.avoindata.fi/en)                                                       | Finland Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, France](https://www.data.gouv.fr/)                                                          | French Government Open Data                                                                        | `apiKey` | Yes   | Unknown |
+| [Open Government, Germany](https://www.govdata.de/daten/-/details/govdata-metadatenkatalog)                   | Germany Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Greece](https://data.gov.gr/)                                                               | Greece Government Open Data                                                                        | `OAuth`  | Yes   | Unknown |
+| [Open Government, India](https://data.gov.in/)                                                                | Indian Government Open Data                                                                        | `apiKey` | Yes   | Unknown |
+| [Open Government, Ireland](https://data.gov.ie/pages/developers)                                              | Ireland Government Open Data                                                                       | No       | Yes   | Unknown |
+| [Open Government, Italy](https://www.dati.gov.it/)                                                            | Italy Government Open Data                                                                         | No       | Yes   | Unknown |
+| [Open Government, Korea](https://www.data.go.kr/)                                                             | Korea Government Open Data                                                                         | `apiKey` | Yes   | Unknown |
+| [Open Government, Lithuania](https://data.gov.lt/public/api/1)                                                | Lithuania Government Open Data                                                                     | No       | Yes   | Unknown |
+| [Open Government, Luxembourg](https://data.public.lu)                                                         | Luxembourgish Government Open Data                                                                 | `apiKey` | Yes   | Unknown |
+| [Open Government, Mexico](https://www.inegi.org.mx/datos/)                                                    | Mexican Statistical Government Open Data                                                           | No       | Yes   | Unknown |
+| [Open Government, Mexico](https://datos.gob.mx/)                                                              | Mexico Government Open Data                                                                        | No       | Yes   | Unknown |
+| [Open Government, Netherlands](https://data.overheid.nl/en/ondersteuning/data-publiceren/api)                 | Netherlands Government Open Data                                                                   | No       | Yes   | Unknown |
+| [Open Government, New South Wales](https://api.nsw.gov.au/)                                                   | New South Wales Government Open Data                                                               | `apiKey` | Yes   | Unknown |
+| [Open Government, New Zealand](https://www.data.govt.nz/)                                                     | New Zealand Government Open Data                                                                   | No       | Yes   | Unknown |
+| [Open Government, Norway](https://data.norge.no/dataservices)                                                 | Norwegian Government Open Data                                                                     | No       | Yes   | Yes     |
+| [Open Government, Poland](https://dane.gov.pl/en)                                                             | Poland Government Open Data                                                                        | No       | Yes   | Yes     |
+| [Open Government, Portugal](https://dados.gov.pt/en/docapi/)                                                  | Portugal Government Open Data                                                                      | `apiKey` | Yes   | Yes     |
+| [Open Government, Queensland Government](https://www.data.qld.gov.au/)                                        | Queensland Government Open Data                                                                    | No       | Yes   | Unknown |
+| [Open Government, Romania](http://data.gov.ro/)                                                               | Romania Government Open Data                                                                       | No       | No    | Unknown |
+| [Open Government, Saudi Arabia](https://data.gov.sa)                                                          | Saudi Arabia Government Open Data                                                                  | No       | Yes   | Unknown |
+| [Open Government, Singapore](https://data.gov.sg/developer)                                                   | Singapore Government Open Data                                                                     | No       | Yes   | Unknown |
+| [Open Government, Slovakia](https://data.gov.sk/en/)                                                          | Slovakia Government Open Data                                                                      | No       | Yes   | Unknown |
+| [Open Government, Slovenia](https://podatki.gov.si/)                                                          | Slovenia Government Open Data                                                                      | No       | Yes   | No      |
+| [Open Government, South Australian Government](https://data.sa.gov.au/)                                       | South Australian Government Open Data                                                              | No       | Yes   | Unknown |
+| [Open Government, Spain](https://datos.gob.es/en)                                                             | Spain Government Open Data                                                                         | No       | Yes   | Unknown |
+| [Open Government, Sweden](https://www.dataportal.se/en/dataservice/91_29789/api-for-the-statistical-database) | Sweden Government Open Data                                                                        | No       | Yes   | Unknown |
+| [Open Government, Switzerland](https://handbook.opendata.swiss/de/content/nutzen/api-nutzen.html)             | Switzerland Government Open Data                                                                   | No       | Yes   | Unknown |
+| [Open Government, Taiwan](https://data.gov.tw/)                                                               | Taiwan Government Open Data                                                                        | No       | Yes   | Unknown |
+| [Open Government, Thailand](https://data.go.th/)                                                              | Thailand Government Open Data                                                                      | `apiKey` | Yes   | Unknown |
+| [Open Government, UK](https://data.gov.uk/)                                                                   | UK Government Open Data                                                                            | No       | Yes   | Unknown |
+| [Open Government, USA](https://www.data.gov/)                                                                 | United States Government Open Data                                                                 | No       | Yes   | Unknown |
+| [Open Government, Victoria State Government](https://www.data.vic.gov.au/)                                    | Victoria State Government Open Data                                                                | No       | Yes   | Unknown |
+| [Open Government, West Australia](https://data.wa.gov.au/)                                                    | West Australia Open Data                                                                           | No       | Yes   | Unknown |
+| [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/)                                             | Unofficial Philippine Professional Regulation Commission's examination schedule                    | No       | Yes   | Yes     |
+| [Represent by Open North](https://represent.opennorth.ca/)                                                    | Find Canadian Government Representatives                                                           | No       | Yes   | Unknown |
+| [UK Companies House](https://developer.company-information.service.gov.uk/)                                   | UK Companies House Data from the UK government                                                     | `OAuth`  | Yes   | Unknown |
+| [USAspending.gov](https://api.usaspending.gov/)                                                               | US federal spending data                                                                           | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Health
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [CMS.gov](https://data.cms.gov/provider-data/) | Access to the data from the CMS - medicare.gov | `apiKey` | Yes | Unknown |
-| [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | UK Government coronavirus data, including deaths and cases by region | No | Yes | Unknown |
-| [Covid Tracking Project](https://covidtracking.com/data/api/version-2) | Covid-19 data for the US | No | Yes | No |
-| [Covid-19](https://github.com/M-Media-Group/Covid-19-API) | Covid 19 cases, deaths and recovery per country | No | Yes | Yes |
-| [Covid-19 Datenhub](https://npgeo-corona-npgeo-de.hub.arcgis.com) | Maps, datasets, applications and more in the context of COVID-19 | No | Yes | Unknown |
-| [Covid-19 Government Response](https://covidtracker.bsg.ox.ac.uk) | Government measures tracker to fight against the Covid-19 pandemic | No | Yes | Yes |
-| [Covid-19 India](https://data.covid19india.org/) | Covid 19 statistics state and district wise about cases, vaccinations, recovery within India | No | Yes | Unknown |
-| [Covid-19 JHU CSSE](https://nuttaphat.com/covid19-api/) | Open-source API for exploring Covid19 cases based on JHU CSSE | No | Yes | Yes |
-| [Covid-19 Live Data](https://github.com/mathdroid/covid-19-api) | Global and countrywise data of Covid 19 daily Summary, confirmed cases, recovered and deaths | No | Yes | Yes |
-| [Covid-19 Philippines](https://github.com/Simperfy/Covid-19-API-Philippines-DOH) | Unofficial Covid-19 Web API for Philippines from data collected by DOH | No | Yes | Yes |
-| [COVID-19 Tracker Canada](https://api.covid19tracker.ca/docs/1.0/overview) | Details on Covid-19 cases across Canada | No | Yes | Unknown |
-| [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/en/api-documentation) | Provides situation of the COVID-19 patients reported in Sri Lanka | No | Yes | Unknown |
-| [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | COVID-19 live statistics into sites per hour | No | Yes | Unknown |
-| [FoodData Central](https://fdc.nal.usda.gov/) | National Nutrient Database for Standard Reference | `apiKey` | Yes | Unknown |
-| [Healthcare.gov](https://www.healthcare.gov/developers/) | Educational content about the US Health Insurance Marketplace | No | Yes | Unknown |
-| [Humanitarian Data Exchange](https://data.humdata.org/) | Humanitarian Data Exchange (HDX) is open platform for sharing data across crises and organisations | No | Yes | Unknown |
-| [Infermedica](https://developer.infermedica.com/docs/) | NLP based symptom checker and patient triage API for health diagnosis from text | `apiKey` | Yes | Yes |
-| [LAPIS](https://cov-spectrum.ethz.ch/public) | SARS-CoV-2 genomic sequences from public sources | No | Yes | Yes |
-| [Lexigram](https://docs.lexigram.io/) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
-| [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
-| [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
-| [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |
-| [Nutritionix](https://developer.nutritionix.com/) | Worlds largest verified nutrition database | `apiKey` | Yes | Unknown |
-| [Open Data NHS Scotland](https://www.opendata.nhs.scot) | Medical reference data and statistics by Public Health Scotland | No | Yes | Unknown |
-| [Open Disease](https://disease.sh/) | API for Current cases and more stuff about COVID-19 and Influenza | No | Yes | Yes |
-| [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Yes | Unknown |
+
+| API                                                                               | Description                                                                                        | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [CMS.gov](https://data.cms.gov/provider-data/)                                    | Access to the data from the CMS - medicare.gov                                                     | `apiKey` | Yes   | Unknown |
+| [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | UK Government coronavirus data, including deaths and cases by region                               | No       | Yes   | Unknown |
+| [Covid Tracking Project](https://covidtracking.com/data/api/version-2)            | Covid-19 data for the US                                                                           | No       | Yes   | No      |
+| [Covid-19](https://github.com/M-Media-Group/Covid-19-API)                         | Covid 19 cases, deaths and recovery per country                                                    | No       | Yes   | Yes     |
+| [Covid-19 Datenhub](https://npgeo-corona-npgeo-de.hub.arcgis.com)                 | Maps, datasets, applications and more in the context of COVID-19                                   | No       | Yes   | Unknown |
+| [Covid-19 Government Response](https://covidtracker.bsg.ox.ac.uk)                 | Government measures tracker to fight against the Covid-19 pandemic                                 | No       | Yes   | Yes     |
+| [Covid-19 India](https://data.covid19india.org/)                                  | Covid 19 statistics state and district wise about cases, vaccinations, recovery within India       | No       | Yes   | Unknown |
+| [Covid-19 JHU CSSE](https://nuttaphat.com/covid19-api/)                           | Open-source API for exploring Covid19 cases based on JHU CSSE                                      | No       | Yes   | Yes     |
+| [Covid-19 Live Data](https://github.com/mathdroid/covid-19-api)                   | Global and countrywise data of Covid 19 daily Summary, confirmed cases, recovered and deaths       | No       | Yes   | Yes     |
+| [Covid-19 Philippines](https://github.com/Simperfy/Covid-19-API-Philippines-DOH)  | Unofficial Covid-19 Web API for Philippines from data collected by DOH                             | No       | Yes   | Yes     |
+| [COVID-19 Tracker Canada](https://api.covid19tracker.ca/docs/1.0/overview)        | Details on Covid-19 cases across Canada                                                            | No       | Yes   | Unknown |
+| [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/en/api-documentation)  | Provides situation of the COVID-19 patients reported in Sri Lanka                                  | No       | Yes   | Unknown |
+| [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com)                         | COVID-19 live statistics into sites per hour                                                       | No       | Yes   | Unknown |
+| [FoodData Central](https://fdc.nal.usda.gov/)                                     | National Nutrient Database for Standard Reference                                                  | `apiKey` | Yes   | Unknown |
+| [Healthcare.gov](https://www.healthcare.gov/developers/)                          | Educational content about the US Health Insurance Marketplace                                      | No       | Yes   | Unknown |
+| [Humanitarian Data Exchange](https://data.humdata.org/)                           | Humanitarian Data Exchange (HDX) is open platform for sharing data across crises and organisations | No       | Yes   | Unknown |
+| [Infermedica](https://developer.infermedica.com/docs/)                            | NLP based symptom checker and patient triage API for health diagnosis from text                    | `apiKey` | Yes   | Yes     |
+| [LAPIS](https://cov-spectrum.ethz.ch/public)                                      | SARS-CoV-2 genomic sequences from public sources                                                   | No       | Yes   | Yes     |
+| [Lexigram](https://docs.lexigram.io/)                                             | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology       | `apiKey` | Yes   | Unknown |
+| [Makeup](http://makeup-api.herokuapp.com/)                                        | Makeup Information                                                                                 | No       | No    | Unknown |
+| [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u)         | Vaccination data for Malaysia                                                                      | No       | Yes   | Unknown |
+| [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api)                        | National Plan & Provider Enumeration System, info on healthcare providers registered in US         | No       | Yes   | Unknown |
+| [Nutritionix](https://developer.nutritionix.com/)                                 | Worlds largest verified nutrition database                                                         | `apiKey` | Yes   | Unknown |
+| [Open Data NHS Scotland](https://www.opendata.nhs.scot)                           | Medical reference data and statistics by Public Health Scotland                                    | No       | Yes   | Unknown |
+| [Open Disease](https://disease.sh/)                                               | API for Current cases and more stuff about COVID-19 and Influenza                                  | No       | Yes   | Yes     |
+| [openFDA](https://open.fda.gov)                                                   | Public FDA data about drugs, devices and foods                                                     | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Jobs
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
-| [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth`| Yes | Unknown |
-| [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |
-| [DevITjobs UK](https://devitjobs.uk/job_feed.xml) | Jobs with GraphQL | No | Yes | Yes |
-| [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Yes | Unknown |
-| [jobdata API](https://jobdataapi.com/) | Simple Job Data API | `apiKey` | Yes | Unknown |
-| [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
-| [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
-| [Jobicy](https://jobicy.com/jobs-rss-feed) | Remote Jobs API Feed | No | Yes | Unknown |
-| [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |
-| [OkJob](https://okjob.io/api) | 4 day week job board | `apiKey` | Yes | Unknown |
-| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data | No | No | Unknown |
-| [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Yes | Unknown |
-| [Techmap's Job Postings](https://jobdatafeeds.com/job-api) | API for International Job postings | `apiKey` | Yes | Unknown |
-| [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Yes | Unknown |
-| [Upwork](https://developers.upwork.com) | Freelance job board and management system | `OAuth`| Yes | Unknown |
-| [USAJOBS](https://developer.usajobs.gov/) | US government job board | `apiKey` | Yes | Unknown |
-| [WhatJobs](https://www.whatjobs.com/affiliates) | Job search engine | `apiKey` | Yes | Unknown |
+
+| API                                                                                      | Description                                                      | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------- | ---------------------------------------------------------------- | -------- | ----- | ------- |
+| [Adzuna](https://developer.adzuna.com/overview)                                          | Job board aggregator                                             | `apiKey` | Yes   | Unknown |
+| [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh)                    | API for Job board aggregator in Europe / Remote                  | No       | Yes   | Yes     |
+| [Arbeitsamt](https://jobsuche.api.bund.dev/)                                             | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth`  | Yes   | Unknown |
+| [Careerjet](https://www.careerjet.com/partners/api/)                                     | Job search engine                                                | `apiKey` | No    | Unknown |
+| [DevITjobs UK](https://devitjobs.uk/job_feed.xml)                                        | Jobs with GraphQL                                                | No       | Yes   | Yes     |
+| [Findwork](https://findwork.dev/developers/)                                             | Job board                                                        | `apiKey` | Yes   | Unknown |
+| [jobdata API](https://jobdataapi.com/)                                                   | Simple Job Data API                                              | `apiKey` | Yes   | Unknown |
+| [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf)                                 | Job aggregator                                                   | `apiKey` | Yes   | Unknown |
+| [Jooble](https://jooble.org/api/about)                                                   | Job search engine                                                | `apiKey` | Yes   | Unknown |
+| [Jobicy](https://jobicy.com/jobs-rss-feed)                                               | Remote Jobs API Feed                                             | No       | Yes   | Unknown |
+| [Juju](http://www.juju.com/publisher/spec/)                                              | Job search engine                                                | `apiKey` | No    | Unknown |
+| [OkJob](https://okjob.io/api)                                                            | 4 day week job board                                             | `apiKey` | Yes   | Unknown |
+| [Open Skills](https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview) | Job titles, skills and related jobs data                         | No       | No    | Unknown |
+| [Reed](https://www.reed.co.uk/developers)                                                | Job board aggregator                                             | `apiKey` | Yes   | Unknown |
+| [Techmap's Job Postings](https://jobdatafeeds.com/job-api)                               | API for International Job postings                               | `apiKey` | Yes   | Unknown |
+| [The Muse](https://www.themuse.com/developers/api/v2)                                    | Job board and company profiles                                   | `apiKey` | Yes   | Unknown |
+| [Upwork](https://developers.upwork.com)                                                  | Freelance job board and management system                        | `OAuth`  | Yes   | Unknown |
+| [USAJOBS](https://developer.usajobs.gov/)                                                | US government job board                                          | `apiKey` | Yes   | Unknown |
+| [WhatJobs](https://www.whatjobs.com/affiliates)                                          | Job search engine                                                | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Machine Learning
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [AI/ML API](https://aimlapi.com) | Access 100+ curated AI Models over 1 API | Yes | Yes | Yes |
-| [AI For Thai](https://aiforthai.in.th/index.php) | Free Various Thai AI API | `apiKey` | Yes | Yes |
-| [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth`| Yes | Unknown |
-| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
-| [Cohere](https://docs.cohere.ai/) | Harness the power of language understanding. Join the developers and businesses who are using Cohere to generate, categorize and organize text at a scale that was previously unimaginable. | `apiKey` | Yes | Yes |
-| [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |
-| [Eden](https://www.edenai.co/) | Get all AI models in one place, e.g. OpenAI, Google and lots more! | `apiKey` | Yes | Yes 
-| [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
-| [Gladia](https://docs.gladia.io) | Artificial intelligence API's | `apiKey` | Yes | No |
-| [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
-| [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
-| [Irisnet](https://irisnet.de/api/) | Realtime content moderation API that blocks or blurs unwanted images in real-time | `apiKey` | Yes | Yes |
-| [jsonAi.cloud](https://jsonai.cloud) | Save JSON schemas as api endpoints, feed it with your data and get structured JSON responses with AI | `apiKey` | Yes | Unknown |
-| [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Yes | Unknown |
-| [Machinetutors](https://machinetutors.com/api/) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
-| [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
-| [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
-| [OpenAI](https://openai.com/index/openai-api) | Use AI models such as ChatGPT or DALL-E to experience the capabilities of AI | `apiKey` | Yes | Yes |
-| [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
-| [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |
-| [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Yes | Unknown |
-| [Summarize Text with AI](https://apyhub.com/utility/ai-summarize) | Generates summaries of text and web pages using AI | `apiKey` | Yes | Yes |
-| [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Yes | Unknown |
-| [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Yes | Unknown |
+
+| API                                                                               | Description                                                                                                                                                                                 | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [AI/ML API](https://aimlapi.com)                                                  | Access 100+ curated AI Models over 1 API                                                                                                                                                    | Yes      | Yes   | Yes     |
+| [AI For Thai](https://aiforthai.in.th/index.php)                                  | Free Various Thai AI API                                                                                                                                                                    | `apiKey` | Yes   | Yes     |
+| [Clarifai](https://docs.clarifai.com/api-guide/api-overview)                      | Computer Vision                                                                                                                                                                             | `OAuth`  | Yes   | Unknown |
+| [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification                                                                                                                                     | `apiKey` | Yes   | Yes     |
+| [Cohere](https://docs.cohere.ai/)                                                 | Harness the power of language understanding. Join the developers and businesses who are using Cohere to generate, categorize and organize text at a scale that was previously unimaginable. | `apiKey` | Yes   | Yes     |
+| [Dialogflow](https://cloud.google.com/dialogflow/docs/)                           | Natural Language Processing                                                                                                                                                                 | `apiKey` | Yes   | Unknown |
+| [Eden](https://www.edenai.co/)                                                    | Get all AI models in one place, e.g. OpenAI, Google and lots more!                                                                                                                          | `apiKey` | Yes   | Yes     |
+| [EXUDE-API](http://uttesh.com/exude-api/)                                         | Used for the primary ways for filtering the stopping, stemming words from the text data                                                                                                     | No       | Yes   | Yes     |
+| [Gladia](https://docs.gladia.io)                                                  | Artificial intelligence API's                                                                                                                                                               | `apiKey` | Yes   | No      |
+| [Imagga](https://imagga.com/)                                                     | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation                                                                                                                    | `apiKey` | Yes   | Unknown |
+| [Inferdo](https://rapidapi.com/user/inferdo)                                      | Computer Vision services like Facial detection, Image labeling, NSFW classification                                                                                                         | `apiKey` | Yes   | Unknown |
+| [Irisnet](https://irisnet.de/api/)                                                | Realtime content moderation API that blocks or blurs unwanted images in real-time                                                                                                           | `apiKey` | Yes   | Yes     |
+| [jsonAi.cloud](https://jsonai.cloud)                                              | Save JSON schemas as api endpoints, feed it with your data and get structured JSON responses with AI                                                                                        | `apiKey` | Yes   | Unknown |
+| [Keen IO](https://keen.io/)                                                       | Data Analytics                                                                                                                                                                              | `apiKey` | Yes   | Unknown |
+| [Machinetutors](https://machinetutors.com/api/)                                   | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP                                                                                                      | `apiKey` | Yes   | Yes     |
+| [MessengerX.io](https://messengerx.rtfd.io)                                       | A FREE API for developers to build and monetize personalized ML based chat apps                                                                                                             | `apiKey` | Yes   | Yes     |
+| [NLP Cloud](https://nlpcloud.io)                                                  | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more                                                                                           | `apiKey` | Yes   | Unknown |
+| [OpenAI](https://openai.com/index/openai-api)                                     | Use AI models such as ChatGPT or DALL-E to experience the capabilities of AI                                                                                                                | `apiKey` | Yes   | Yes     |
+| [Perspective](https://perspectiveapi.com)                                         | NLP API to return probability that if text is toxic, obscene, insulting or threatening                                                                                                      | `apiKey` | Yes   | Unknown |
+| [Roboflow Universe](https://universe.roboflow.com)                                | Pre-trained computer vision models                                                                                                                                                          | `apiKey` | Yes   | Yes     |
+| [SkyBiometry](https://skybiometry.com/documentation/)                             | Face Detection, Face Recognition and Face Grouping                                                                                                                                          | `apiKey` | Yes   | Unknown |
+| [Summarize Text with AI](https://apyhub.com/utility/ai-summarize)                 | Generates summaries of text and web pages using AI                                                                                                                                          | `apiKey` | Yes   | Yes     |
+| [Unplugg](https://unplu.gg/test_api.html)                                         | Forecasting API for timeseries data                                                                                                                                                         | `apiKey` | Yes   | Unknown |
+| [WolframAlpha](https://products.wolframalpha.com/api/)                            | Provides specific answers to questions using data and algorithms                                                                                                                            | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Music
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [7digital](https://docs.7digital.com/reference) | Api of Music store 7digital | `OAuth`| Yes | Unknown |
-| [AI Mastering](https://aimastering.com/api_docs/) | Automated Music Mastering | `apiKey` | Yes | Yes |
-| [Audiomack](https://www.audiomack.com/data-api/docs) | Api of the streaming music hub Audiomack | `OAuth`| Yes | Unknown |
-| [Bandcamp](https://bandcamp.com/developer) | API of Music store Bandcamp | `OAuth`| Yes | Unknown |
-| [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0) | Music Events | No | Yes | Unknown |
-| [Deezer](https://developers.deezer.com/api) | Music | `OAuth`| Yes | Unknown |
-| [Discogs](https://www.discogs.com/developers) | Music | `OAuth`| Yes | Unknown |
-| [Freesound](https://freesound.org/docs/api/) | Music Samples | `apiKey` | Yes | Unknown |
-| [Gaana](https://github.com/cyberboysumanjay/GaanaAPI) | API to retrieve song information from Gaana | No | Yes | Unknown |
-| [Genius](https://docs.genius.com) | Crowdsourced lyrics and music knowledge | `OAuth`| Yes | Unknown |
-| [Genrenator](https://binaryjazz.us/genrenator-api/) | Music genre generator | No | Yes | Unknown |
-| [Jamendo](https://developer.jamendo.com/v3.0/docs) | Music | `OAuth`| Yes | Unknown |
-| [JioSaavn](https://github.com/cyberboysumanjay/JioSaavnAPI) | API to retrieve song information, album meta data and many more from JioSaavn | No | Yes | Unknown |
-| [KKBOX](https://developer.kkbox.com) | Get music libraries, playlists, charts, and perform out of KKBOX's platform | `OAuth`| Yes | Unknown |
-| [LastFm](https://www.last.fm/api) | Music | `apiKey` | Yes | Unknown |
-| [Mixcloud](https://www.mixcloud.com/developers/) | Music | `OAuth`| Yes | Yes |
-| [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music | No | Yes | Unknown |
-| [Musixmatch](https://developer.musixmatch.com/) | Music | `apiKey` | Yes | Unknown |
-| [Napster](https://developer.napster.com/api/v2.2) | Music | `apiKey` | Yes | Yes |
-| [Openwhyd](https://openwhyd.github.io/openwhyd/API) | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...) | No | Yes | No |
-| [Phishin](https://phish.in/api-docs) | A web-based archive of legal live audio recordings of the improvisational rock band Phish | `apiKey` | Yes | No |
-| [Radio Browser](https://api.radio-browser.info/) | List of internet radio stations | No | Yes | Yes |
-| [Songkick](https://www.songkick.com/developer/) | Music Events | `apiKey` | Yes | Unknown |
-| [Songlink / Odesli](https://www.notion.so/API-d0ebe08a5e304a55928405eb682f6741) | Get all the services on which a song is available | `apiKey` | Yes | Yes |
-| [SoundCloud](https://developers.soundcloud.com/docs/api/guide) | With SoundCloud API you can build applications that will give more power to control your content | `OAuth`| Yes | Unknown |
-| [Spotify](https://beta.developer.spotify.com/documentation/web-api/) | View Spotify music catalog, manage users' libraries, get recommendations and more | `OAuth`| Yes | Unknown |
-| [TasteDive](https://tastedive.com/read/api) | Similar artist API (also works for movies and TV shows) | `apiKey` | Yes | Unknown |
-| [TheAudioDB](https://www.theaudiodb.com/api_guide.php) | Music | `apiKey` | Yes | Unknown |
-| [Vagalume](https://api.vagalume.com.br/docs/) | Crowdsourced lyrics and music knowledge | `apiKey` | Yes | Unknown |
+
+| API                                                                              | Description                                                                                      | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [7digital](https://docs.7digital.com/reference)                                  | Api of Music store 7digital                                                                      | `OAuth`  | Yes   | Unknown |
+| [AI Mastering](https://aimastering.com/api_docs/)                                | Automated Music Mastering                                                                        | `apiKey` | Yes   | Yes     |
+| [Audiomack](https://www.audiomack.com/data-api/docs)                             | Api of the streaming music hub Audiomack                                                         | `OAuth`  | Yes   | Unknown |
+| [Bandcamp](https://bandcamp.com/developer)                                       | API of Music store Bandcamp                                                                      | `OAuth`  | Yes   | Unknown |
+| [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0)       | Music Events                                                                                     | No       | Yes   | Unknown |
+| [Deezer](https://developers.deezer.com/api)                                      | Music                                                                                            | `OAuth`  | Yes   | Unknown |
+| [Discogs](https://www.discogs.com/developers)                                    | Music                                                                                            | `OAuth`  | Yes   | Unknown |
+| [Freesound](https://freesound.org/docs/api/)                                     | Music Samples                                                                                    | `apiKey` | Yes   | Unknown |
+| [Gaana](https://github.com/cyberboysumanjay/GaanaAPI)                            | API to retrieve song information from Gaana                                                      | No       | Yes   | Unknown |
+| [Genius](https://docs.genius.com)                                                | Crowdsourced lyrics and music knowledge                                                          | `OAuth`  | Yes   | Unknown |
+| [Genrenator](https://binaryjazz.us/genrenator-api/)                              | Music genre generator                                                                            | No       | Yes   | Unknown |
+| [Jamendo](https://developer.jamendo.com/v3.0/docs)                               | Music                                                                                            | `OAuth`  | Yes   | Unknown |
+| [JioSaavn](https://github.com/cyberboysumanjay/JioSaavnAPI)                      | API to retrieve song information, album meta data and many more from JioSaavn                    | No       | Yes   | Unknown |
+| [KKBOX](https://developer.kkbox.com)                                             | Get music libraries, playlists, charts, and perform out of KKBOX's platform                      | `OAuth`  | Yes   | Unknown |
+| [LastFm](https://www.last.fm/api)                                                | Music                                                                                            | `apiKey` | Yes   | Unknown |
+| [Mixcloud](https://www.mixcloud.com/developers/)                                 | Music                                                                                            | `OAuth`  | Yes   | Yes     |
+| [MusicBrainz](https://musicbrainz.org/doc/Development/XML_Web_Service/Version_2) | Music                                                                                            | No       | Yes   | Unknown |
+| [Musixmatch](https://developer.musixmatch.com/)                                  | Music                                                                                            | `apiKey` | Yes   | Unknown |
+| [Napster](https://developer.napster.com/api/v2.2)                                | Music                                                                                            | `apiKey` | Yes   | Yes     |
+| [Openwhyd](https://openwhyd.github.io/openwhyd/API)                              | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...)                     | No       | Yes   | No      |
+| [Phishin](https://phish.in/api-docs)                                             | A web-based archive of legal live audio recordings of the improvisational rock band Phish        | `apiKey` | Yes   | No      |
+| [Radio Browser](https://api.radio-browser.info/)                                 | List of internet radio stations                                                                  | No       | Yes   | Yes     |
+| [Songkick](https://www.songkick.com/developer/)                                  | Music Events                                                                                     | `apiKey` | Yes   | Unknown |
+| [Songlink / Odesli](https://www.notion.so/API-d0ebe08a5e304a55928405eb682f6741)  | Get all the services on which a song is available                                                | `apiKey` | Yes   | Yes     |
+| [SoundCloud](https://developers.soundcloud.com/docs/api/guide)                   | With SoundCloud API you can build applications that will give more power to control your content | `OAuth`  | Yes   | Unknown |
+| [Spotify](https://beta.developer.spotify.com/documentation/web-api/)             | View Spotify music catalog, manage users' libraries, get recommendations and more                | `OAuth`  | Yes   | Unknown |
+| [TasteDive](https://tastedive.com/read/api)                                      | Similar artist API (also works for movies and TV shows)                                          | `apiKey` | Yes   | Unknown |
+| [TheAudioDB](https://www.theaudiodb.com/api_guide.php)                           | Music                                                                                            | `apiKey` | Yes   | Unknown |
+| [Vagalume](https://api.vagalume.com.br/docs/)                                    | Crowdsourced lyrics and music knowledge                                                          | `apiKey` | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### News
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Yes | Unknown |
-| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | No | Unknown |
-| [Currents](https://currentsapi.services/) | Latest news published in various news sources, blogs and forums | `apiKey` | Yes | Yes |
-| [Feedbin](https://github.com/feedbin/feedbin-api) | RSS reader | `OAuth`| Yes | Unknown |
-| [GNews](https://gnews.io/) | Search for news from various sources | `apiKey` | Yes | Yes |
-| [HackerNews Node](https://github.com/EdixonAlberto/api-hackernews-node) | Api to get related articles about Node.js in Hacker News | `apiKey` | Yes | No |
-| [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API) | Provides news from inshorts | No | Yes | Unknown |
-| [MarketAux](https://www.marketaux.com/) | Live stock market news with tagged tickers + sentiment and stats JSON API | `apiKey` | Yes | Yes |
-| [New York Times](https://developer.nytimes.com/) | The New York Times Developer Network | `apiKey` | Yes | Unknown |
-| [News](https://newsapi.org/) | Headlines currently published on a range of news sources and blogs | `apiKey` | Yes | Unknown |
-| [NewsAPI.ai](https://www.newsapi.ai/documentation) | News API access to real-time and archive news content | `apiKey` | Yes | Yes |
-| [NewsData](https://newsdata.io/docs) | News data API for live-breaking news and headlines from reputed news sources | `apiKey` | Yes | Unknown |
-| [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖| `apiKey` | Yes | Unknown |
-| [Spaceflight News](https://spaceflightnewsapi.net) | Spaceflight related news 🚀| No | Yes | Yes |
-| [Substack API Wrapper](https://github.com/NHagar/substack_api) | Substack's newsletter platform now has an API wrapper, for easy access to latest posts | `No` | Yes | Unknown |
-| [The Guardian](http://open-platform.theguardian.com/) | Access all the content the Guardian creates, categorised by tags and section | `apiKey` | Yes | Unknown |
-| [The Old Reader](https://github.com/theoldreader/api) | RSS reader | `apiKey` | Yes | Unknown |
-| [TheNews](https://www.thenewsapi.com/) | Aggregated headlines, top story and live news JSON API | `apiKey` | Yes | Yes |
-| [Trove](https://trove.nla.gov.au/about/create-something/using-api) | Search through the National Library of Australia collection of 1000s of digitised newspapers | `apiKey` | Yes | Unknown |
-| [World News](https://worldnewsapi.com) | Search through millions of semantically tagged worldwide news | `apiKey` | Yes | Yes |
+
+| API                                                                      | Description                                                                                  | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Associated Press](https://developer.ap.org/)                            | Search for news and metadata from Associated Press                                           | `apiKey` | Yes   | Unknown |
+| [Chronicling America](http://chroniclingamerica.loc.gov/about/api/)      | Provides access to millions of pages of historic US newspapers from the Library of Congress  | No       | No    | Unknown |
+| [Currents](https://currentsapi.services/)                                | Latest news published in various news sources, blogs and forums                              | `apiKey` | Yes   | Yes     |
+| [Feedbin](https://github.com/feedbin/feedbin-api)                        | RSS reader                                                                                   | `OAuth`  | Yes   | Unknown |
+| [GNews](https://gnews.io/)                                               | Search for news from various sources                                                         | `apiKey` | Yes   | Yes     |
+| [HackerNews Node](https://github.com/EdixonAlberto/api-hackernews-node)  | Api to get related articles about Node.js in Hacker News                                     | `apiKey` | Yes   | No      |
+| [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API)   | Provides news from inshorts                                                                  | No       | Yes   | Unknown |
+| [MarketAux](https://www.marketaux.com/)                                  | Live stock market news with tagged tickers + sentiment and stats JSON API                    | `apiKey` | Yes   | Yes     |
+| [New York Times](https://developer.nytimes.com/)                         | The New York Times Developer Network                                                         | `apiKey` | Yes   | Unknown |
+| [News](https://newsapi.org/)                                             | Headlines currently published on a range of news sources and blogs                           | `apiKey` | Yes   | Unknown |
+| [NewsAPI.ai](https://www.newsapi.ai/documentation)                       | News API access to real-time and archive news content                                        | `apiKey` | Yes   | Yes     |
+| [NewsData](https://newsdata.io/docs)                                     | News data API for live-breaking news and headlines from reputed news sources                 | `apiKey` | Yes   | Unknown |
+| [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖                              | `apiKey` | Yes   | Unknown |
+| [Spaceflight News](https://spaceflightnewsapi.net)                       | Spaceflight related news 🚀                                                                  | No       | Yes   | Yes     |
+| [Substack API Wrapper](https://github.com/NHagar/substack_api)           | Substack's newsletter platform now has an API wrapper, for easy access to latest posts       | `No`     | Yes   | Unknown |
+| [The Guardian](http://open-platform.theguardian.com/)                    | Access all the content the Guardian creates, categorised by tags and section                 | `apiKey` | Yes   | Unknown |
+| [The Old Reader](https://github.com/theoldreader/api)                    | RSS reader                                                                                   | `apiKey` | Yes   | Unknown |
+| [TheNews](https://www.thenewsapi.com/)                                   | Aggregated headlines, top story and live news JSON API                                       | `apiKey` | Yes   | Yes     |
+| [Trove](https://trove.nla.gov.au/about/create-something/using-api)       | Search through the National Library of Australia collection of 1000s of digitised newspapers | `apiKey` | Yes   | Unknown |
+| [World News](https://worldnewsapi.com)                                   | Search through millions of semantically tagged worldwide news                                | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Open Data
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [18F](http://18f.github.io/API-All-the-X/) | Unofficial US Federal Government API Development | No | No | Unknown |
-| [Archive.org](https://archive.readme.io/docs) | The Internet Archive | No | Yes | No |
-| [ArgentinaDatos](https://argentinadatos.com/) | Unofficial Argentinian data API | No | Yes | Yes |
-| [Black History Facts](https://www.blackhistoryapi.io/docs) | Contribute or search one of the largest black history fact databases on the web | `apiKey` | Yes | Yes |
-| [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
-| [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
-| [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
-| [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
-| [DataStream](https://github.com/datastreamapp/api-docs) | An open access platform for sharing Canadian water quality data | `apiKey` | Yes | Yes |
-| [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
-| [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |
-| [Generate Link Preview (including checking for malicious links)](https://apyhub.com/utility/link-preview) | Fetches metadata from any URL passed to it, including Open Graph tags. | `apiKey` | Yes | Yes |
-| [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html) | Federal Statistical Office Germany | `OAuth`| Yes | Unknown |
-| [Joshua Project](https://api.joshuaproject.net/) | People groups of the world with the fewest followers of Christ | `apiKey` | Yes | Unknown |
-| [Kaggle](https://www.kaggle.com/docs/api) | Create and interact with Datasets, Notebooks, and connect with Kaggle | `apiKey` | Yes | Unknown |
-| [LinkPreview](https://www.linkpreview.net) | Get JSON formatted summary with title, description and preview image for any requested URL | `apiKey` | Yes | Yes |
-| [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs) | Get measure resources and influence to rank the relative power of states in Asia | No | Yes | Unknown |
-| [Microlink.io](https://microlink.io) | Extract structured data from any website | No | Yes | Yes |
-| [Nasdaq Data Link](https://docs.data.nasdaq.com/) | Stock market data | `apiKey` | Yes | Unknown |
-| [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/) | Open data about nobel prizes and events | No | Yes | Yes |
-| [Open Data Minneapolis](https://opendata.minneapolismn.gov/) | Spatial (GIS) and non-spatial city data for Minneapolis | No | Yes | No |
-| [openAFRICA](https://africaopendata.org/) | Large datasets repository of African open data | No | Yes | Unknown |
-| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Yes | Unknown |
-| [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes | Yes |
-| [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Yes | Unknown |
-| [Scoop.it](http://www.scoop.it/dev) | Content Curation Service | `apiKey` | No | Unknown |
-| [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth`| Yes | Yes |
-| [Sofiaplan](https://sofiaplan.bg/api/) | Access to urban research data for the Bulgarian capital Sofia | No | Yes | Yes |
-| [Umeå Open Data](https://opendata.umea.se/api/) | Open data of the city Umeå in northern Sweden | No | Yes | Yes |
-| [UniDb](https://unidbapi.com) | Data that helps people gain useful insight into universities in the United Kingdom | `apiKey` | Yes | Yes |
-| [Universities List](https://github.com/Hipo/university-domains-list) | University names, countries and domains | No | Yes | Unknown |
-| [University of Oslo](https://data.uio.no/) | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No | Yes | Unknown |
-| [UPC database](https://upcdatabase.org/api) | More than 1.5 million barcode numbers from all around the world | `apiKey` | Yes | Unknown |
-| [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
-| [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth`| Yes | Unknown |
-| [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
-| [Yelp](https://www.yelp.com/developers) | Find Local Business | `OAuth`| Yes | Unknown |
+
+| API                                                                                                       | Description                                                                                        | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [18F](http://18f.github.io/API-All-the-X/)                                                                | Unofficial US Federal Government API Development                                                   | No       | No    | Unknown |
+| [Archive.org](https://archive.readme.io/docs)                                                             | The Internet Archive                                                                               | No       | Yes   | No      |
+| [ArgentinaDatos](https://argentinadatos.com/)                                                             | Unofficial Argentinian data API                                                                    | No       | Yes   | Yes     |
+| [Black History Facts](https://www.blackhistoryapi.io/docs)                                                | Contribute or search one of the largest black history fact databases on the web                    | `apiKey` | Yes   | Yes     |
+| [BotsArchive](https://botsarchive.com/docs.html)                                                          | JSON formatted details about Telegram Bots available in database                                   | No       | Yes   | Unknown |
+| [Callook.info](https://callook.info)                                                                      | United States ham radio callsigns                                                                  | No       | Yes   | Unknown |
+| [CARTO](https://carto.com/)                                                                               | Location Information Prediction                                                                    | `apiKey` | Yes   | Unknown |
+| [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/)                                          | Data on higher education institutions in the United States                                         | No       | Yes   | Unknown |
+| [DataStream](https://github.com/datastreamapp/api-docs)                                                   | An open access platform for sharing Canadian water quality data                                    | `apiKey` | Yes   | Yes     |
+| [Enigma Public](https://developers.enigma.com/docs)                                                       | Broadest collection of public data                                                                 | `apiKey` | Yes   | Yes     |
+| [French Address Search](https://geo.api.gouv.fr/adresse)                                                  | Address search via the French Government                                                           | No       | Yes   | Unknown |
+| [Generate Link Preview (including checking for malicious links)](https://apyhub.com/utility/link-preview) | Fetches metadata from any URL passed to it, including Open Graph tags.                             | `apiKey` | Yes   | Yes     |
+| [GENESIS](https://www.destatis.de/EN/Service/OpenData/api-webservice.html)                                | Federal Statistical Office Germany                                                                 | `OAuth`  | Yes   | Unknown |
+| [Joshua Project](https://api.joshuaproject.net/)                                                          | People groups of the world with the fewest followers of Christ                                     | `apiKey` | Yes   | Unknown |
+| [Kaggle](https://www.kaggle.com/docs/api)                                                                 | Create and interact with Datasets, Notebooks, and connect with Kaggle                              | `apiKey` | Yes   | Unknown |
+| [LinkPreview](https://www.linkpreview.net)                                                                | Get JSON formatted summary with title, description and preview image for any requested URL         | `apiKey` | Yes   | Yes     |
+| [Lowy Asia Power Index](https://github.com/0x0is1/lowy-index-api-docs)                                    | Get measure resources and influence to rank the relative power of states in Asia                   | No       | Yes   | Unknown |
+| [Microlink.io](https://microlink.io)                                                                      | Extract structured data from any website                                                           | No       | Yes   | Yes     |
+| [Nasdaq Data Link](https://docs.data.nasdaq.com/)                                                         | Stock market data                                                                                  | `apiKey` | Yes   | Unknown |
+| [Nobel Prize](https://www.nobelprize.org/about/developer-zone-2/)                                         | Open data about nobel prizes and events                                                            | No       | Yes   | Yes     |
+| [Open Data Minneapolis](https://opendata.minneapolismn.gov/)                                              | Spatial (GIS) and non-spatial city data for Minneapolis                                            | No       | Yes   | No      |
+| [openAFRICA](https://africaopendata.org/)                                                                 | Large datasets repository of African open data                                                     | No       | Yes   | Unknown |
+| [OpenCorporates](http://api.opencorporates.com/documentation/API-Reference)                               | Data on corporate entities and directors in many countries                                         | `apiKey` | Yes   | Unknown |
+| [OpenSanctions](https://www.opensanctions.org/docs/api/)                                                  | Data on international sanctions, crime and politically exposed persons                             | No       | Yes   | Yes     |
+| [Recreation Information Database](https://ridb.recreation.gov/)                                           | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US)    | `apiKey` | Yes   | Unknown |
+| [Scoop.it](http://www.scoop.it/dev)                                                                       | Content Curation Service                                                                           | `apiKey` | No    | Unknown |
+| [Socrata](https://dev.socrata.com/)                                                                       | Access to Open Data from Governments, Non-profits and NGOs around the world                        | `OAuth`  | Yes   | Yes     |
+| [Sofiaplan](https://sofiaplan.bg/api/)                                                                    | Access to urban research data for the Bulgarian capital Sofia                                      | No       | Yes   | Yes     |
+| [Umeå Open Data](https://opendata.umea.se/api/)                                                           | Open data of the city Umeå in northern Sweden                                                      | No       | Yes   | Yes     |
+| [UniDb](https://unidbapi.com)                                                                             | Data that helps people gain useful insight into universities in the United Kingdom                 | `apiKey` | Yes   | Yes     |
+| [Universities List](https://github.com/Hipo/university-domains-list)                                      | University names, countries and domains                                                            | No       | Yes   | Unknown |
+| [University of Oslo](https://data.uio.no/)                                                                | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No       | Yes   | Unknown |
+| [UPC database](https://upcdatabase.org/api)                                                               | More than 1.5 million barcode numbers from all around the world                                    | `apiKey` | Yes   | Unknown |
+| [Urban Observatory](https://urbanobservatory.ac.uk)                                                       | The largest set of publicly available real time urban data in the UK                               | No       | No    | No      |
+| [Wikidata](https://www.wikidata.org/w/api.php?action=help)                                                | Collaboratively edited knowledge base operated by the Wikimedia Foundation                         | `OAuth`  | Yes   | Unknown |
+| [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page)                                                 | Mediawiki Encyclopedia                                                                             | No       | Yes   | Unknown |
+| [Yelp](https://www.yelp.com/developers)                                                                   | Find Local Business                                                                                | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Open Source Projects
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Countly](https://api.count.ly/reference) | Countly web analytics | No | No | Unknown |
-| [Creative Commons Catalog](https://api.creativecommons.engineering/) | Search among openly licensed and public domain works | `OAuth` | Yes | Yes |
-| [Datamuse](https://www.datamuse.com/api/) | Word-finding query engine | No | Yes | Unknown |
-| [Drupal.org](https://www.drupal.org/drupalorg/docs/api) | Drupal.org | No | Yes | Unknown |
-| [Evil Insult Generator](https://evilinsult.com/api) | Evil Insults | No | Yes | Yes |
-| [GitHub Contribution Chart Generator](https://github-contributions.vercel.app) | Create an image of your GitHub contributions | No | Yes | Yes |
-| [GitHub ReadMe Stats](https://github.com/anuraghazra/github-readme-stats) | Add dynamically generated statistics to your GitHub profile ReadMe | No | Yes | Yes |
-| [Metabase](https://www.metabase.com/) | An open source Business Intelligence server to share data and analytics inside your company | No | Yes | Yes |
-| [Shields](https://shields.io/) | Concise, consistent, and legible badges in SVG and raster format | No | Yes | Unknown |
+
+| API                                                                            | Description                                                                                 | Auth    | HTTPS | CORS    |
+| ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | ------- | ----- | ------- |
+| [Countly](https://api.count.ly/reference)                                      | Countly web analytics                                                                       | No      | No    | Unknown |
+| [Creative Commons Catalog](https://api.creativecommons.engineering/)           | Search among openly licensed and public domain works                                        | `OAuth` | Yes   | Yes     |
+| [Datamuse](https://www.datamuse.com/api/)                                      | Word-finding query engine                                                                   | No      | Yes   | Unknown |
+| [Drupal.org](https://www.drupal.org/drupalorg/docs/api)                        | Drupal.org                                                                                  | No      | Yes   | Unknown |
+| [Evil Insult Generator](https://evilinsult.com/api)                            | Evil Insults                                                                                | No      | Yes   | Yes     |
+| [GitHub Contribution Chart Generator](https://github-contributions.vercel.app) | Create an image of your GitHub contributions                                                | No      | Yes   | Yes     |
+| [GitHub ReadMe Stats](https://github.com/anuraghazra/github-readme-stats)      | Add dynamically generated statistics to your GitHub profile ReadMe                          | No      | Yes   | Yes     |
+| [Metabase](https://www.metabase.com/)                                          | An open source Business Intelligence server to share data and analytics inside your company | No      | Yes   | Yes     |
+| [Shields](https://shields.io/)                                                 | Concise, consistent, and legible badges in SVG and raster format                            | No      | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Patent
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [EPO](https://developers.epo.org/) | European patent search system api | `OAuth`| Yes | Unknown |
-| [PatentsView ](https://patentsview.org/apis/purpose) | API is intended to explore and visualize trends/patterns across the US innovation landscape | No | Yes | Unknown |
-| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api | `apiKey` | Yes | Unknown |
-| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility) | USA patent api services | No | Yes | Unknown |
+
+| API                                                                           | Description                                                                                 | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [EPO](https://developers.epo.org/)                                            | European patent search system api                                                           | `OAuth`  | Yes   | Unknown |
+| [PatentsView ](https://patentsview.org/apis/purpose)                          | API is intended to explore and visualize trends/patterns across the US innovation landscape | No       | Yes   | Unknown |
+| [TIPO](https://tiponet.tipo.gov.tw/Gazette/OpenData/OD/OD05.aspx?QryDS=API00) | Taiwan patent search system api                                                             | `apiKey` | Yes   | Unknown |
+| [USPTO](https://www.uspto.gov/learning-and-resources/open-data-and-mobility)  | USA patent api services                                                                     | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Personality
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Advice Slip](http://api.adviceslip.com/) | Generate random advice slips | No | Yes | Unknown |
-| [Dev.to](https://developers.forem.com/api) | Access Forem articles, users and other resources via API | `apiKey` | Yes | Unknown |
-| [Dictum](https://github.com/fisenkodv/dictum) | API to get access to the collection of the most inspiring expressions of mankind | No | Yes | Unknown |
-| [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Yes | Unknown |
-| [Forismatic](http://forismatic.com/en/api/) | Inspirational Quotes | No | No | Unknown |
-| [icanhazdadjoke](https://icanhazdadjoke.com/api) | The largest selection of dad jokes on the internet | No | Yes | Unknown |
-| [kanye.rest](https://kanye.rest) | REST API for random Kanye West quotes | No | Yes | Yes |
-| [kimiquotes](https://kimiquotes.pages.dev/docs) | Team radio and interview quotes by Finnish F1 legend Kimi Räikkönen | No | Yes | Yes |
-| [Medium](https://github.com/Medium/medium-api-docs) | Community of readers and writers offering unique perspectives on ideas | `OAuth`| Yes | Unknown |
-| [Programming Quotes](https://github.com/skolakoda/programming-quotes-api) | Programming Quotes API for open source projects | No | Yes | Unknown |
-| [Quotable Quotes](https://github.com/lukePeavey/quotable) | Quotable is a free, open source quotations API | No | Yes | Unknown |
-| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/) | REST API for more than 5000 famous quotes | No | Yes | Unknown |
-| [Quotes on Design](https://quotesondesign.com/api/) | Inspirational Quotes | No | Yes | Unknown |
-| [Stoicism Quote](https://github.com/tlcheah2/stoic-quote-lambda-public-api) | Quotes about Stoicism | No | Yes | Unknown |
-| [They Said So Quotes](https://theysaidso.com/api/) | Quotes Trusted by many fortune brands around the world | No | Yes | Unknown |
-| [Traitify](https://app.traitify.com/developer) | Assess, collect and analyze Personality | No | Yes | Unknown |
-| [Udemy(instructor)](https://www.udemy.com/developers/instructor/) | API for instructors on Udemy | `apiKey` | Yes | Unknown |
-| [Vadivelu HTTP Codes](https://vadivelu.anoram.com/) | On demand HTTP Codes with images | No | Yes | No |
-| [Zen Quotes](https://zenquotes.io/) | Large collection of Zen quotes for inspiration | No | Yes | Yes |
+
+| API                                                                         | Description                                                                      | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Advice Slip](http://api.adviceslip.com/)                                   | Generate random advice slips                                                     | No       | Yes   | Unknown |
+| [Dev.to](https://developers.forem.com/api)                                  | Access Forem articles, users and other resources via API                         | `apiKey` | Yes   | Unknown |
+| [Dictum](https://github.com/fisenkodv/dictum)                               | API to get access to the collection of the most inspiring expressions of mankind | No       | Yes   | Unknown |
+| [FavQs.com](https://favqs.com/api)                                          | FavQs allows you to collect, discover and share your favorite quotes             | `apiKey` | Yes   | Unknown |
+| [Forismatic](http://forismatic.com/en/api/)                                 | Inspirational Quotes                                                             | No       | No    | Unknown |
+| [icanhazdadjoke](https://icanhazdadjoke.com/api)                            | The largest selection of dad jokes on the internet                               | No       | Yes   | Unknown |
+| [kanye.rest](https://kanye.rest)                                            | REST API for random Kanye West quotes                                            | No       | Yes   | Yes     |
+| [kimiquotes](https://kimiquotes.pages.dev/docs)                             | Team radio and interview quotes by Finnish F1 legend Kimi Räikkönen              | No       | Yes   | Yes     |
+| [Medium](https://github.com/Medium/medium-api-docs)                         | Community of readers and writers offering unique perspectives on ideas           | `OAuth`  | Yes   | Unknown |
+| [Programming Quotes](https://github.com/skolakoda/programming-quotes-api)   | Programming Quotes API for open source projects                                  | No       | Yes   | Unknown |
+| [Quotable Quotes](https://github.com/lukePeavey/quotable)                   | Quotable is a free, open source quotations API                                   | No       | Yes   | Unknown |
+| [Quote Garden](https://pprathameshmore.github.io/QuoteGarden/)              | REST API for more than 5000 famous quotes                                        | No       | Yes   | Unknown |
+| [Quotes on Design](https://quotesondesign.com/api/)                         | Inspirational Quotes                                                             | No       | Yes   | Unknown |
+| [Stoicism Quote](https://github.com/tlcheah2/stoic-quote-lambda-public-api) | Quotes about Stoicism                                                            | No       | Yes   | Unknown |
+| [They Said So Quotes](https://theysaidso.com/api/)                          | Quotes Trusted by many fortune brands around the world                           | No       | Yes   | Unknown |
+| [Traitify](https://app.traitify.com/developer)                              | Assess, collect and analyze Personality                                          | No       | Yes   | Unknown |
+| [Udemy(instructor)](https://www.udemy.com/developers/instructor/)           | API for instructors on Udemy                                                     | `apiKey` | Yes   | Unknown |
+| [Vadivelu HTTP Codes](https://vadivelu.anoram.com/)                         | On demand HTTP Codes with images                                                 | No       | Yes   | No      |
+| [Zen Quotes](https://zenquotes.io/)                                         | Large collection of Zen quotes for inspiration                                   | No       | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Phone
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Abstract Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
-| [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
-| [NumlookupAPI](https://numlookupapi.com) | Worldwide Phone Number Lookup & Verification API | `apiKey` | Yes | Yes |
-| [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
-| [Proweblook Phone Number Checker](https://proweblook.com/phone-number-validator) | Phone number validation | `apiKey` | Yes | Yes |
-| [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes | Yes |
-| [Proweblook Whatsapp Contact Checker](https://proweblook.com/whatsapp-number-checker) | Whatsapp number validation | `apiKey` | Yes | Yes |
+
+| API                                                                                   | Description                                      | Auth     | HTTPS | CORS |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------ | -------- | ----- | ---- |
+| [Abstract Phone Validation](https://www.abstractapi.com/phone-validation-api)         | Validate phone numbers globally                  | `apiKey` | Yes   | Yes  |
+| [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API)         | Validate international phone numbers             | `apiKey` | Yes   | Yes  |
+| [NumlookupAPI](https://numlookupapi.com)                                              | Worldwide Phone Number Lookup & Verification API | `apiKey` | Yes   | Yes  |
+| [Phone Specification](https://github.com/azharimm/phone-specs-api)                    | Rest Api for Phone specifications                | No       | Yes   | Yes  |
+| [Proweblook Phone Number Checker](https://proweblook.com/phone-number-validator)      | Phone number validation                          | `apiKey` | Yes   | Yes  |
+| [Veriphone](https://veriphone.io)                                                     | Phone number validation & carrier lookup         | `apiKey` | Yes   | Yes  |
+| [Proweblook Whatsapp Contact Checker](https://proweblook.com/whatsapp-number-checker) | Whatsapp number validation                       | `apiKey` | Yes   | Yes  |
 
 **[⬆ Back to Index](#index)**
 
 ### Photography
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [APITemplate.io](https://apitemplate.io) | Dynamically generate images and PDFs from templates with a simple API | `apiKey` | Yes | Yes |
-| [CheetahO](https://cheetaho.com/docs/getting-started) | Photo optimization and resize | `apiKey` | Yes | Unknown |
-| [Dagpi](https://dagpi.xyz) | Image manipulation and processing | `apiKey` | Yes | Unknown |
-| [Duply](https://app.duply.co/docs) | Generate, Edit, Scale and Manage Images and Videos Smarter & Faster | `apiKey` | Yes | Yes |
-| [DynaPictures](https://dynapictures.com/docs/) | Generate Hundreds of Personalized Images in Minutes | `apiKey` | Yes | Yes |
-| [Flickr](https://www.flickr.com/services/api/) | Flickr Services | `OAuth`| Yes | Unknown |
-| [Getty Images](http://developers.gettyimages.com/en/) | Build applications using the world's most powerful imagery | `OAuth`| Yes | Unknown |
-| [Giphy](https://developers.giphy.com/docs/) | Get all your gifs | `apiKey` | Yes | Unknown |
-| [Google Photos](https://developers.google.com/photos) | Integrate Google Photos with your apps or devices | `OAuth`| Yes | Unknown |
-| [Imgur](https://apidocs.imgur.com/) | Images | `OAuth`| Yes | Unknown |
-| [Lorem Picsum](https://picsum.photos/) | Images from Unsplash | No | Yes | Unknown |
-| [ObjectCut](https://objectcut.com/) | Image Background removal | `apiKey` | Yes | Yes |
-| [Pexels](https://www.pexels.com/api) | Free Stock Photos and Videos | `apiKey` | Yes | Yes |
-| [PhotoRoom](https://www.photoroom.com/api/) | Remove background from images | `apiKey` | Yes | Unknown |
-| [Pixabay](https://pixabay.com/sk/service/about/api/) | Photography | `apiKey` | Yes | Unknown |
-| [PlaceKeanu](https://placekeanu.com/) | Resizable Keanu Reeves placeholder images with grayscale and young Keanu options | No | Yes | Unknown |
-| [Readme typing SVG](https://github.com/DenverCoder1/readme-typing-svg) | Customizable typing and deleting text SVG | No | Yes | Unknown |
-| [Remove.bg](https://www.remove.bg/api) | Image Background removal | `apiKey` | Yes | Unknown |
-| [ReSmush.it](https://resmush.it/api) | Photo optimization | No | No | Unknown |
-| [shutterstock](https://api-reference.shutterstock.com/) | Stock Photos and Videos | `OAuth`| Yes | Unknown |
-| [Sirv](https://apidocs.sirv.com/) | Image management solutions like optimization, manipulation, hosting | `apiKey` | Yes | Unknown |
-| [Templated](https://templated.io) | Generate images and PDFs with a simple API. Design in a Canva-like editor and render images with code | `apiKey` | Yes | Yes |
-| [Unsplash](https://unsplash.com/developers) | Photography | `OAuth`| Yes | Unknown |
-| [Wallhaven](https://wallhaven.cc/help/api) | Wallpapers | `apiKey` | Yes | Unknown |
-| [Webdam](https://www.damsuccess.com/hc/en-us/articles/202134055-REST-API) | Images | `OAuth`| Yes | Unknown |
+
+| API                                                                       | Description                                                                                           | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [APITemplate.io](https://apitemplate.io)                                  | Dynamically generate images and PDFs from templates with a simple API                                 | `apiKey` | Yes   | Yes     |
+| [CheetahO](https://cheetaho.com/docs/getting-started)                     | Photo optimization and resize                                                                         | `apiKey` | Yes   | Unknown |
+| [Dagpi](https://dagpi.xyz)                                                | Image manipulation and processing                                                                     | `apiKey` | Yes   | Unknown |
+| [Duply](https://app.duply.co/docs)                                        | Generate, Edit, Scale and Manage Images and Videos Smarter & Faster                                   | `apiKey` | Yes   | Yes     |
+| [DynaPictures](https://dynapictures.com/docs/)                            | Generate Hundreds of Personalized Images in Minutes                                                   | `apiKey` | Yes   | Yes     |
+| [Flickr](https://www.flickr.com/services/api/)                            | Flickr Services                                                                                       | `OAuth`  | Yes   | Unknown |
+| [Getty Images](http://developers.gettyimages.com/en/)                     | Build applications using the world's most powerful imagery                                            | `OAuth`  | Yes   | Unknown |
+| [Giphy](https://developers.giphy.com/docs/)                               | Get all your gifs                                                                                     | `apiKey` | Yes   | Unknown |
+| [Google Photos](https://developers.google.com/photos)                     | Integrate Google Photos with your apps or devices                                                     | `OAuth`  | Yes   | Unknown |
+| [Imgur](https://apidocs.imgur.com/)                                       | Images                                                                                                | `OAuth`  | Yes   | Unknown |
+| [Lorem Picsum](https://picsum.photos/)                                    | Images from Unsplash                                                                                  | No       | Yes   | Unknown |
+| [ObjectCut](https://objectcut.com/)                                       | Image Background removal                                                                              | `apiKey` | Yes   | Yes     |
+| [Pexels](https://www.pexels.com/api)                                      | Free Stock Photos and Videos                                                                          | `apiKey` | Yes   | Yes     |
+| [PhotoRoom](https://www.photoroom.com/api/)                               | Remove background from images                                                                         | `apiKey` | Yes   | Unknown |
+| [Pixabay](https://pixabay.com/sk/service/about/api/)                      | Photography                                                                                           | `apiKey` | Yes   | Unknown |
+| [PlaceKeanu](https://placekeanu.com/)                                     | Resizable Keanu Reeves placeholder images with grayscale and young Keanu options                      | No       | Yes   | Unknown |
+| [Readme typing SVG](https://github.com/DenverCoder1/readme-typing-svg)    | Customizable typing and deleting text SVG                                                             | No       | Yes   | Unknown |
+| [Remove.bg](https://www.remove.bg/api)                                    | Image Background removal                                                                              | `apiKey` | Yes   | Unknown |
+| [ReSmush.it](https://resmush.it/api)                                      | Photo optimization                                                                                    | No       | No    | Unknown |
+| [shutterstock](https://api-reference.shutterstock.com/)                   | Stock Photos and Videos                                                                               | `OAuth`  | Yes   | Unknown |
+| [Sirv](https://apidocs.sirv.com/)                                         | Image management solutions like optimization, manipulation, hosting                                   | `apiKey` | Yes   | Unknown |
+| [Templated](https://templated.io)                                         | Generate images and PDFs with a simple API. Design in a Canva-like editor and render images with code | `apiKey` | Yes   | Yes     |
+| [Unsplash](https://unsplash.com/developers)                               | Photography                                                                                           | `OAuth`  | Yes   | Unknown |
+| [Wallhaven](https://wallhaven.cc/help/api)                                | Wallpapers                                                                                            | `apiKey` | Yes   | Unknown |
+| [Webdam](https://www.damsuccess.com/hc/en-us/articles/202134055-REST-API) | Images                                                                                                | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Podcasts
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [iTunes](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI/index.html#//apple_ref/doc/uid/TP40017632-CH3-SW1) | Apple Podcasts Directory | No | Yes | Unknown |
-| [PodcastIndex](https://podcastindex-org.github.io/docs-api/) | Get details on podcasts & episodes, Podcast Search | `apiKey`| Yes | Unknown |
-| [Spotify](https://developer.spotify.com/documentation/web-api/) | Get details on podcasts & episodes | `OAuth` | Yes | Unknown |
-| [Taddy Podcasts](https://taddy.org/developers/podcast-api) | Get details on podcasts & episodes, Podcast & Episode Search, Webhook notifications | `apiKey` | Yes | Yes |
+
+| API                                                                                                                                                        | Description                                                                         | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [iTunes](https://developer.apple.com/library/archive/documentation/AudioVideo/Conceptual/iTuneSearchAPI/index.html#//apple_ref/doc/uid/TP40017632-CH3-SW1) | Apple Podcasts Directory                                                            | No       | Yes   | Unknown |
+| [PodcastIndex](https://podcastindex-org.github.io/docs-api/)                                                                                               | Get details on podcasts & episodes, Podcast Search                                  | `apiKey` | Yes   | Unknown |
+| [Spotify](https://developer.spotify.com/documentation/web-api/)                                                                                            | Get details on podcasts & episodes                                                  | `OAuth`  | Yes   | Unknown |
+| [Taddy Podcasts](https://taddy.org/developers/podcast-api)                                                                                                 | Get details on podcasts & episodes, Podcast & Episode Search, Webhook notifications | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Programming
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Codeforces](https://codeforces.com/apiHelp) | Get access to Codeforces data | `apiKey` | Yes | Unknown |
-| [Hackerearth](https://www.hackerearth.com/docs/wiki/developers/v4) | For compiling and running code in several languages | `apiKey` | Yes | Unknown |
-| [Judge0 CE](https://ce.judge0.com/) | Online code execution system | `apiKey` | Yes | Unknown |
-| [Let's Count](https://letscountapi.com) | Create, retrieve, update, increment, and decrement counters identified by namespace and key | No | Yes | Unknown |
-| [Pythonium](https://pythonium.net/linter) | Validate Python code syntax | No | Yes | No |
-| [Softwium](https://softwium.com/sql-validator/) | Validate SQL queries | No | Yes | No |
-| [Volca](https://volca.io#api) | List of programming languages and technologies | No | Yes | Unknown |
+
+| API                                                                | Description                                                                                 | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Codeforces](https://codeforces.com/apiHelp)                       | Get access to Codeforces data                                                               | `apiKey` | Yes   | Unknown |
+| [Hackerearth](https://www.hackerearth.com/docs/wiki/developers/v4) | For compiling and running code in several languages                                         | `apiKey` | Yes   | Unknown |
+| [Judge0 CE](https://ce.judge0.com/)                                | Online code execution system                                                                | `apiKey` | Yes   | Unknown |
+| [Let's Count](https://letscountapi.com)                            | Create, retrieve, update, increment, and decrement counters identified by namespace and key | No       | Yes   | Unknown |
+| [Pythonium](https://pythonium.net/linter)                          | Validate Python code syntax                                                                 | No       | Yes   | No      |
+| [Softwium](https://softwium.com/sql-validator/)                    | Validate SQL queries                                                                        | No       | Yes   | No      |
+| [Volca](https://volca.io#api)                                      | List of programming languages and technologies                                              | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Science & Math
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [arcsecond.io](https://api.arcsecond.io/) | Multiple astronomy data sources | `apiKey` | Yes | Unknown |
-| [arXiv](https://arxiv.org/help/api) | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No | Yes | Unknown |
-| [CORE](https://core.ac.uk/services#api) | Access the world's Open Access research papers | `apiKey` | Yes | Unknown |
-| [GBIF](https://www.gbif.org/developer/summary) | Global Biodiversity Information Facility | No | Yes | Yes |
-| [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki) | Access millions of museum specimens from organizations around the world | No | Yes | Unknown |
-| [inspirehep.net](https://github.com/inspirehep/rest-api-doc) | High Energy Physics info. system | No | Yes | Unknown |
-| [isEven (humor)](https://isevenapi.xyz/) | Check if a number is even | No | Yes | Unknown |
-| [ISRO](https://isro.vercel.app) | ISRO Space Crafts Information | No | Yes | No |
-| [ISRO Statistics](https://isrostats.in/apis) | ISRO Launches and Spacecrafts details | No | Yes | Yes |
-| [ITIS](https://www.itis.gov/ws_description.html) | Integrated Taxonomic Information System | No | Yes | Unknown |
-| [Launch Library 2](https://thespacedevs.com/llapi) | Spaceflight launches and events database | No | Yes | Yes |
-| [Materials Platform for Data Science](https://mpds.io) | Curated experimental data for materials science | `apiKey` | Yes | No |
-| [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | No |
-| [NASA ADS](https://ui.adsabs.harvard.edu/help/api/api-docs.html) | NASA Astrophysics Data System | `OAuth`| Yes | Yes |
-| [Newton](https://newton.vercel.app) | Symbolic and Arithmetic Math Calculator | No | Yes | No |
-| [Noctua](https://api.noctuasky.com/api/v1/swaggerdoc/) | REST API used to access NoctuaSky features | No | Yes | Unknown |
-| [Numbers](https://math.tools/api/numbers/) | Number of the day, random number, number facts and anything else you want to do with numbers | `apiKey` | Yes | No |
-| [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
-| [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
-| [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | No | Yes | Unknown |
-| [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
-| [Remote Calc](https://github.com/elizabethadegbaju/remotecalc) | Decodes base64 encoding and parses it to return a solution to the calculation in JSON | No | Yes | Yes |
-| [Satellite Passes](https://sat.terrestre.ar) | Find satellite passes | No | Yes | Yes |
-| [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |
-| [SpaceX](https://github.com/r-spacex/SpaceX-API) | Company, vehicle, launchpad and launch data | No | Yes | No |
-| [Sunrise and Sunset](https://sunrise-sunset.org/api) | Sunset and sunrise times for a given latitude and longitude | No | Yes | No |
-| [Times Adder](https://github.com/FranP-code/API-Times-Adder) | With this API you can add each of the times introduced in the array sent | No | Yes | No |
-| [TLE](https://tle.ivanstanojevic.me) | Satellite information | No | Yes | No |
-| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time | No | Yes | No |
-| [USGS Water Services](https://waterservices.usgs.gov/) | Water quality and level info for rivers and lakes | No | Yes | No |
-| [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589) | World Data | No | Yes | No |
+
+| API                                                                            | Description                                                                                  | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [arcsecond.io](https://api.arcsecond.io/)                                      | Multiple astronomy data sources                                                              | `apiKey` | Yes   | Unknown |
+| [arXiv](https://arxiv.org/help/api)                                            | Curated research-sharing platform: physics, mathematics, quantitative finance, and economics | No       | Yes   | Unknown |
+| [CORE](https://core.ac.uk/services#api)                                        | Access the world's Open Access research papers                                               | `apiKey` | Yes   | Unknown |
+| [GBIF](https://www.gbif.org/developer/summary)                                 | Global Biodiversity Information Facility                                                     | No       | Yes   | Yes     |
+| [iDigBio](https://github.com/idigbio/idigbio-search-api/wiki)                  | Access millions of museum specimens from organizations around the world                      | No       | Yes   | Unknown |
+| [inspirehep.net](https://github.com/inspirehep/rest-api-doc)                   | High Energy Physics info. system                                                             | No       | Yes   | Unknown |
+| [isEven (humor)](https://isevenapi.xyz/)                                       | Check if a number is even                                                                    | No       | Yes   | Unknown |
+| [ISRO](https://isro.vercel.app)                                                | ISRO Space Crafts Information                                                                | No       | Yes   | No      |
+| [ISRO Statistics](https://isrostats.in/apis)                                   | ISRO Launches and Spacecrafts details                                                        | No       | Yes   | Yes     |
+| [ITIS](https://www.itis.gov/ws_description.html)                               | Integrated Taxonomic Information System                                                      | No       | Yes   | Unknown |
+| [Launch Library 2](https://thespacedevs.com/llapi)                             | Spaceflight launches and events database                                                     | No       | Yes   | Yes     |
+| [Materials Platform for Data Science](https://mpds.io)                         | Curated experimental data for materials science                                              | `apiKey` | Yes   | No      |
+| [NASA](https://api.nasa.gov)                                                   | NASA data, including imagery                                                                 | No       | Yes   | No      |
+| [NASA ADS](https://ui.adsabs.harvard.edu/help/api/api-docs.html)               | NASA Astrophysics Data System                                                                | `OAuth`  | Yes   | Yes     |
+| [Newton](https://newton.vercel.app)                                            | Symbolic and Arithmetic Math Calculator                                                      | No       | Yes   | No      |
+| [Noctua](https://api.noctuasky.com/api/v1/swaggerdoc/)                         | REST API used to access NoctuaSky features                                                   | No       | Yes   | Unknown |
+| [Numbers](https://math.tools/api/numbers/)                                     | Number of the day, random number, number facts and anything else you want to do with numbers | `apiKey` | Yes   | No      |
+| [Numbers](http://numbersapi.com)                                               | Facts about numbers                                                                          | No       | No    | No      |
+| [Open Notify](http://open-notify.org/Open-Notify-API/)                         | ISS astronauts, current location, etc                                                        | No       | No    | No      |
+| [Open Science Framework](https://developer.osf.io)                             | Repository and archive for study designs, research materials, data, manuscripts, etc         | No       | Yes   | Unknown |
+| [Purple Air](https://www2.purpleair.com/)                                      | Real Time Air Quality Monitoring                                                             | No       | Yes   | Unknown |
+| [Remote Calc](https://github.com/elizabethadegbaju/remotecalc)                 | Decodes base64 encoding and parses it to return a solution to the calculation in JSON        | No       | Yes   | Yes     |
+| [Satellite Passes](https://sat.terrestre.ar)                                   | Find satellite passes                                                                        | No       | Yes   | Yes     |
+| [SHARE](https://share.osf.io/api/v2/)                                          | A free, open, dataset about research and scholarly activities                                | No       | Yes   | No      |
+| [SpaceX](https://github.com/r-spacex/SpaceX-API)                               | Company, vehicle, launchpad and launch data                                                  | No       | Yes   | No      |
+| [Sunrise and Sunset](https://sunrise-sunset.org/api)                           | Sunset and sunrise times for a given latitude and longitude                                  | No       | Yes   | No      |
+| [Times Adder](https://github.com/FranP-code/API-Times-Adder)                   | With this API you can add each of the times introduced in the array sent                     | No       | Yes   | No      |
+| [TLE](https://tle.ivanstanojevic.me)                                           | Satellite information                                                                        | No       | Yes   | No      |
+| [USGS Earthquake Hazards Program](https://earthquake.usgs.gov/fdsnws/event/1/) | Earthquakes data real-time                                                                   | No       | Yes   | No      |
+| [USGS Water Services](https://waterservices.usgs.gov/)                         | Water quality and level info for rivers and lakes                                            | No       | Yes   | No      |
+| [World Bank](https://datahelpdesk.worldbank.org/knowledgebase/topics/125589)   | World Data                                                                                   | No       | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
 
 ### Security
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Application Environment Verification](https://github.com/fingerprintjs/aev) | Android library and API to verify the safety of user devices, detect rooted devices and other risks | `apiKey` | Yes | Yes |
-| [BinaryEdge](https://docs.binaryedge.io/api-v2.html) | Provide access to BinaryEdge 40fy scanning platform | `apiKey` | Yes | Yes |
-| [BitWarden](https://bitwarden.com/help/api/) | Best open-source password manager | `OAuth`| Yes | Unknown |
-| [Botd](https://github.com/fingerprintjs/botd) | Botd is a browser library for JavaScript bot detection | `apiKey` | Yes | Yes |
-| [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | Bugcrowd API for interacting and tracking the reported issues programmatically | `apiKey` | Yes | Unknown |
-| [Censys](https://search.censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
-| [Classify](https://github.com/cheatsnake/classify) | Encrypting & decrypting text messages | No | Yes | Yes |
-| [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Pureto Rico | `apiKey` | Yes | Yes |
-| [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
-| [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
-| [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
-| [FilterLists](https://filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |
-| [FingerprintJS Pro](https://dev.fingerprintjs.com/docs) | Fraud detection API offering highly accurate browser fingerprinting | `apiKey` | Yes | Yes |
-| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | Screen order information using AI to detect frauds | `apiKey` | Yes | Unknown |
-| [FullHunt](https://api-docs.fullhunt.io/#introduction) | Searchable attack surface database of the entire internet | `apiKey` | Yes | Unknown |
-| [GitGuardian](https://api.gitguardian.com/doc) | Scan files for secrets (API Keys, database credentials) | `apiKey` | Yes | No |
-| [GreyNoise](https://docs.greynoise.io/reference/get_v3-community-ip) | Query IPs in the GreyNoise dataset and retrieve a subset of the full IP context data | `apiKey` | Yes | Unknown |
-| [HackerOne](https://api.hackerone.com/) | The industry’s first hacker API that helps increase productivity towards creative bug bounty hunting | `apiKey` | Yes | Unknown |
-| [HaveIBeenPwned](https://haveibeenpwned.com/API/v3) | Passwords which have previously been exposed in data breaches | `apiKey` | Yes | Unknown |
-| [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
-| [IntelOwl](https://intelowl.readthedocs.io) | Manage your Threat Intelligence at scale | No | Yes | Unknown |
-| [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
-| [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
-| [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |
-| [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Yes | Unknown |
-| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database | No | Yes | Unknown |
-| [OWASP ZAP](https://www.zaproxy.org/docs/api/) | Automated security testing API for web apps | No | Yes | Unknown |
-| [Passwordinator](https://github.com/fawazsullia/password-generator/) | Generate random passwords of varying complexities | No | Yes | Yes |
-| [PhishStats](https://phishstats.info/) | Phishing database | No | Yes | Unknown |
-| [Privacy.com](https://privacy.com/developer/docs) | Generate merchant-specific and one-time use credit card numbers that link back to your bank | `apiKey` | Yes | Unknown |
-| [Pulsedive](https://pulsedive.com/api/) | Scan, search and collect threat intelligence data in real-time | `apiKey` | Yes | Unknown |
-| [SecurityTrails](https://securitytrails.com/corp/api) | Domain and IP related information such as current and historical WHOIS and DNS records | `apiKey` | Yes | Unknown |
-| [Shodan](https://developer.shodan.io/) | Search engine for Internet connected devices | `apiKey` | Yes | Unknown |
-| [Spyse](https://spyse-dev.readme.io/reference/quick-start) | Access data on all Internet assets and build powerful attack surface management applications | `apiKey` | Yes | Unknown |
-| [Threat Jammer](https://threatjammer.com/docs/index) | Risk scoring service from curated threat intelligence data | `apiKey` | Yes | Unknown |
-| [UK Police](https://data.police.uk/docs/) | UK Police data | No | Yes | Unknown |
-| [VulDB](https://vuldb.com/?doc.api) | VulDB API allows to initiate queries for one or more items along with transactional bots | `apiKey` | Yes | Unknown |
-| [Whoisfreaks](https://whoisfreaks.com/) | Domain and DNS related information that will equip organizaion with comprehensive threat intelligence and attack surface analysis capabilities for enhanced security | `apiKey` | Yes | No |
+
+| API                                                                                                 | Description                                                                                                                                                          | Auth     | HTTPS | CORS    |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Application Environment Verification](https://github.com/fingerprintjs/aev)                        | Android library and API to verify the safety of user devices, detect rooted devices and other risks                                                                  | `apiKey` | Yes   | Yes     |
+| [BinaryEdge](https://docs.binaryedge.io/api-v2.html)                                                | Provide access to BinaryEdge 40fy scanning platform                                                                                                                  | `apiKey` | Yes   | Yes     |
+| [BitWarden](https://bitwarden.com/help/api/)                                                        | Best open-source password manager                                                                                                                                    | `OAuth`  | Yes   | Unknown |
+| [Botd](https://github.com/fingerprintjs/botd)                                                       | Botd is a browser library for JavaScript bot detection                                                                                                               | `apiKey` | Yes   | Yes     |
+| [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/)                                          | Bugcrowd API for interacting and tracking the reported issues programmatically                                                                                       | `apiKey` | Yes   | Unknown |
+| [Censys](https://search.censys.io/api)                                                              | Search engine for Internet connected host and devices                                                                                                                | `apiKey` | Yes   | No      |
+| [Classify](https://github.com/cheatsnake/classify)                                                  | Encrypting & decrypting text messages                                                                                                                                | No       | Yes   | Yes     |
+| [Complete Criminal Checks](https://completecriminalchecks.com/Developers)                           | Provides data of offenders from all U.S. States and Pureto Rico                                                                                                      | `apiKey` | Yes   | Yes     |
+| [CRXcavator](https://crxcavator.io/apidocs)                                                         | Chrome extension risk scoring                                                                                                                                        | `apiKey` | Yes   | Unknown |
+| [EmailRep](https://docs.emailrep.io/)                                                               | Email address threat and risk prediction                                                                                                                             | No       | Yes   | Unknown |
+| [Escape](https://github.com/polarspetroll/EscapeAPI)                                                | An API for escaping different kind of queries                                                                                                                        | No       | Yes   | No      |
+| [FilterLists](https://filterlists.com)                                                              | Lists of filters for adblockers and firewalls                                                                                                                        | No       | Yes   | Unknown |
+| [FingerprintJS Pro](https://dev.fingerprintjs.com/docs)                                             | Fraud detection API offering highly accurate browser fingerprinting                                                                                                  | `apiKey` | Yes   | Yes     |
+| [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order)                            | Screen order information using AI to detect frauds                                                                                                                   | `apiKey` | Yes   | Unknown |
+| [FullHunt](https://api-docs.fullhunt.io/#introduction)                                              | Searchable attack surface database of the entire internet                                                                                                            | `apiKey` | Yes   | Unknown |
+| [GitGuardian](https://api.gitguardian.com/doc)                                                      | Scan files for secrets (API Keys, database credentials)                                                                                                              | `apiKey` | Yes   | No      |
+| [GreyNoise](https://docs.greynoise.io/reference/get_v3-community-ip)                                | Query IPs in the GreyNoise dataset and retrieve a subset of the full IP context data                                                                                 | `apiKey` | Yes   | Unknown |
+| [HackerOne](https://api.hackerone.com/)                                                             | The industry’s first hacker API that helps increase productivity towards creative bug bounty hunting                                                                 | `apiKey` | Yes   | Unknown |
+| [HaveIBeenPwned](https://haveibeenpwned.com/API/v3)                                                 | Passwords which have previously been exposed in data breaches                                                                                                        | `apiKey` | Yes   | Unknown |
+| [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf)       | Perform OSINT via Intelligence X                                                                                                                                     | `apiKey` | Yes   | Unknown |
+| [IntelOwl](https://intelowl.readthedocs.io)                                                         | Manage your Threat Intelligence at scale                                                                                                                             | No       | Yes   | Unknown |
+| [LoginRadius](https://www.loginradius.com/docs/)                                                    | Managed User Authentication Service                                                                                                                                  | `apiKey` | Yes   | Yes     |
+| [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer)            | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC)                                                                                 | No       | Yes   | Unknown |
+| [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner                                                                                                                                     | No       | Yes   | Unknown |
+| [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints)                     | Mozilla observatory tls scanner                                                                                                                                      | No       | Yes   | Unknown |
+| [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog)         | U.S. National Vulnerability Database                                                                                                                                 | No       | Yes   | Unknown |
+| [OWASP ZAP](https://www.zaproxy.org/docs/api/)                                                      | Automated security testing API for web apps                                                                                                                          | No       | Yes   | Unknown |
+| [Passwordinator](https://github.com/fawazsullia/password-generator/)                                | Generate random passwords of varying complexities                                                                                                                    | No       | Yes   | Yes     |
+| [PhishStats](https://phishstats.info/)                                                              | Phishing database                                                                                                                                                    | No       | Yes   | Unknown |
+| [Privacy.com](https://privacy.com/developer/docs)                                                   | Generate merchant-specific and one-time use credit card numbers that link back to your bank                                                                          | `apiKey` | Yes   | Unknown |
+| [Pulsedive](https://pulsedive.com/api/)                                                             | Scan, search and collect threat intelligence data in real-time                                                                                                       | `apiKey` | Yes   | Unknown |
+| [SecurityTrails](https://securitytrails.com/corp/api)                                               | Domain and IP related information such as current and historical WHOIS and DNS records                                                                               | `apiKey` | Yes   | Unknown |
+| [Shodan](https://developer.shodan.io/)                                                              | Search engine for Internet connected devices                                                                                                                         | `apiKey` | Yes   | Unknown |
+| [Spyse](https://spyse-dev.readme.io/reference/quick-start)                                          | Access data on all Internet assets and build powerful attack surface management applications                                                                         | `apiKey` | Yes   | Unknown |
+| [Threat Jammer](https://threatjammer.com/docs/index)                                                | Risk scoring service from curated threat intelligence data                                                                                                           | `apiKey` | Yes   | Unknown |
+| [UK Police](https://data.police.uk/docs/)                                                           | UK Police data                                                                                                                                                       | No       | Yes   | Unknown |
+| [VulDB](https://vuldb.com/?doc.api)                                                                 | VulDB API allows to initiate queries for one or more items along with transactional bots                                                                             | `apiKey` | Yes   | Unknown |
+| [Whoisfreaks](https://whoisfreaks.com/)                                                             | Domain and DNS related information that will equip organizaion with comprehensive threat intelligence and attack surface analysis capabilities for enhanced security | `apiKey` | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
 
 ### Shopping
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview) | Products, Buying Options, Categories, Recommendations, Stores and Commerce | `apiKey` | Yes | Unknown |
-| [Canopy](https://www.canopyapi.co/) | A modern API for Amazon Data | `apiKey` | Yes | Unknown |
-| [Digi-Key](https://www.digikey.com/en/resources/api-solutions) | Retrieve price and inventory of electronic components as well as place orders | `OAuth`| Yes | Unknown |
-| [eBay](https://developer.ebay.com/) | Sell and Buy on eBay | `OAuth`| Yes | Unknown |
-| [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | Manage shop and interact with listings | `OAuth`| Yes | Unknown |
-| [Flipkart Marketplace](https://seller.flipkart.com/api-docs/FMSAPI.html) | Product listing management, Order Fulfilment in the Flipkart Marketplace | `OAuth`| Yes | Yes |
-| [Lazada](https://open.lazada.com/doc/doc.htm) | Retrieve product ratings and seller performance metrics | `apiKey` | Yes | Unknown |
-| [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es) | Manage sales, ads, products, services and Shops | `apiKey` | Yes | Unknown |
-| [OLX Poland](https://developer.olx.pl/api/doc#section/) | Integrate with local sites by posting, managing adverts and communicating with OLX users | `apiKey` | Yes | Unknown |
-| [Platzi Fake Store](https://fakeapi.platzi.com/) | A fake store API for your e-commerce or shopping website prototype. For testing and learning | `apiKey` | Yes | Unknown |
-| [Printful](https://developers.printful.com) | Printful's official API to manage and integrate their services | `OAuth` | Yes | Unknown |
-| [Printify](https://developers.printify.com/) | Printify's official API to manage and integrate their services | `OAuth` | Yes | Unknown |
-| [Rappi](https://dev-portal.rappi.com/) | Manage orders from Rappi's app | `OAuth`| Yes | Unknown |
-| [Shopee](https://open.shopee.com/documents?version=1) | Shopee's official API for integration of various services from Shopee | `apiKey` | Yes | Unknown |
-| [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/) | Tokopedia's Official API for integration of various services from Tokopedia | `OAuth`| Yes | Unknown |
-| [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/) | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes | Yes |
+
+| API                                                                              | Description                                                                                        | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Best Buy](https://bestbuyapis.github.io/api-documentation/#overview)            | Products, Buying Options, Categories, Recommendations, Stores and Commerce                         | `apiKey` | Yes   | Unknown |
+| [Canopy](https://www.canopyapi.co/)                                              | A modern API for Amazon Data                                                                       | `apiKey` | Yes   | Unknown |
+| [Digi-Key](https://www.digikey.com/en/resources/api-solutions)                   | Retrieve price and inventory of electronic components as well as place orders                      | `OAuth`  | Yes   | Unknown |
+| [eBay](https://developer.ebay.com/)                                              | Sell and Buy on eBay                                                                               | `OAuth`  | Yes   | Unknown |
+| [Etsy](https://www.etsy.com/developers/documentation/getting_started/api_basics) | Manage shop and interact with listings                                                             | `OAuth`  | Yes   | Unknown |
+| [Flipkart Marketplace](https://seller.flipkart.com/api-docs/FMSAPI.html)         | Product listing management, Order Fulfilment in the Flipkart Marketplace                           | `OAuth`  | Yes   | Yes     |
+| [Lazada](https://open.lazada.com/doc/doc.htm)                                    | Retrieve product ratings and seller performance metrics                                            | `apiKey` | Yes   | Unknown |
+| [Mercadolibre](https://developers.mercadolibre.cl/es_ar/api-docs-es)             | Manage sales, ads, products, services and Shops                                                    | `apiKey` | Yes   | Unknown |
+| [OLX Poland](https://developer.olx.pl/api/doc#section/)                          | Integrate with local sites by posting, managing adverts and communicating with OLX users           | `apiKey` | Yes   | Unknown |
+| [Platzi Fake Store](https://fakeapi.platzi.com/)                                 | A fake store API for your e-commerce or shopping website prototype. For testing and learning       | `apiKey` | Yes   | Unknown |
+| [Printful](https://developers.printful.com)                                      | Printful's official API to manage and integrate their services                                     | `OAuth`  | Yes   | Unknown |
+| [Printify](https://developers.printify.com/)                                     | Printify's official API to manage and integrate their services                                     | `OAuth`  | Yes   | Unknown |
+| [Rappi](https://dev-portal.rappi.com/)                                           | Manage orders from Rappi's app                                                                     | `OAuth`  | Yes   | Unknown |
+| [Shopee](https://open.shopee.com/documents?version=1)                            | Shopee's official API for integration of various services from Shopee                              | `apiKey` | Yes   | Unknown |
+| [Tokopedia](https://developer.tokopedia.com/openapi/guide/#/)                    | Tokopedia's Official API for integration of various services from Tokopedia                        | `OAuth`  | Yes   | Unknown |
+| [WooCommerce](https://woocommerce.github.io/woocommerce-rest-api-docs/)          | WooCommerce REST APIS to create, read, update, and delete data on wordpress website in JSON format | `apiKey` | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Social
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [4chan](https://github.com/4chan/4chan-API) | Simple image-based bulletin board dedicated to a variety of topics | No | Yes | Yes |
-| [Ayrshare](https://www.ayrshare.com) | Social media APIs to post, get analytics, and manage multiple users social media accounts | `apiKey` | Yes | Yes |
-| [Blogger](https://developers.google.com/blogger/) | The Blogger APIs allows client applications to view and update Blogger content | `OAuth`| Yes | Unknown |
-| [Discord](https://discord.com/developers/docs/intro) | Make bots for Discord, integrate Discord onto an external platform | `OAuth`| Yes | Unknown |
-| [Disqus](https://disqus.com/api/docs/auth/) | Communicate with Disqus data | `OAuth`| Yes | Unknown |
-| [Facebook](https://developers.facebook.com/) | Facebook Login, Share on FB, Social Plugins, Analytics and more | `OAuth`| Yes | Unknown |
-| [Foursquare](https://developer.foursquare.com/) | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth`| Yes | Unknown |
-| [Full Contact](https://docs.fullcontact.com/) | Get Social Media profiles and contact Information | `OAuth`| Yes | Unknown |
-| [HackerNews](https://github.com/HackerNews/API) | Social news for CS and entrepreneurship | No | Yes | Unknown |
-| [Hashnode](https://hashnode.com) | A blogging platform built for developers | No | Yes | Unknown |
-| [Hashtag](https://mukeshsolanki.gitbook.io/hashtag-api/) | Generate Hashtags using a keyword or an Image | `apiKey` | Yes | Unknown |
-| [Instagram](https://www.instagram.com/developer/) | Instagram Login, Share on Instagram, Social Plugins and more | `OAuth`| Yes | Unknown |
-| [Kakao](https://developers.kakao.com/) | Kakao Login, Share on KakaoTalk, Social Plugins and more | `OAuth`| Yes | Unknown |
-| [Lanyard](https://github.com/Phineas/lanyard) | Retrieve your presence on Discord through an HTTP REST API or WebSocket | No | Yes | Yes |
-| [Line](https://developers.line.biz/) | Line Login, Share on Line, Social Plugins and more | `OAuth`| Yes | Unknown |
-| [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | The foundation of all digital integrations with LinkedIn | `OAuth`| Yes | Unknown |
-| [Meetup.com](https://www.meetup.com/api/guide) | Data about Meetups from Meetup.com | `apiKey` | Yes | Unknown |
-| [Microsoft Graph](https://docs.microsoft.com/en-us/graph/api/overview) | Access the data and intelligence in Microsoft 365, Windows 10, and Enterprise Mobility | `OAuth`| Yes | Unknown |
-| [NAVER](https://developers.naver.com/main/) | NAVER Login, Share on NAVER, Social Plugins and more | `OAuth`| Yes | Unknown |
-| [Open Collective](https://docs.opencollective.com/help/developers/api) | Get Open Collective data | No | Yes | Unknown |
-| [Pinterest](https://developers.pinterest.com/) | The world's catalog of ideas | `OAuth`| Yes | Unknown |
-| [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth`| Yes | Unknown |
-| [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth`| Yes | Unknown |
-| [Revolt](https://developers.revolt.chat) | Revolt open source Discord alternative | `apiKey` | Yes | Unknown |
-| [Saidit](https://www.saidit.net/dev/api) | Open Source Reddit Clone | `OAuth`| Yes | Unknown |
-| [SocialData API](https://socialdata.tools) | Read Twitter data | `apiKey`| Yes | No |
-| [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth`| Yes | Unknown |
-| [TamTam](https://dev.tamtam.chat/) | Bot API to interact with TamTam | `apiKey` | Yes | Unknown |
-| [Telegram Bot](https://core.telegram.org/bots/api) | Simplified HTTP version of the MTProto API for bots | `apiKey` | Yes | Unknown |
-| [Telegram MTProto](https://core.telegram.org/api#getting-started) | Read and write Telegram data | `OAuth`| Yes | Unknown |
-| [TikTok](https://developers.tiktok.com/doc/login-kit-web) | Fetches user info and user's video posts on TikTok platform | `OAuth`| Yes | Unknown |
-| [Trash Nothing](https://trashnothing.com/developer) | A freecycling community with thousands of free items posted every day | `OAuth`| Yes | Yes |
-| [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth`| Yes | Unknown |
-| [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth`| Yes | Unknown |
-| [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth`| Yes | No |
-| [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth`| Yes | Unknown |
-| [Webex](https://developer.webex.com) | Team collaboration software | `OAuth`| Yes | Yes |
+
+| API                                                                             | Description                                                                                       | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [4chan](https://github.com/4chan/4chan-API)                                     | Simple image-based bulletin board dedicated to a variety of topics                                | No       | Yes   | Yes     |
+| [Ayrshare](https://www.ayrshare.com)                                            | Social media APIs to post, get analytics, and manage multiple users social media accounts         | `apiKey` | Yes   | Yes     |
+| [Blogger](https://developers.google.com/blogger/)                               | The Blogger APIs allows client applications to view and update Blogger content                    | `OAuth`  | Yes   | Unknown |
+| [Discord](https://discord.com/developers/docs/intro)                            | Make bots for Discord, integrate Discord onto an external platform                                | `OAuth`  | Yes   | Unknown |
+| [Disqus](https://disqus.com/api/docs/auth/)                                     | Communicate with Disqus data                                                                      | `OAuth`  | Yes   | Unknown |
+| [Facebook](https://developers.facebook.com/)                                    | Facebook Login, Share on FB, Social Plugins, Analytics and more                                   | `OAuth`  | Yes   | Unknown |
+| [Foursquare](https://developer.foursquare.com/)                                 | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth`  | Yes   | Unknown |
+| [Full Contact](https://docs.fullcontact.com/)                                   | Get Social Media profiles and contact Information                                                 | `OAuth`  | Yes   | Unknown |
+| [HackerNews](https://github.com/HackerNews/API)                                 | Social news for CS and entrepreneurship                                                           | No       | Yes   | Unknown |
+| [Hashnode](https://hashnode.com)                                                | A blogging platform built for developers                                                          | No       | Yes   | Unknown |
+| [Hashtag](https://mukeshsolanki.gitbook.io/hashtag-api/)                        | Generate Hashtags using a keyword or an Image                                                     | `apiKey` | Yes   | Unknown |
+| [Instagram](https://www.instagram.com/developer/)                               | Instagram Login, Share on Instagram, Social Plugins and more                                      | `OAuth`  | Yes   | Unknown |
+| [Kakao](https://developers.kakao.com/)                                          | Kakao Login, Share on KakaoTalk, Social Plugins and more                                          | `OAuth`  | Yes   | Unknown |
+| [Lanyard](https://github.com/Phineas/lanyard)                                   | Retrieve your presence on Discord through an HTTP REST API or WebSocket                           | No       | Yes   | Yes     |
+| [Line](https://developers.line.biz/)                                            | Line Login, Share on Line, Social Plugins and more                                                | `OAuth`  | Yes   | Unknown |
+| [LinkedIn](https://docs.microsoft.com/en-us/linkedin/?context=linkedin/context) | The foundation of all digital integrations with LinkedIn                                          | `OAuth`  | Yes   | Unknown |
+| [Meetup.com](https://www.meetup.com/api/guide)                                  | Data about Meetups from Meetup.com                                                                | `apiKey` | Yes   | Unknown |
+| [Microsoft Graph](https://docs.microsoft.com/en-us/graph/api/overview)          | Access the data and intelligence in Microsoft 365, Windows 10, and Enterprise Mobility            | `OAuth`  | Yes   | Unknown |
+| [NAVER](https://developers.naver.com/main/)                                     | NAVER Login, Share on NAVER, Social Plugins and more                                              | `OAuth`  | Yes   | Unknown |
+| [Open Collective](https://docs.opencollective.com/help/developers/api)          | Get Open Collective data                                                                          | No       | Yes   | Unknown |
+| [Pinterest](https://developers.pinterest.com/)                                  | The world's catalog of ideas                                                                      | `OAuth`  | Yes   | Unknown |
+| [Product Hunt](https://api.producthunt.com/v2/docs)                             | The best new products in tech                                                                     | `OAuth`  | Yes   | Unknown |
+| [Reddit](https://www.reddit.com/dev/api)                                        | Homepage of the internet                                                                          | `OAuth`  | Yes   | Unknown |
+| [Revolt](https://developers.revolt.chat)                                        | Revolt open source Discord alternative                                                            | `apiKey` | Yes   | Unknown |
+| [Saidit](https://www.saidit.net/dev/api)                                        | Open Source Reddit Clone                                                                          | `OAuth`  | Yes   | Unknown |
+| [SocialData API](https://socialdata.tools)                                      | Read Twitter data                                                                                 | `apiKey` | Yes   | No      |
+| [Slack](https://api.slack.com/)                                                 | Team Instant Messaging                                                                            | `OAuth`  | Yes   | Unknown |
+| [TamTam](https://dev.tamtam.chat/)                                              | Bot API to interact with TamTam                                                                   | `apiKey` | Yes   | Unknown |
+| [Telegram Bot](https://core.telegram.org/bots/api)                              | Simplified HTTP version of the MTProto API for bots                                               | `apiKey` | Yes   | Unknown |
+| [Telegram MTProto](https://core.telegram.org/api#getting-started)               | Read and write Telegram data                                                                      | `OAuth`  | Yes   | Unknown |
+| [TikTok](https://developers.tiktok.com/doc/login-kit-web)                       | Fetches user info and user's video posts on TikTok platform                                       | `OAuth`  | Yes   | Unknown |
+| [Trash Nothing](https://trashnothing.com/developer)                             | A freecycling community with thousands of free items posted every day                             | `OAuth`  | Yes   | Yes     |
+| [Tumblr](https://www.tumblr.com/docs/en/api/v2)                                 | Read and write Tumblr Data                                                                        | `OAuth`  | Yes   | Unknown |
+| [Twitch](https://dev.twitch.tv/docs)                                            | Game Streaming API                                                                                | `OAuth`  | Yes   | Unknown |
+| [Twitter](https://developer.twitter.com/en/docs)                                | Read and write Twitter data                                                                       | `OAuth`  | Yes   | No      |
+| [vk](https://vk.com/dev/sites)                                                  | Read and write vk data                                                                            | `OAuth`  | Yes   | Unknown |
+| [Webex](https://developer.webex.com)                                            | Team collaboration software                                                                       | `OAuth`  | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Sports & Fitness
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [American Football Highlights API](https://highlightly.net/documentation/american-football/) | Real time American Football (NFL/NCAA) highlights | `apiKey`| Yes | Unknown |
-| [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey`| Yes | Yes |
-| [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes | Yes |
-| [Basketball Highlights API](https://highlightly.net/documentation/basketball/) | Real time basketball video highlights | `apiKey`| Yes | Unknown |
-| [Canadian Football League (CFL)](http://api.cfl.ca/) | Official JSON API providing real-time league, team and player statistics about the CFL | `apiKey`| Yes | No |
-| [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Yes | Unknown |
-| [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey`| Yes | Yes |
-| [CollegeFootballData.com](https://collegefootballdata.com) | Unofficial detailed American college football statistics, records, and results API | `apiKey`| Yes | Unknown |
-| [Ergast F1](http://ergast.com/mrd/) | F1 data from the beginning of the world championships in 1950 | No | Yes | Unknown |
-| [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Yes | Unknown |
-| [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Yes | Unknown |
-| [Football Highlights](https://highlightly.net/documentation/football/) | Real time football (soccer) highlights from over +950 leagues | `apiKey` | Yes | Unknown |
-| [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes | Yes |
-| [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes | Yes |
-| [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Yes | Unknown |
-| [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
-| [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
-| [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
-| [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |
-| [NBA GraphQL](https://nbaapi.com/graphql/) | Advanced NBA Player, Team, and Season Statistics and Data | No | Yes | Yes |
-| [NBA REST API](http://rest.nbaapi.com/index.html) | Up-to-date NBA Player, Team, and Season Statistics, Totals, Advanced, and Shot Chart Data | No | Yes | Yes |
-| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description) | Current and historical NBA Statistics | No | Yes | Unknown |
-| [NBA Stats](https://documenter.getpostman.com/view/24232555/2s93shzpR3) | NBA player statistics and data | No | Yes | Yes |
-| [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
-| [Oddsmagnet](https://oddsmagnet.com/oddsdata) | Odds history from multiple UK bookmakers | No | Yes | Yes |
-| [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
-| [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey`| Yes | Unknown |
-| [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey`| Yes | Unknown |
-| [Sport Highlights](https://highlightly.net/documentation/sports/) | Real time Sport Highlights | `apiKey`| Yes | Unknown |
-| [Sportmonks Cricket](https://docs.sportmonks.com/cricket/) | Live cricket score, player statistics and fantasy API | `apiKey`| Yes | Unknown |
-| [Sportmonks Football](https://docs.sportmonks.com/football/) | Football score/schedule, news api, tv channels, stats, history, display standing e.g. epl, la liga | `apiKey`| Yes | Unknown |
-| [Squiggle](https://api.squiggle.com.au) | Fixtures, results and predictions for Australian Football League matches | No | Yes | Yes |
-| [Strava](https://strava.github.io/api/) | Connect with athletes, activities and more | `OAuth` | Yes | Unknown |
-| [SuredBits](https://suredbits.com/api/) | Query sports data, including teams, players, games, scores and statistics | No | No | No |
-| [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey`| Yes | Yes |
-| [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
-| [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey`| Yes | Unknown |
+
+| API                                                                                          | Description                                                                                         | Auth            | HTTPS | CORS    |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [American Football Highlights API](https://highlightly.net/documentation/american-football/) | Real time American Football (NFL/NCAA) highlights                                                   | `apiKey`        | Yes   | Unknown |
+| [API-FOOTBALL](https://www.api-football.com/documentation-v3)                                | Get information about Football Leagues & Cups                                                       | `apiKey`        | Yes   | Yes     |
+| [balldontlie](https://www.balldontlie.io)                                                    | Balldontlie provides access to stats data from the NBA                                              | No              | Yes   | Yes     |
+| [Basketball Highlights API](https://highlightly.net/documentation/basketball/)               | Real time basketball video highlights                                                               | `apiKey`        | Yes   | Unknown |
+| [Canadian Football League (CFL)](http://api.cfl.ca/)                                         | Official JSON API providing real-time league, team and player statistics about the CFL              | `apiKey`        | Yes   | No      |
+| [City Bikes](https://api.citybik.es/v2/)                                                     | City Bikes around the world                                                                         | No              | Yes   | Unknown |
+| [Cloudbet](https://www.cloudbet.com/api/)                                                    | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey`        | Yes   | Yes     |
+| [CollegeFootballData.com](https://collegefootballdata.com)                                   | Unofficial detailed American college football statistics, records, and results API                  | `apiKey`        | Yes   | Unknown |
+| [Ergast F1](http://ergast.com/mrd/)                                                          | F1 data from the beginning of the world championships in 1950                                       | No              | Yes   | Unknown |
+| [Fitbit](https://dev.fitbit.com/)                                                            | Fitbit Information                                                                                  | `OAuth`         | Yes   | Unknown |
+| [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/)                         | A simple Open Source Football API to get squads’ stats, best scorers and more                       | `X-Mashape-Key` | Yes   | Unknown |
+| [Football Highlights](https://highlightly.net/documentation/football/)                       | Real time football (soccer) highlights from over +950 leagues                                       | `apiKey`        | Yes   | Unknown |
+| [Football (Soccer) Videos](https://www.scorebat.com/video-api/)                              | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more         | No              | Yes   | Yes     |
+| [Football Standings](https://github.com/azharimm/football-standings-api)                     | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site            | No              | Yes   | Yes     |
+| [Football-Data](https://www.football-data.org)                                               | Football data with matches info, players, teams, and competitions                                   | `X-Mashape-Key` | Yes   | Unknown |
+| [Hockey Highlights](https://highlightly.net/documentation/hockey/)                           | Real time hockey highlights                                                                         | `apiKey`        | Yes   | Unknown |
+| [JCDecaux Bike](https://developer.jcdecaux.com/)                                             | JCDecaux's self-service bicycles                                                                    | `apiKey`        | Yes   | Unknown |
+| [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/)                          | Current and historical MLB statistics                                                               | No              | No    | Unknown |
+| [NBA Data](https://rapidapi.com/api-sports/api/api-nba/)                                     | All NBA Stats DATA, Games, Livescore, Standings, Statistics                                         | `apiKey`        | Yes   | Unknown |
+| [NBA GraphQL](https://nbaapi.com/graphql/)                                                   | Advanced NBA Player, Team, and Season Statistics and Data                                           | No              | Yes   | Yes     |
+| [NBA REST API](http://rest.nbaapi.com/index.html)                                            | Up-to-date NBA Player, Team, and Season Statistics, Totals, Advanced, and Shot Chart Data           | No              | Yes   | Yes     |
+| [NBA Stats](https://any-api.com/nba_com/nba_com/docs/API_Description)                        | Current and historical NBA Statistics                                                               | No              | Yes   | Unknown |
+| [NBA Stats](https://documenter.getpostman.com/view/24232555/2s93shzpR3)                      | NBA player statistics and data                                                                      | No              | Yes   | Yes     |
+| [NHL Records and Stats](https://gitlab.com/dword4/nhlapi)                                    | NHL historical data and statistics                                                                  | No              | Yes   | Unknown |
+| [Oddsmagnet](https://oddsmagnet.com/oddsdata)                                                | Odds history from multiple UK bookmakers                                                            | No              | Yes   | Yes     |
+| [OpenLigaDB](https://www.openligadb.de)                                                      | Crowd sourced sports league results                                                                 | No              | Yes   | Yes     |
+| [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/)  | All Current Premier League Standings and Statistics                                                 | `apiKey`        | Yes   | Unknown |
+| [Sport Data](https://sportdataapi.com)                                                       | Get sports data from all over the world                                                             | `apiKey`        | Yes   | Unknown |
+| [Sport Highlights](https://highlightly.net/documentation/sports/)                            | Real time Sport Highlights                                                                          | `apiKey`        | Yes   | Unknown |
+| [Sportmonks Cricket](https://docs.sportmonks.com/cricket/)                                   | Live cricket score, player statistics and fantasy API                                               | `apiKey`        | Yes   | Unknown |
+| [Sportmonks Football](https://docs.sportmonks.com/football/)                                 | Football score/schedule, news api, tv channels, stats, history, display standing e.g. epl, la liga  | `apiKey`        | Yes   | Unknown |
+| [Squiggle](https://api.squiggle.com.au)                                                      | Fixtures, results and predictions for Australian Football League matches                            | No              | Yes   | Yes     |
+| [Strava](https://strava.github.io/api/)                                                      | Connect with athletes, activities and more                                                          | `OAuth`         | Yes   | Unknown |
+| [SuredBits](https://suredbits.com/api/)                                                      | Query sports data, including teams, players, games, scores and statistics                           | No              | No    | No      |
+| [TheSportsDB](https://www.thesportsdb.com/api.php)                                           | Crowd-Sourced Sports Data and Artwork                                                               | `apiKey`        | Yes   | Yes     |
+| [Tredict](https://www.tredict.com/blog/oauth_docs/)                                          | Get and set activities, health data and more                                                        | `OAuth`         | Yes   | Unknown |
+| [Wger](https://wger.de/en/software/api)                                                      | Workout manager data as exercises, muscles or equipment                                             | `apiKey`        | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Test Data
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Bacon Ipsum](https://baconipsum.com/json-api/) | A Meatier Lorem Ipsum Generator | No | Yes | Unknown |
-| [Dicebear Avatars](https://avatars.dicebear.com/) | Generate random pixel-art avatars | No | Yes | No |
-| [DummyJSON](https://dummyjson.com/) | Generate dummy data in JSON format | Yes | Yes | Unknown |
-| [Faker](https://fakerjs.dev/) | Generate massive amounts of fake (but realistic) data for testing and development. | No | Yes | Unknown |
-| [FakerAPI](https://fakerapi.it/en) | APIs collection to get fake data | No | Yes | Yes |
-| [FakeStoreAPI](https://fakestoreapi.com/) | Fake store rest API for your e-commerce or shopping website prototype | No | Yes | Unknown |
-| [GeneradorDNI](https://api.generadordni.es) | Data generator API. Profiles, vehicles, banks and cards, etc | `apiKey` | Yes | Unknown |
-| [ItsThisForThat](https://itsthisforthat.com/api.php) | Generate Random startup ideas | No | Yes | No |
-| [JSONPlaceholder](http://jsonplaceholder.typicode.com/) | Fake data for testing and prototyping | No | No | Unknown |
-| [Loripsum](http://loripsum.net/) | The "lorem ipsum" generator that doesn't suck | No | No | Unknown |
-| [Mailsac](https://mailsac.com/docs/api) | Disposable Email | `apiKey` | Yes | Unknown |
-| [Metaphorsum](http://metaphorpsum.com/) | Generate demo paragraphs giving number of words and sentences | No | No | Unknown |
-| [Mockaroo](https://www.mockaroo.com/docs) | Generate fake data to JSON, CSV, TXT, SQL and XML | `apiKey` | Yes | Unknown |
-| [QuickMocker](https://quickmocker.com) | API mocking tool to generate contextual, fake or random data | No | Yes | Yes |
-| [Random Data](https://random-data-api.com) | Random data generator | No | Yes | Unknown |
-| [Random Identity](https://rapidapi.com/edualc1018/api/random-identity-generator) | Random Identity Generator with custom response format | `apiKey` | Yes | Yes |
-| [Randommer](https://randommer.io/randommer-api) | Random data generator | `apiKey` | Yes | Yes |
-| [RandomUser](https://randomuser.me) | Generates and list user data | No | Yes | Unknown |
-| [RoboHash](https://robohash.org/) | Generate random robot/alien avatars | No | Yes | Unknown |
-| [This Person Does not Exist](https://thispersondoesnotexist.com) | Generates real-life faces of people who do not exist | No | Yes | Unknown |
-| [UUID Generator](https://www.uuidtools.com/docs) | Generate UUIDs | No | Yes | No |
-| [What The Commit](http://whatthecommit.com/index.txt) | Random commit message generator | No | No | Yes |
-| [Yes No](https://yesno.wtf/api) | Generate yes or no randomly | No | Yes | Unknown |
+
+| API                                                                              | Description                                                                        | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [Bacon Ipsum](https://baconipsum.com/json-api/)                                  | A Meatier Lorem Ipsum Generator                                                    | No       | Yes   | Unknown |
+| [Dicebear Avatars](https://avatars.dicebear.com/)                                | Generate random pixel-art avatars                                                  | No       | Yes   | No      |
+| [DummyJSON](https://dummyjson.com/)                                              | Generate dummy data in JSON format                                                 | Yes      | Yes   | Unknown |
+| [Faker](https://fakerjs.dev/)                                                    | Generate massive amounts of fake (but realistic) data for testing and development. | No       | Yes   | Unknown |
+| [FakerAPI](https://fakerapi.it/en)                                               | APIs collection to get fake data                                                   | No       | Yes   | Yes     |
+| [FakeStoreAPI](https://fakestoreapi.com/)                                        | Fake store rest API for your e-commerce or shopping website prototype              | No       | Yes   | Unknown |
+| [GeneradorDNI](https://api.generadordni.es)                                      | Data generator API. Profiles, vehicles, banks and cards, etc                       | `apiKey` | Yes   | Unknown |
+| [ItsThisForThat](https://itsthisforthat.com/api.php)                             | Generate Random startup ideas                                                      | No       | Yes   | No      |
+| [JSONPlaceholder](http://jsonplaceholder.typicode.com/)                          | Fake data for testing and prototyping                                              | No       | No    | Unknown |
+| [Loripsum](http://loripsum.net/)                                                 | The "lorem ipsum" generator that doesn't suck                                      | No       | No    | Unknown |
+| [Mailsac](https://mailsac.com/docs/api)                                          | Disposable Email                                                                   | `apiKey` | Yes   | Unknown |
+| [Metaphorsum](http://metaphorpsum.com/)                                          | Generate demo paragraphs giving number of words and sentences                      | No       | No    | Unknown |
+| [Mockaroo](https://www.mockaroo.com/docs)                                        | Generate fake data to JSON, CSV, TXT, SQL and XML                                  | `apiKey` | Yes   | Unknown |
+| [QuickMocker](https://quickmocker.com)                                           | API mocking tool to generate contextual, fake or random data                       | No       | Yes   | Yes     |
+| [Random Data](https://random-data-api.com)                                       | Random data generator                                                              | No       | Yes   | Unknown |
+| [Random Identity](https://rapidapi.com/edualc1018/api/random-identity-generator) | Random Identity Generator with custom response format                              | `apiKey` | Yes   | Yes     |
+| [Randommer](https://randommer.io/randommer-api)                                  | Random data generator                                                              | `apiKey` | Yes   | Yes     |
+| [RandomUser](https://randomuser.me)                                              | Generates and list user data                                                       | No       | Yes   | Unknown |
+| [RoboHash](https://robohash.org/)                                                | Generate random robot/alien avatars                                                | No       | Yes   | Unknown |
+| [This Person Does not Exist](https://thispersondoesnotexist.com)                 | Generates real-life faces of people who do not exist                               | No       | Yes   | Unknown |
+| [UUID Generator](https://www.uuidtools.com/docs)                                 | Generate UUIDs                                                                     | No       | Yes   | No      |
+| [What The Commit](http://whatthecommit.com/index.txt)                            | Random commit message generator                                                    | No       | No    | Yes     |
+| [Yes No](https://yesno.wtf/api)                                                  | Generate yes or no randomly                                                        | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Text Analysis
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started) | A collection of information retrieval and natural language APIs | `apiKey` | Yes | Unknown |
-| [Chatpdf](https://chatpdf.so/api) | Chat with pdf using GPT4 and ChatGPT | `apiKey` | Yes | Yes |
-| [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api) | Natural language processing and text analysis | `apiKey` | Yes | Yes |
-| [Code Detection API](https://codedetectionapi.runtime.dev) | Detect, label, format and enrich the code in your app or in your data pipeline | `OAuth`| Yes | Unknown |
-| [Detect Language](https://detectlanguage.com/) | Detects text language | `apiKey` | Yes | Unknown |
-| [ELI](https://nlp.insightera.co.th/docs/v1.0) | Natural Language Processing Tools for Thai Language | `apiKey` | Yes | Unknown |
-| [Google Cloud Natural](https://cloud.google.com/natural-language/docs/) | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes | Unknown |
-| [LanguageTool](https://languagetool.org/http-api/) | Style and Grammar Checker for 25+ Languages | No | Yes | Unknown |
-| [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/) | Translation API with free tier and reasonable prices | `apiKey` | Yes | Yes |
-| [LibreTranslate](https://libretranslate.com/docs) | Translation tool with 17 available languages | No | Yes | Unknown |
-| [Semantria](https://semantria.readme.io/docs) | Text Analytics with sentiment analysis, categorization & named entity extraction | `OAuth`| Yes | Unknown |
-| [Sentiment Analysis](https://www.meaningcloud.com/developer/sentiment-analysis) | Multilingual sentiment analysis of texts from different sources | `apiKey` | Yes | Yes |
-| [Tisane](https://tisane.ai/) | Text Analytics with focus on detection of abusive content and law enforcement applications | `OAuth`| Yes | Yes |
-| [Watson Natural Language Understanding](https://cloud.ibm.com/apidocs/natural-language-understanding/natural-language-understanding) | Natural language processing for advanced text analysis | `OAuth`| Yes | Unknown |
+
+| API                                                                                                                                  | Description                                                                                | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [Aylien Text Analysis](https://docs.aylien.com/textapi/#getting-started)                                                             | A collection of information retrieval and natural language APIs                            | `apiKey` | Yes   | Unknown |
+| [Chatpdf](https://chatpdf.so/api)                                                                                                    | Chat with pdf using GPT4 and ChatGPT                                                       | `apiKey` | Yes   | Yes     |
+| [Cloudmersive Natural Language Processing](https://www.cloudmersive.com/nlp-api)                                                     | Natural language processing and text analysis                                              | `apiKey` | Yes   | Yes     |
+| [Code Detection API](https://codedetectionapi.runtime.dev)                                                                           | Detect, label, format and enrich the code in your app or in your data pipeline             | `OAuth`  | Yes   | Unknown |
+| [Detect Language](https://detectlanguage.com/)                                                                                       | Detects text language                                                                      | `apiKey` | Yes   | Unknown |
+| [ELI](https://nlp.insightera.co.th/docs/v1.0)                                                                                        | Natural Language Processing Tools for Thai Language                                        | `apiKey` | Yes   | Unknown |
+| [Google Cloud Natural](https://cloud.google.com/natural-language/docs/)                                                              | Natural language understanding technology, including sentiment, entity and syntax analysis | `apiKey` | Yes   | Unknown |
+| [LanguageTool](https://languagetool.org/http-api/)                                                                                   | Style and Grammar Checker for 25+ Languages                                                | No       | Yes   | Unknown |
+| [Lecto Translation](https://rapidapi.com/lecto-lecto-default/api/lecto-translation/)                                                 | Translation API with free tier and reasonable prices                                       | `apiKey` | Yes   | Yes     |
+| [LibreTranslate](https://libretranslate.com/docs)                                                                                    | Translation tool with 17 available languages                                               | No       | Yes   | Unknown |
+| [Semantria](https://semantria.readme.io/docs)                                                                                        | Text Analytics with sentiment analysis, categorization & named entity extraction           | `OAuth`  | Yes   | Unknown |
+| [Sentiment Analysis](https://www.meaningcloud.com/developer/sentiment-analysis)                                                      | Multilingual sentiment analysis of texts from different sources                            | `apiKey` | Yes   | Yes     |
+| [Tisane](https://tisane.ai/)                                                                                                         | Text Analytics with focus on detection of abusive content and law enforcement applications | `OAuth`  | Yes   | Yes     |
+| [Watson Natural Language Understanding](https://cloud.ibm.com/apidocs/natural-language-understanding/natural-language-understanding) | Natural language processing for advanced text analysis                                     | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Tracking
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Aftership](https://developers.aftership.com/reference/quick-start) | API to update, manage and track shipment efficiently | `apiKey`| Yes | Yes |
-| [Correios](https://cws.correios.com.br/ajuda) | Integration to provide information and prepare shipments using Correio's services | `apiKey`| Yes | Unknown |
-| [IndianPincodes](https://www.indianpincodes.co.in) | API for getting Pincode details in India | `apiKey` | Yes | Unknown |
-| [Pixela](https://pixe.la) | API for recording and tracking habits or effort, routines | `X-Mashape-Key` | Yes | Yes |
-| [PostalPinCode](http://www.postalpincode.in/Api-Details) | API for getting Pincode details in India | No | Yes | Unknown |
-| [Postmon](http://postmon.com.br) | An API to query Brazilian ZIP codes and orders easily, quickly and free | No | No | Unknown |
-| [PostNord](https://developer.postnord.com/apis) | Provides information about parcels in transport for Sweden and Denmark | `apiKey`| No | Unknown |
-| [UPS](https://www.ups.com/upsdeveloperkit) | Shipment and Address information | `apiKey`| Yes | Unknown |
-| [WeCanTrack](https://docs.wecantrack.com) | Automatically place subids in affiliate links to attribute affiliate conversions to click data | `apiKey`| Yes | Yes |
-| [WhatPulse](https://developer.whatpulse.org/#web-api) | Small application that measures your keyboard/mouse usage | No | Yes | Unknown |
+
+| API                                                                 | Description                                                                                    | Auth            | HTTPS | CORS    |
+| ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------- | --------------- | ----- | ------- |
+| [Aftership](https://developers.aftership.com/reference/quick-start) | API to update, manage and track shipment efficiently                                           | `apiKey`        | Yes   | Yes     |
+| [Correios](https://cws.correios.com.br/ajuda)                       | Integration to provide information and prepare shipments using Correio's services              | `apiKey`        | Yes   | Unknown |
+| [IndianPincodes](https://www.indianpincodes.co.in)                  | API for getting Pincode details in India                                                       | `apiKey`        | Yes   | Unknown |
+| [Pixela](https://pixe.la)                                           | API for recording and tracking habits or effort, routines                                      | `X-Mashape-Key` | Yes   | Yes     |
+| [PostalPinCode](http://www.postalpincode.in/Api-Details)            | API for getting Pincode details in India                                                       | No              | Yes   | Unknown |
+| [Postmon](http://postmon.com.br)                                    | An API to query Brazilian ZIP codes and orders easily, quickly and free                        | No              | No    | Unknown |
+| [PostNord](https://developer.postnord.com/apis)                     | Provides information about parcels in transport for Sweden and Denmark                         | `apiKey`        | No    | Unknown |
+| [UPS](https://www.ups.com/upsdeveloperkit)                          | Shipment and Address information                                                               | `apiKey`        | Yes   | Unknown |
+| [WeCanTrack](https://docs.wecantrack.com)                           | Automatically place subids in affiliate links to attribute affiliate conversions to click data | `apiKey`        | Yes   | Yes     |
+| [WhatPulse](https://developer.whatpulse.org/#web-api)               | Small application that measures your keyboard/mouse usage                                      | No              | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Transportation
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [adsbdb](https://www.adsbdb.com) | Open access to aircraft, airline, and flight route data | No | Yes | Yes |
-| [ADS-B Exchange](https://www.adsbexchange.com/data/) | Access real-time and historical data of any and all airborne aircraft | `apiKey` | Yes | Unknown |
-| [airportsapi](https://airport-web.appspot.com/api/docs/) | Get name and website-URL for airports by ICAO code | No | Yes | Unknown |
-| [AIS Hub](http://www.aishub.net/api) | Real-time data of any marine and inland vessel equipped with AIS tracking system | `apiKey` | No | Unknown |
-| [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth`| Yes | Unknown |
-| [AviationAPI](https://docs.aviationapi.com) | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather | No | Yes | No |
-| [AZ511](https://www.az511.com/developers/doc) | Access traffic data from the ADOT API | `apiKey` | Yes | Unknown |
-| [Bay Area Rapid Transit](http://api.bart.gov) | Stations and predicted arrivals for BART | `apiKey` | No | Unknown |
-| [BC Ferries](https://www.bcferriesapi.ca) | Sailing times and capacities for BC Ferries | No | Yes | Yes |
-| [BIC-Boxtech](https://docs.bic-boxtech.org/) | Container technical detail for the global container fleet | `OAuth`| Yes | Unknown |
-| [Boston MBTA Transit](https://www.mbta.com/developers/v3-api) | Stations and predicted arrivals for MBTA | `apiKey` | Yes | Unknown |
-| [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | Transitland API | No | Yes | Unknown |
-| [CTS](https://api.cts-strasbourg.eu/) | CTS Realtime API | `apiKey` | Yes | Yes |
-| [facha](https://docs.api.facha.dev/) | Aircraft Tracking, AIS Ship Tracking, Temporary Email Detection, IP GeoLocation, Package Tracking  | No | Yes | Unknown |
-| [Flight Fare Search](https://rapidapi.com/farish978/api/flight-fare-search) | Search for realtime flight fares across destinations | `apiKey` | Yes | Yes |
-| [Fuel Prices at Spanish Gas Stations](https://datos.gob.es/en/apidata) | Provides information about fuel prices at gas stations in Spain | No | Yes | No |
-| [Grab](https://developer.grab.com/docs/) | Track deliveries, ride fares, payments and loyalty points | `OAuth`| Yes | Unknown |
-| [GraphHopper](https://docs.graphhopper.com/) | A-to-B routing with turn-by-turn instructions | `apiKey` | Yes | Unknown |
-| [Icelandic APIs](http://docs.apis.is/) | Open APIs that deliver services in or regarding Iceland | No | Yes | Unknown |
-| [Izi](http://api-docs.izi.travel/) | Audio guide for travellers | `apiKey` | Yes | Unknown |
-| [Konkan Railway Live Train Position](https://konkan-railway-api.vercel.app/) | Realtime data for trains on India's Konkan Railway | No | Yes | Yes |
-| [Land Transport Authority DataMall, Singapore](https://datamall.lta.gov.sg/content/dam/datamall/datasets/LTA_DataMall_API_User_Guide.pdf) | Singapore transport information | `apiKey` | No | Unknown |
-| [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
-| [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
-| [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
-| [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
-| [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
-| [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
-| [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
-| [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
-| [Swedavia Airports](https://apideveloper.swedavia.se/) | Airport and flight information of Swedish Airports operated by Swedavia | `apiKey` | Yes | No |
-| [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |
-| [TransitLand](https://www.transit.land/documentation/datastore/api-endpoints.html) | Transit Aggregation | No | Yes | Unknown |
-| [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx) | Marta | No | No | Unknown |
-| [Transport for Auckland, New Zealand](https://dev-portal.at.govt.nz/) | Auckland Transport | No | Yes | Unknown |
-| [Transport for Belgium](https://docs.irail.be/) | The iRail API is a third-party API for Belgian public transport by train | No | Yes | Yes |
-| [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/5/docs/api.md) | Third-party VBB API | No | Yes | Unknown |
-| [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/) | Bordeaux Métropole public transport and more (France) | `apiKey` | Yes | Unknown |
-| [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io) | Budapest public transport API | No | Yes | Unknown |
-| [Transport for Chicago, US](http://www.transitchicago.com/developers/) | Chicago Transit Authority (CTA) | `apiKey` | No | Unknown |
-| [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet) | Czech transport API | No | Yes | Unknown |
-| [Transport for Finland](https://digitransit.fi/en/developers/) | Finnish transport API | `apiKey` | Yes | Unknown |
-| [Transport for Grenoble, France](https://www.mobilites-m.fr/pages/opendata/OpenDataApi.html) | Grenoble public transport | No | No | No |
-| [Transport for Hessen, Germany](https://opendata.rmv.de/site/start.html) | RMV API (Public Transport in Hessen) | No | Yes | Unknown |
-| [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp) | Honolulu Transportation Information | `apiKey` | No | Unknown |
-| [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/) | Data about buses routes, parking and traffic | `apiKey` | Yes | Unknown |
-| [Transport for London, England](https://api.tfl.gov.uk) | TfL API | `apiKey` | Yes | Unknown |
-| [Transport for Los Angeles, US](https://developer.metro.net/api/) | Data about positions of Metro vehicles in real time and travel their routes | No | Yes | Unknown |
-| [Transport for Norway](https://developer.entur.org/) | Transport APIs and dataset for Norway | No | Yes | Unknown |
-| [Transport for Ottawa, Canada](https://www.octranspo.com/en/plan-your-trip/travel-tools/developers) | OC Transpo API | `apiKey` | Yes | Unknown |
-| [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/) | RATP Open Data API | No | No | Unknown |
-| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/) | SPTrans | `OAuth`| No | Unknown |
-| [Transport for Spain](https://data.renfe.com/api/1/util/snippet/api_info.html?resource_id=a2368cff-1562-4dde-8466-9635ea3a572a) | Public trains of Spain | No | Yes | Unknown |
-| [Transport for Sweden](https://www.trafiklab.se/api) | Public Transport consumer | `OAuth`| Yes | Unknown |
-| [Transport for Switzerland](https://opentransportdata.swiss/en/) | Official Swiss Public Transport Open Data | `apiKey` | Yes | Unknown |
-| [Transport for Switzerland](https://transport.opendata.ch/) | Swiss public transport API | No | Yes | Unknown |
-| [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api) | NS, only trains | `apiKey` | No | Unknown |
-| [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki) | OVAPI, country-wide public transport | No | Yes | Unknown |
-| [Transport for Toronto, Canada](https://myttc.ca/developers) | TTC | No | Yes | Unknown |
-| [Transport for UK](https://developer.transportapi.com) | Transport API and dataset for UK | `apiKey` | Yes | Unknown |
-| [Transport for United States](https://retro.umoiq.com/xmlFeedDocs/NextBusXMLFeed.pdf) | NextBus API | No | No | Unknown |
-| [Transport for Vancouver, Canada](https://developer.translink.ca/) | TransLink | `OAuth`| Yes | Unknown |
-| [Transport for Washington, US](https://developer.wmata.com/) | Washington Metro transport API | `OAuth`| Yes | Unknown |
-| [transport.rest](https://transport.rest) | Community maintained, developer-friendly public transport API | No | Yes | Yes |
-| [Tripadvisor](https://developer-tripadvisor.com/home/) | Rating content for a hotel, restaurant, attraction or destination | `apiKey` | Yes | Unknown |
-| [Uber](https://developer.uber.com/products) | Uber ride requests and price estimation | `OAuth`| Yes | Yes |
-| [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole) | Velib Open Data API | No | Yes | No |
+
+| API                                                                                                                                       | Description                                                                                       | Auth     | HTTPS | CORS    |
+| ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [adsbdb](https://www.adsbdb.com)                                                                                                          | Open access to aircraft, airline, and flight route data                                           | No       | Yes   | Yes     |
+| [ADS-B Exchange](https://www.adsbexchange.com/data/)                                                                                      | Access real-time and historical data of any and all airborne aircraft                             | `apiKey` | Yes   | Unknown |
+| [airportsapi](https://airport-web.appspot.com/api/docs/)                                                                                  | Get name and website-URL for airports by ICAO code                                                | No       | Yes   | Unknown |
+| [AIS Hub](http://www.aishub.net/api)                                                                                                      | Real-time data of any marine and inland vessel equipped with AIS tracking system                  | `apiKey` | No    | Unknown |
+| [Amadeus for Developers](https://developers.amadeus.com/self-service)                                                                     | Travel Search - Limited usage                                                                     | `OAuth`  | Yes   | Unknown |
+| [AviationAPI](https://docs.aviationapi.com)                                                                                               | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather                | No       | Yes   | No      |
+| [AZ511](https://www.az511.com/developers/doc)                                                                                             | Access traffic data from the ADOT API                                                             | `apiKey` | Yes   | Unknown |
+| [Bay Area Rapid Transit](http://api.bart.gov)                                                                                             | Stations and predicted arrivals for BART                                                          | `apiKey` | No    | Unknown |
+| [BC Ferries](https://www.bcferriesapi.ca)                                                                                                 | Sailing times and capacities for BC Ferries                                                       | No       | Yes   | Yes     |
+| [BIC-Boxtech](https://docs.bic-boxtech.org/)                                                                                              | Container technical detail for the global container fleet                                         | `OAuth`  | Yes   | Unknown |
+| [Boston MBTA Transit](https://www.mbta.com/developers/v3-api)                                                                             | Stations and predicted arrivals for MBTA                                                          | `apiKey` | Yes   | Unknown |
+| [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints)                             | Transitland API                                                                                   | No       | Yes   | Unknown |
+| [CTS](https://api.cts-strasbourg.eu/)                                                                                                     | CTS Realtime API                                                                                  | `apiKey` | Yes   | Yes     |
+| [facha](https://docs.api.facha.dev/)                                                                                                      | Aircraft Tracking, AIS Ship Tracking, Temporary Email Detection, IP GeoLocation, Package Tracking | No       | Yes   | Unknown |
+| [Flight Fare Search](https://rapidapi.com/farish978/api/flight-fare-search)                                                               | Search for realtime flight fares across destinations                                              | `apiKey` | Yes   | Yes     |
+| [Fuel Prices at Spanish Gas Stations](https://datos.gob.es/en/apidata)                                                                    | Provides information about fuel prices at gas stations in Spain                                   | No       | Yes   | No      |
+| [Grab](https://developer.grab.com/docs/)                                                                                                  | Track deliveries, ride fares, payments and loyalty points                                         | `OAuth`  | Yes   | Unknown |
+| [GraphHopper](https://docs.graphhopper.com/)                                                                                              | A-to-B routing with turn-by-turn instructions                                                     | `apiKey` | Yes   | Unknown |
+| [Icelandic APIs](http://docs.apis.is/)                                                                                                    | Open APIs that deliver services in or regarding Iceland                                           | No       | Yes   | Unknown |
+| [Izi](http://api-docs.izi.travel/)                                                                                                        | Audio guide for travellers                                                                        | `apiKey` | Yes   | Unknown |
+| [Konkan Railway Live Train Position](https://konkan-railway-api.vercel.app/)                                                              | Realtime data for trains on India's Konkan Railway                                                | No       | Yes   | Yes     |
+| [Land Transport Authority DataMall, Singapore](https://datamall.lta.gov.sg/content/dam/datamall/datasets/LTA_DataMall_API_User_Guide.pdf) | Singapore transport information                                                                   | `apiKey` | No    | Unknown |
+| [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php)                                                                            | Delays in subway lines                                                                            | No       | No    | No      |
+| [Navitia](https://doc.navitia.io/)                                                                                                        | The open API for building cool stuff with transport data                                          | `apiKey` | Yes   | Unknown |
+| [Open Charge Map](https://openchargemap.org/site/develop/api)                                                                             | Global public registry of electric vehicle charging locations                                     | `apiKey` | Yes   | Yes     |
+| [OpenSky Network](https://opensky-network.org/apidoc/index.html)                                                                          | Free real-time ADS-B aviation data                                                                | No       | Yes   | Unknown |
+| [Railway Transport for France](https://www.digital.sncf.com/startup/api)                                                                  | SNCF public API                                                                                   | `apiKey` | Yes   | Unknown |
+| [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms)                                                                 | Provides safe restroom access for transgender, intersex and gender nonconforming individuals      | No       | Yes   | Unknown |
+| [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel)                             | Travel Search - Limited usage                                                                     | `apiKey` | Yes   | Unknown |
+| [Schiphol Airport](https://developer.schiphol.nl/)                                                                                        | Schiphol                                                                                          | `apiKey` | Yes   | Unknown |
+| [Swedavia Airports](https://apideveloper.swedavia.se/)                                                                                    | Airport and flight information of Swedish Airports operated by Swedavia                           | `apiKey` | Yes   | No      |
+| [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/)                                                                          | German realtime gas/diesel prices                                                                 | `apiKey` | Yes   | Yes     |
+| [TransitLand](https://www.transit.land/documentation/datastore/api-endpoints.html)                                                        | Transit Aggregation                                                                               | No       | Yes   | Unknown |
+| [Transport for Atlanta, US](http://www.itsmarta.com/app-developer-resources.aspx)                                                         | Marta                                                                                             | No       | No    | Unknown |
+| [Transport for Auckland, New Zealand](https://dev-portal.at.govt.nz/)                                                                     | Auckland Transport                                                                                | No       | Yes   | Unknown |
+| [Transport for Belgium](https://docs.irail.be/)                                                                                           | The iRail API is a third-party API for Belgian public transport by train                          | No       | Yes   | Yes     |
+| [Transport for Berlin, Germany](https://github.com/derhuerst/vbb-rest/blob/5/docs/api.md)                                                 | Third-party VBB API                                                                               | No       | Yes   | Unknown |
+| [Transport for Bordeaux, France](https://opendata.bordeaux-metropole.fr/explore/)                                                         | Bordeaux Métropole public transport and more (France)                                             | `apiKey` | Yes   | Unknown |
+| [Transport for Budapest, Hungary](https://bkkfutar.docs.apiary.io)                                                                        | Budapest public transport API                                                                     | No       | Yes   | Unknown |
+| [Transport for Chicago, US](http://www.transitchicago.com/developers/)                                                                    | Chicago Transit Authority (CTA)                                                                   | `apiKey` | No    | Unknown |
+| [Transport for Czech Republic](https://www.chaps.cz/eng/products/idos-internet)                                                           | Czech transport API                                                                               | No       | Yes   | Unknown |
+| [Transport for Finland](https://digitransit.fi/en/developers/)                                                                            | Finnish transport API                                                                             | `apiKey` | Yes   | Unknown |
+| [Transport for Grenoble, France](https://www.mobilites-m.fr/pages/opendata/OpenDataApi.html)                                              | Grenoble public transport                                                                         | No       | No    | No      |
+| [Transport for Hessen, Germany](https://opendata.rmv.de/site/start.html)                                                                  | RMV API (Public Transport in Hessen)                                                              | No       | Yes   | Unknown |
+| [Transport for Honolulu, US](http://hea.thebus.org/api_info.asp)                                                                          | Honolulu Transportation Information                                                               | `apiKey` | No    | Unknown |
+| [Transport for Lisbon, Portugal](https://emel.city-platform.com/opendata/)                                                                | Data about buses routes, parking and traffic                                                      | `apiKey` | Yes   | Unknown |
+| [Transport for London, England](https://api.tfl.gov.uk)                                                                                   | TfL API                                                                                           | `apiKey` | Yes   | Unknown |
+| [Transport for Los Angeles, US](https://developer.metro.net/api/)                                                                         | Data about positions of Metro vehicles in real time and travel their routes                       | No       | Yes   | Unknown |
+| [Transport for Norway](https://developer.entur.org/)                                                                                      | Transport APIs and dataset for Norway                                                             | No       | Yes   | Unknown |
+| [Transport for Ottawa, Canada](https://www.octranspo.com/en/plan-your-trip/travel-tools/developers)                                       | OC Transpo API                                                                                    | `apiKey` | Yes   | Unknown |
+| [Transport for Paris, France](http://data.ratp.fr/api/v1/console/datasets/1.0/search/)                                                    | RATP Open Data API                                                                                | No       | No    | Unknown |
+| [Transport for Sao Paulo, Brazil](http://www.sptrans.com.br/desenvolvedores/api-do-olho-vivo-guia-de-referencia/documentacao-api/)        | SPTrans                                                                                           | `OAuth`  | No    | Unknown |
+| [Transport for Spain](https://data.renfe.com/api/1/util/snippet/api_info.html?resource_id=a2368cff-1562-4dde-8466-9635ea3a572a)           | Public trains of Spain                                                                            | No       | Yes   | Unknown |
+| [Transport for Sweden](https://www.trafiklab.se/api)                                                                                      | Public Transport consumer                                                                         | `OAuth`  | Yes   | Unknown |
+| [Transport for Switzerland](https://opentransportdata.swiss/en/)                                                                          | Official Swiss Public Transport Open Data                                                         | `apiKey` | Yes   | Unknown |
+| [Transport for Switzerland](https://transport.opendata.ch/)                                                                               | Swiss public transport API                                                                        | No       | Yes   | Unknown |
+| [Transport for The Netherlands](http://www.ns.nl/reisinformatie/ns-api)                                                                   | NS, only trains                                                                                   | `apiKey` | No    | Unknown |
+| [Transport for The Netherlands](https://github.com/skywave/KV78Turbo-OVAPI/wiki)                                                          | OVAPI, country-wide public transport                                                              | No       | Yes   | Unknown |
+| [Transport for Toronto, Canada](https://myttc.ca/developers)                                                                              | TTC                                                                                               | No       | Yes   | Unknown |
+| [Transport for UK](https://developer.transportapi.com)                                                                                    | Transport API and dataset for UK                                                                  | `apiKey` | Yes   | Unknown |
+| [Transport for United States](https://retro.umoiq.com/xmlFeedDocs/NextBusXMLFeed.pdf)                                                     | NextBus API                                                                                       | No       | No    | Unknown |
+| [Transport for Vancouver, Canada](https://developer.translink.ca/)                                                                        | TransLink                                                                                         | `OAuth`  | Yes   | Unknown |
+| [Transport for Washington, US](https://developer.wmata.com/)                                                                              | Washington Metro transport API                                                                    | `OAuth`  | Yes   | Unknown |
+| [transport.rest](https://transport.rest)                                                                                                  | Community maintained, developer-friendly public transport API                                     | No       | Yes   | Yes     |
+| [Tripadvisor](https://developer-tripadvisor.com/home/)                                                                                    | Rating content for a hotel, restaurant, attraction or destination                                 | `apiKey` | Yes   | Unknown |
+| [Uber](https://developer.uber.com/products)                                                                                               | Uber ride requests and price estimation                                                           | `OAuth`  | Yes   | Yes     |
+| [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole)                       | Velib Open Data API                                                                               | No       | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
 
 ### URL Shorteners
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [1pt](https://github.com/1pt-co/api/blob/main/README.md) | A simple URL shortener | No | Yes | Yes |
-| [Bitly](http://dev.bitly.com/get_started.html) | URL shortener and link management | `OAuth`| Yes | Unknown |
-| [CleanURI](https://cleanuri.com/docs) | URL shortener service | No | Yes | Yes |
-| [Cutt.ly](https://cutt.ly/api-documentation/cuttly-links-api) | URL shortener service | `apiKey` | Yes | Unknown |
-| [Free Url Shortener](https://ulvis.net/developer.html) | Free URL Shortener offers a powerful API to interact with other sites | No | Yes | Unknown |
-| [Kutt](https://docs.kutt.it/) | Free Modern URL Shortener | `apiKey` | Yes | Yes |
-| [Manyapis.com](https://manyapis.com/products/short-url) | Free URL shortener API with up to 50 requests per day  | Yes | Yes | Yes |
-| [Mgnet.me](http://mgnet.me/api.html) | Torrent URL shorten API | No | Yes | No |
-| [Rebrandly](https://developers.rebrandly.com/v1/docs) | Custom URL shortener for sharing branded links | `apiKey` | Yes | Unknown |
-| [Shrtlnk](https://shrtlnk.dev/developer) | Simple and efficient short link creation | `apiKey` | Yes | Yes |
-| [Spoo.me](https://spoo.me/api) | Free URL shortener with custom alias, max-clicks, password protection and advanced analytics support | No | Yes | Yes |
-| [TinyURL](https://tinyurl.com/app/dev) | Shorten long URLs | `apiKey` | Yes | No |
-| [Urlmskr](https://github.com/Axorax/urlmskr#urlmskr-api) | Easy and fast masked, shortened link creation | No | Yes | Unknown |
+
+| API                                                           | Description                                                                                          | Auth     | HTTPS | CORS    |
+| ------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [1pt](https://github.com/1pt-co/api/blob/main/README.md)      | A simple URL shortener                                                                               | No       | Yes   | Yes     |
+| [Bitly](http://dev.bitly.com/get_started.html)                | URL shortener and link management                                                                    | `OAuth`  | Yes   | Unknown |
+| [CleanURI](https://cleanuri.com/docs)                         | URL shortener service                                                                                | No       | Yes   | Yes     |
+| [Cutt.ly](https://cutt.ly/api-documentation/cuttly-links-api) | URL shortener service                                                                                | `apiKey` | Yes   | Unknown |
+| [Free Url Shortener](https://ulvis.net/developer.html)        | Free URL Shortener offers a powerful API to interact with other sites                                | No       | Yes   | Unknown |
+| [Kutt](https://docs.kutt.it/)                                 | Free Modern URL Shortener                                                                            | `apiKey` | Yes   | Yes     |
+| [Manyapis.com](https://manyapis.com/products/short-url)       | Free URL shortener API with up to 50 requests per day                                                | Yes      | Yes   | Yes     |
+| [Mgnet.me](http://mgnet.me/api.html)                          | Torrent URL shorten API                                                                              | No       | Yes   | No      |
+| [Rebrandly](https://developers.rebrandly.com/v1/docs)         | Custom URL shortener for sharing branded links                                                       | `apiKey` | Yes   | Unknown |
+| [Shrtlnk](https://shrtlnk.dev/developer)                      | Simple and efficient short link creation                                                             | `apiKey` | Yes   | Yes     |
+| [Spoo.me](https://spoo.me/api)                                | Free URL shortener with custom alias, max-clicks, password protection and advanced analytics support | No       | Yes   | Yes     |
+| [TinyURL](https://tinyurl.com/app/dev)                        | Shorten long URLs                                                                                    | `apiKey` | Yes   | No      |
+| [Urlmskr](https://github.com/Axorax/urlmskr#urlmskr-api)      | Easy and fast masked, shortened link creation                                                        | No       | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Vehicle
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe | No | Yes | No |
-| [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Yes | Unknown |
-| [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |
-| [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | Yes | No |
-| [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Yes | Unknown |
-| [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth`| Yes | Yes |
+
+| API                                                                    | Description                                                                                      | Auth     | HTTPS | CORS    |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------- | ----- | ------- |
+| [Brazilian Vehicles and Prices](https://deividfortuna.github.io/fipe/) | Vehicles information from Fundação Instituto de Pesquisas Econômicas - Fipe                      | No       | Yes   | No      |
+| [Helipaddy sites](https://helipaddy.com/api/)                          | Helicopter and passenger drone landing site directory, Helipaddy data and much more              | `apiKey` | Yes   | Unknown |
+| [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default)         | Vehicle info, pricing, configuration, plus much more                                             | `apiKey` | Yes   | No      |
+| [Mercedes-Benz](https://developer.mercedes-benz.com/apis)              | Telematics data, remotely access vehicle functions, car configurator, locate service dealers     | `apiKey` | Yes   | No      |
+| [NHTSA](https://vpic.nhtsa.dot.gov/api/)                               | NHTSA Product Information Catalog and Vehicle Listing                                            | No       | Yes   | Unknown |
+| [Smartcar](https://smartcar.com/docs/)                                 | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth`  | Yes   | Yes     |
 
 **[⬆ Back to Index](#index)**
 
 ### Video
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [An API of Ice And Fire](https://anapioficeandfire.com/) | Game Of Thrones API | No | Yes | Unknown |
-| [Bob's Burgers API](https://bobsburgersapi.com/) | The Bob's Burgers API contains data for hundreds of characters, episodes, running gags, and images from the show | No | Yes | Yes |
-| [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes) | Some Breaking Bad quotes | No | Yes | Unknown |
-| [Buffy the Vampire Slayer and Angel](https://github.com/Thatskat/btvs-angel-api) | Get episode, cast and crew data from Buffy the Vampire Slayer and Angel | No | Yes | Yes |
-| [Catalogopolis](https://api.catalogopolis.xyz/docs/) | Doctor Who API | No | Yes | Unknown |
-| [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/) | TV programme of Czech TV | No | No | Unknown |
-| [Dailymotion](https://developer.dailymotion.com/) | Dailymotion Developer API | `OAuth`| Yes | Unknown |
-| [Dune](https://github.com/ywalia01/dune-api) | A simple API which provides you with book, character, movie and quotes JSON data | No | Yes | Yes |
-| [Final Space](https://finalspaceapi.com/docs/) | Final Space API | No | Yes | Yes |
-| [Game of Thrones Quotes](https://gameofthronesquotes.xyz/) | Some Game of Thrones quotes | No | Yes | Unknown |
-| [Gcore Streaming](https://docs.gcore.com/streaming) | Scale to 100+ million viewers and beyond. Stream everything from online games to online events reliably in minutes instead of months. | `apiKey` | Yes | Yes |
-| [Harry Potter Characters](https://hp-api.onrender.com/) | Harry Potter Characters Data with with imagery | No | Yes | Unknown |
-| [IMDb](https://developer.imdb.com/) | API for receiving movie, serial and cast information | `apiKey` | Yes | Unknown |
-| [IMDbOT](https://github.com/SpEcHiDe/IMDbOT) | Unofficial IMDb Movie / Series Information | No | Yes | Yes |
-| [JSON2Video](https://json2video.com) | Create and edit videos programmatically: watermarks,resizing,slideshows,voice-over,text animations | `apiKey` | Yes | No |
-| [Lucifer Quotes](https://github.com/shadowoff09/lucifer-quotes) | Returns Lucifer quotes | No | Yes | Unknown |
-| [MCU Countdown](https://github.com/DiljotSG/MCU-Countdown) | A Countdown to the next MCU Film | No | Yes | Yes |
-| [Movie Quote](https://github.com/F4R4N/movie-quote/) | Random Movie and Series Quotes | No | Yes | Yes |
-| [Mux](https://www.mux.com/) | Mux Video is an API that enables developers to build unique live and on-demand video experiences | `apiKey` | Yes | Unknown |
-| [Open Movie Database](http://www.omdbapi.com/) | Movie information | `apiKey` | Yes | Unknown |
-| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
-| [Shotstack](https://shotstack.io/) | Cloud-based video editing API | `apiKey` | Yes | Unknown |
-| [Simkl](https://simkl.docs.apiary.io) | Movie, TV and Anime data | `apiKey` | Yes | Unknown |
-| [South Park Quotes](https://github.com/Thatskat/southpark-quotes-api) | Get some quotes from South Park, mmkay! | No | Yes | Unknown |
-| [STAPI](https://stapi.co) | Information on all things Star Trek | No | Yes | Yes |
-| [Stranger Things Quotes](https://github.com/shadowoff09/strangerthings-quotes) | Returns Stranger Things quotes | No | Yes | Unknown |
-| [Stromberg Quotes](https://www.stromberg-api.de/) | Returns Stromberg quotes and more | No | Yes | Unknown |
-| [Supernatural Quotes](https://lidiakovac.github.io/supernatural-api) | 100+ Supernatural quotes | No | Yes | Unknown |
-| [SWAPI](https://swapi.dev/) | All the Star Wars data you've ever wanted | No | Yes | Yes |
-| [SWAPI](https://www.swapi.tech) | All things Star Wars | No | Yes | Yes |
-| [SWAPI GraphQL](https://graphql.org/swapi-graphql) | Star Wars GraphQL API | No | Yes | Unknown |
-| [The Lord of the Rings](https://the-one-api.dev/) | The Lord of the Rings API | `apiKey` | Yes | Unknown |
-| [The Vampire Diaries](https://vampire-diaries-api.netlify.app/) | TV Show Data | `apiKey` | Yes | Yes |
-| [ThronesApi](https://thronesapi.com/) | Game Of Thrones Characters Data with imagery | No | Yes | Unknown |
-| [TMDb](https://www.themoviedb.org/documentation/api) | Community-based movie data | `apiKey` | Yes | Unknown |
-| [TrailerAddict](https://www.traileraddict.com/trailerapi) | Easily embed trailers from TrailerAddict | `apiKey` | No | Unknown |
-| [Trakt](https://trakt.docs.apiary.io/) | Movie and TV Data | `apiKey` | Yes | Yes |
-| [TVDB](https://thetvdb.com/api-information) | Television data | `apiKey` | Yes | Unknown |
-| [TVMaze](http://www.tvmaze.com/api) | TV Show Data | No | No | Unknown |
-| [uNoGS](https://rapidapi.com/unogs/api/unogsng) | Unofficial Netflix Online Global Search, Search all netflix regions in one place | `apiKey` | Yes | Yes |
-| [Vimeo](https://developer.vimeo.com/) | Vimeo Developer API | `OAuth`| Yes | Unknown |
-| [Watchmode](https://api.watchmode.com/) | API for finding out the streaming availability of movies & shows | `apiKey` | Yes | Unknown |
-| [Web Series Quotes Generator](https://github.com/yogeshwaran01/web-series-quotes) | API generates various Web Series Quote Images | No | Yes | Yes |
-| [YouTube](https://developers.google.com/youtube/) | Add YouTube functionality to your sites and apps | `OAuth`| Yes | Unknown |
+
+| API                                                                                                | Description                                                                                                                           | Auth     | HTTPS | CORS    |
+| -------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | -------- | ----- | ------- |
+| [An API of Ice And Fire](https://anapioficeandfire.com/)                                           | Game Of Thrones API                                                                                                                   | No       | Yes   | Unknown |
+| [Bob's Burgers API](https://bobsburgersapi.com/)                                                   | The Bob's Burgers API contains data for hundreds of characters, episodes, running gags, and images from the show                      | No       | Yes   | Yes     |
+| [Breaking Bad Quotes](https://github.com/shevabam/breaking-bad-quotes)                             | Some Breaking Bad quotes                                                                                                              | No       | Yes   | Unknown |
+| [Buffy the Vampire Slayer and Angel](https://github.com/Thatskat/btvs-angel-api)                   | Get episode, cast and crew data from Buffy the Vampire Slayer and Angel                                                               | No       | Yes   | Yes     |
+| [Catalogopolis](https://api.catalogopolis.xyz/docs/)                                               | Doctor Who API                                                                                                                        | No       | Yes   | Unknown |
+| [Czech Television](http://www.ceskatelevize.cz/xml/tv-program/)                                    | TV programme of Czech TV                                                                                                              | No       | No    | Unknown |
+| [Dailymotion](https://developer.dailymotion.com/)                                                  | Dailymotion Developer API                                                                                                             | `OAuth`  | Yes   | Unknown |
+| [Final Space](https://finalspaceapi.com/docs/)                                                     | Final Space API                                                                                                                       | No       | Yes   | Yes     |
+| [Game of Thrones Quotes](https://gameofthronesquotes.xyz/)                                         | Some Game of Thrones quotes                                                                                                           | No       | Yes   | Unknown |
+| [Gcore Streaming](https://docs.gcore.com/streaming)                                                | Scale to 100+ million viewers and beyond. Stream everything from online games to online events reliably in minutes instead of months. | `apiKey` | Yes   | Yes     |
+| [Harry Potter Characters](https://hp-api.onrender.com/)                                            | Harry Potter Characters Data with with imagery                                                                                        | No       | Yes   | Unknown |
+| [IMDb](https://developer.imdb.com/)                                                                | API for receiving movie, serial and cast information                                                                                  | `apiKey` | Yes   | Unknown |
+| [IMDbOT](https://github.com/SpEcHiDe/IMDbOT)                                                       | Unofficial IMDb Movie / Series Information                                                                                            | No       | Yes   | Yes     |
+| [JSON2Video](https://json2video.com)                                                               | Create and edit videos programmatically: watermarks,resizing,slideshows,voice-over,text animations                                    | `apiKey` | Yes   | No      |
+| [Lucifer Quotes](https://github.com/shadowoff09/lucifer-quotes)                                    | Returns Lucifer quotes                                                                                                                | No       | Yes   | Unknown |
+| [MCU Countdown](https://github.com/DiljotSG/MCU-Countdown)                                         | A Countdown to the next MCU Film                                                                                                      | No       | Yes   | Yes     |
+| [Movie Quote](https://github.com/F4R4N/movie-quote/)                                               | Random Movie and Series Quotes                                                                                                        | No       | Yes   | Yes     |
+| [Mux](https://www.mux.com/)                                                                        | Mux Video is an API that enables developers to build unique live and on-demand video experiences                                      | `apiKey` | Yes   | Unknown |
+| [Open Movie Database](http://www.omdbapi.com/)                                                     | Movie information                                                                                                                     | `apiKey` | Yes   | Unknown |
+| [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television                                                                                                                            | No       | Yes   | Unknown |
+| [Shotstack](https://shotstack.io/)                                                                 | Cloud-based video editing API                                                                                                         | `apiKey` | Yes   | Unknown |
+| [Simkl](https://simkl.docs.apiary.io)                                                              | Movie, TV and Anime data                                                                                                              | `apiKey` | Yes   | Unknown |
+| [South Park Quotes](https://github.com/Thatskat/southpark-quotes-api)                              | Get some quotes from South Park, mmkay!                                                                                               | No       | Yes   | Unknown |
+| [STAPI](https://stapi.co)                                                                          | Information on all things Star Trek                                                                                                   | No       | Yes   | Yes     |
+| [Stranger Things Quotes](https://github.com/shadowoff09/strangerthings-quotes)                     | Returns Stranger Things quotes                                                                                                        | No       | Yes   | Unknown |
+| [Stromberg Quotes](https://www.stromberg-api.de/)                                                  | Returns Stromberg quotes and more                                                                                                     | No       | Yes   | Unknown |
+| [Supernatural Quotes](https://lidiakovac.github.io/supernatural-api)                               | 100+ Supernatural quotes                                                                                                              | No       | Yes   | Unknown |
+| [SWAPI](https://swapi.dev/)                                                                        | All the Star Wars data you've ever wanted                                                                                             | No       | Yes   | Yes     |
+| [SWAPI](https://www.swapi.tech)                                                                    | All things Star Wars                                                                                                                  | No       | Yes   | Yes     |
+| [SWAPI GraphQL](https://graphql.org/swapi-graphql)                                                 | Star Wars GraphQL API                                                                                                                 | No       | Yes   | Unknown |
+| [The Lord of the Rings](https://the-one-api.dev/)                                                  | The Lord of the Rings API                                                                                                             | `apiKey` | Yes   | Unknown |
+| [The Vampire Diaries](https://vampire-diaries-api.netlify.app/)                                    | TV Show Data                                                                                                                          | `apiKey` | Yes   | Yes     |
+| [ThronesApi](https://thronesapi.com/)                                                              | Game Of Thrones Characters Data with imagery                                                                                          | No       | Yes   | Unknown |
+| [TMDb](https://www.themoviedb.org/documentation/api)                                               | Community-based movie data                                                                                                            | `apiKey` | Yes   | Unknown |
+| [TrailerAddict](https://www.traileraddict.com/trailerapi)                                          | Easily embed trailers from TrailerAddict                                                                                              | `apiKey` | No    | Unknown |
+| [Trakt](https://trakt.docs.apiary.io/)                                                             | Movie and TV Data                                                                                                                     | `apiKey` | Yes   | Yes     |
+| [TVDB](https://thetvdb.com/api-information)                                                        | Television data                                                                                                                       | `apiKey` | Yes   | Unknown |
+| [TVMaze](http://www.tvmaze.com/api)                                                                | TV Show Data                                                                                                                          | No       | No    | Unknown |
+| [uNoGS](https://rapidapi.com/unogs/api/unogsng)                                                    | Unofficial Netflix Online Global Search, Search all netflix regions in one place                                                      | `apiKey` | Yes   | Yes     |
+| [Vimeo](https://developer.vimeo.com/)                                                              | Vimeo Developer API                                                                                                                   | `OAuth`  | Yes   | Unknown |
+| [Watchmode](https://api.watchmode.com/)                                                            | API for finding out the streaming availability of movies & shows                                                                      | `apiKey` | Yes   | Unknown |
+| [Web Series Quotes Generator](https://github.com/yogeshwaran01/web-series-quotes)                  | API generates various Web Series Quote Images                                                                                         | No       | Yes   | Yes     |
+| [YouTube](https://developers.google.com/youtube/)                                                  | Add YouTube functionality to your sites and apps                                                                                      | `OAuth`  | Yes   | Unknown |
 
 **[⬆ Back to Index](#index)**
 
 ### Weather
-| API | Description | Auth | HTTPS | CORS |
-|---|---|---|---|---|
-| [7Timer!](http://www.7timer.info/doc.php?lang=en) | Weather, especially for Astroweather | No | No | Unknown |
-| [AccuWeather](https://developer.accuweather.com/apis) | Weather and forecast data | `apiKey` | No | Unknown |
-| [Aemet](https://opendata.aemet.es/centrodedescargas/inicio) | Weather and forecast data from Spain | `apiKey` | Yes | Unknown |
-| [APIXU](https://www.apixu.com/doc/request.aspx) | Weather | `apiKey` | Yes | Unknown |
-| [AQICN](https://aqicn.org/api/) | Air Quality Index Data for over 1000 cities | `apiKey` | Yes | Unknown |
-| [AviationWeather](https://www.aviationweather.gov/dataserver) | NOAA aviation weather forecasts and observations | No | Yes | Unknown |
-| [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API) | Weather | `apiKey` | Yes | Yes |
-| [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/) | Meteorological data of the Basque Country | `apiKey` | Yes | Unknown |
-| [Foreca](https://developer.foreca.com) | Weather | `OAuth`| Yes | Unknown |
-| [HG Weather](https://hgbrasil.com/status/weather) | Provides weather forecast data for cities in Brazil | `apiKey` | Yes | Yes |
-| [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data | No | Yes | Unknown |
-| [Korea Meteorological Administration](https://apihub.kma.go.kr/) | Weather and climate data from KMA | `apiKey` | Yes | Unknown |
-| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation) | Weather and climate data | `User-Agent` | Yes | Unknown |
-| [Meteosource](https://www.meteosource.com/) | Global weather forecasts based on machine learning and historical data | `apiKey` | Yes | Unknown |
-| [Met Office DataPoint](https://www.metoffice.gov.uk/services/data/datapoint/) | Weather data for the UK | `apiKey` | Yes | Unknown |
-| [ODWeather](http://api.oceandrivers.com/static/docs.html) | Weather and weather webcams | No | No | Unknown |
-| [Oikolab](https://docs.oikolab.com) | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey` | Yes | Yes |
-| [Open-Meteo](https://open-meteo.com/) | Global weather forecast API for non-commercial use | No | Yes | Yes |
-| [openSenseMap](https://api.opensensemap.org/) | Data from Personal Weather Stations called senseBoxes | No | Yes | Yes |
-| [OpenUV](https://www.openuv.io) | Real-time UV Index Forecast | `apiKey` | Yes | Unknown |
-| [OpenWeatherMap](https://openweathermap.org/api) | Weather | `apiKey` | Yes | Unknown |
-| [QWeather](https://dev.qweather.com/en/) | Location-based weather data | `apiKey` | Yes | Yes |
-| [RainViewer](https://www.rainviewer.com/api.html) | Radar data collected from different websites across the Internet | No | Yes | Unknown |
-| [Storm Glass](https://stormglass.io/) | Global marine weather from multiple sources | `apiKey` | Yes | Yes |
-| [Tomorrow](https://docs.tomorrow.io) | Weather API Powered by Proprietary Technology | `apiKey` | Yes | Unknown |
-| [US Weather](https://www.weather.gov/documentation/services-web-api) | US National Weather Service | No | Yes | Yes |
-| [Visual Crossing](https://www.visualcrossing.com/weather-api) | Global historical and weather forecast data | `apiKey` | Yes | Yes |
-| [weather-api](https://github.com/robertoduessmann/weather-api) | A RESTful free API to check the weather | No | Yes | No |
-| [WeatherAPI](https://www.weatherapi.com/) | Weather API with other stuff like Astronomy and Geolocation API | `apiKey` | Yes | Yes |
-| [Weatherbit](https://www.weatherbit.io/api) | Weather | `apiKey` | Yes | Unknown |
-| [Yandex.Weather](https://yandex.com/dev/weather/) | Assesses weather condition in specific locations | `apiKey` | Yes | No |
+
+| API                                                                           | Description                                                                          | Auth         | HTTPS | CORS    |
+| ----------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ | ------------ | ----- | ------- |
+| [7Timer!](http://www.7timer.info/doc.php?lang=en)                             | Weather, especially for Astroweather                                                 | No           | No    | Unknown |
+| [AccuWeather](https://developer.accuweather.com/apis)                         | Weather and forecast data                                                            | `apiKey`     | No    | Unknown |
+| [Aemet](https://opendata.aemet.es/centrodedescargas/inicio)                   | Weather and forecast data from Spain                                                 | `apiKey`     | Yes   | Unknown |
+| [APIXU](https://www.apixu.com/doc/request.aspx)                               | Weather                                                                              | `apiKey`     | Yes   | Unknown |
+| [AQICN](https://aqicn.org/api/)                                               | Air Quality Index Data for over 1000 cities                                          | `apiKey`     | Yes   | Unknown |
+| [AviationWeather](https://www.aviationweather.gov/dataserver)                 | NOAA aviation weather forecasts and observations                                     | No           | Yes   | Unknown |
+| [ColorfulClouds](https://open.caiyunapp.com/ColorfulClouds_Weather_API)       | Weather                                                                              | `apiKey`     | Yes   | Yes     |
+| [Euskalmet](https://opendata.euskadi.eus/api-euskalmet/-/api-de-euskalmet/)   | Meteorological data of the Basque Country                                            | `apiKey`     | Yes   | Unknown |
+| [Foreca](https://developer.foreca.com)                                        | Weather                                                                              | `OAuth`      | Yes   | Unknown |
+| [HG Weather](https://hgbrasil.com/status/weather)                             | Provides weather forecast data for cities in Brazil                                  | `apiKey`     | Yes   | Yes     |
+| [Hong Kong Obervatory](https://www.hko.gov.hk/en/abouthko/opendata_intro.htm) | Provide weather information, earthquake information, and climate data                | No           | Yes   | Unknown |
+| [Korea Meteorological Administration](https://apihub.kma.go.kr/)              | Weather and climate data from KMA                                                    | `apiKey`     | Yes   | Unknown |
+| [Meteorologisk Institutt](https://api.met.no/weatherapi/documentation)        | Weather and climate data                                                             | `User-Agent` | Yes   | Unknown |
+| [Meteosource](https://www.meteosource.com/)                                   | Global weather forecasts based on machine learning and historical data               | `apiKey`     | Yes   | Unknown |
+| [Met Office DataPoint](https://www.metoffice.gov.uk/services/data/datapoint/) | Weather data for the UK                                                              | `apiKey`     | Yes   | Unknown |
+| [ODWeather](http://api.oceandrivers.com/static/docs.html)                     | Weather and weather webcams                                                          | No           | No    | Unknown |
+| [Oikolab](https://docs.oikolab.com)                                           | 70+ years of global, hourly historical and forecast weather data from NOAA and ECMWF | `apiKey`     | Yes   | Yes     |
+| [Open-Meteo](https://open-meteo.com/)                                         | Global weather forecast API for non-commercial use                                   | No           | Yes   | Yes     |
+| [openSenseMap](https://api.opensensemap.org/)                                 | Data from Personal Weather Stations called senseBoxes                                | No           | Yes   | Yes     |
+| [OpenUV](https://www.openuv.io)                                               | Real-time UV Index Forecast                                                          | `apiKey`     | Yes   | Unknown |
+| [OpenWeatherMap](https://openweathermap.org/api)                              | Weather                                                                              | `apiKey`     | Yes   | Unknown |
+| [QWeather](https://dev.qweather.com/en/)                                      | Location-based weather data                                                          | `apiKey`     | Yes   | Yes     |
+| [RainViewer](https://www.rainviewer.com/api.html)                             | Radar data collected from different websites across the Internet                     | No           | Yes   | Unknown |
+| [Storm Glass](https://stormglass.io/)                                         | Global marine weather from multiple sources                                          | `apiKey`     | Yes   | Yes     |
+| [Tomorrow](https://docs.tomorrow.io)                                          | Weather API Powered by Proprietary Technology                                        | `apiKey`     | Yes   | Unknown |
+| [US Weather](https://www.weather.gov/documentation/services-web-api)          | US National Weather Service                                                          | No           | Yes   | Yes     |
+| [Visual Crossing](https://www.visualcrossing.com/weather-api)                 | Global historical and weather forecast data                                          | `apiKey`     | Yes   | Yes     |
+| [weather-api](https://github.com/robertoduessmann/weather-api)                | A RESTful free API to check the weather                                              | No           | Yes   | No      |
+| [WeatherAPI](https://www.weatherapi.com/)                                     | Weather API with other stuff like Astronomy and Geolocation API                      | `apiKey`     | Yes   | Yes     |
+| [Weatherbit](https://www.weatherbit.io/api)                                   | Weather                                                                              | `apiKey`     | Yes   | Unknown |
+| [Yandex.Weather](https://yandex.com/dev/weather/)                             | Assesses weather condition in specific locations                                     | `apiKey`     | Yes   | No      |
 
 **[⬆ Back to Index](#index)**
-


### PR DESCRIPTION
See https://github.com/ywalia01/dune-api - API is unfortunately unreachable

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit