### PR TITLE
Add GG.deals to Games & Comics

### DIFF
--- a/README.md
+++ b/README.md
@@ -868,6 +868,7 @@
 | [GamerPower](https://www.gamerpower.com/api-read) | Game Giveaways Tracker | No | Yes | Yes |
 | [Geek-Jokes](https://github.com/sameerkumar18/geek-joke-api) | Fetch a random geeky/programming related joke for use in all sorts of applications | No | Yes | Yes |
 | [Genshin Impact](https://genshin.dev) | Genshin Impact game data | No | Yes | Yes |
+| [GG.deals](https://apidocs.gg.deals/) | Game price comparison and deal data from major stores | apiKey | Yes | No |
 | [Giant Bomb](https://www.giantbomb.com/api/documentation) | Video Games | `apiKey`| Yes | Unknown |
 | [GraphQL Pokemon](https://github.com/favware/graphql-pokemon) | GraphQL powered Pokemon API. Supports generations 1 through 8 | No | Yes | Yes |
 | [Guild Wars 2](https://wiki.guildwars2.com/wiki/API:Main) | Guild Wars 2 Game Information | `apiKey`| Yes | Unknown |


### PR DESCRIPTION
This pull request adds GG.deals API to the Games & Comics section.
The API provides access to video game price comparisons and deal data from major stores like Steam, GOG, and Epic.
Requires a free API key.