### PR TITLE
Delete  OpenSky Network API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1739,7 +1739,6 @@
 | [Metro Lisboa](http://app.metrolisboa.pt/status/getLinhas.php) | Delays in subway lines | No | No | No |
 | [Navitia](https://doc.navitia.io/) | The open API for building cool stuff with transport data | `apiKey` | Yes | Unknown |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
-| [OpenSky Network](https://opensky-network.org/apidoc/index.html) | Free real-time ADS-B aviation data | No | Yes | Unknown |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change removes the entry for the OpenSky Network API, which provided free real-time ADS-B aviation data.

closes #548
removed Broken link

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [ ] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [ ] My addition is ordered alphabetically
-   [ ] My submission has a useful description
-   [ ] The description does not have more than 100 characters
-   [ ] The description does not end with punctuation
-   [ ] Each table column is padded with one space on either side
-   [ ] I have searched the repository for any relevant issues or pull requests
-   [ ] Any category I am creating has the minimum requirement of 3 items
-   [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
