### PR TITLE
Add StockAlert API

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,7 @@
 | [RentCast](https://developers.rentcast.io) | Retrieve real-time property and rental data for real estate in the United States | `apiKey` | Yes | Yes |
 | [SEC EDGAR Data](https://www.sec.gov/search-filings/edgar-application-programming-interfaces) | API to access annual reports of public US companies | No | Yes | Yes |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Yes | Unknown |
+| [StockAlert](https://stockalert.pro/api/docs) | Real-time stock alerts with 21 alert types, technical indicators, and notifications | `apiKey` | Yes | Unknown |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes | Yes |
 | [Stripe](https://stripe.com/docs/api) | Payment processing, subscriptions, and financial management | `apiKey` | Yes | Unknown |
 | [Tradier](https://developer.tradier.com) | US equity/option market data (delayed, intraday, historical) | `OAuth`| Yes | Yes |


### PR DESCRIPTION
Adding StockAlert.pro - a real-time stock alerts API with 21 alert types, technical indicators, and multi-channel notifications.

API Documentation: https://stockalert.pro/api/docs

## Checklist
- [x] API is active and maintained
- [x] Description is under 100 characters (84 chars)
- [x] Follows alphabetical ordering (between SmartAPI and StockData)
- [x] Uses correct authentication field value (apiKey)
- [x] Follows the table format exactly
- [x] One link per PR