### PR TITLE
Add LeakInsight to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1516,6 +1516,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Intelligence X](https://github.com/IntelligenceX/SDK/blob/master/Intelligence%20X%20API.pdf) | Perform OSINT via Intelligence X | `apiKey` | Yes | Unknown |
 | [IntelOwl](https://intelowl.readthedocs.io) | Manage your Threat Intelligence at scale | No | Yes | Unknown |
 | [LoginRadius](https://www.loginradius.com/docs/) | Managed User Authentication Service | `apiKey` | Yes | Yes |
+| [LeakInsight](https://rapidapi.com/codigo6-codigo6-default/api/leakinsight-api/) | Find leaked or exposed credentials by email, username, phone, domain, hash, or breach origin | `apiKey` | Yes | Unknown |
 | [Microsoft Security Response Center (MSRC)](https://msrc.microsoft.com/report/developer) | Programmatic interfaces to engage with the Microsoft Security Response Center (MSRC) | No | Yes | Unknown |
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Yes | Unknown |
 | [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Yes | Unknown |


### PR DESCRIPTION
This PR adds the LeakInsight API to the Security section, maintaining strict alphabetical order and the repository's format. LeakInsight allows users to check leaked credentials by email, username, phone, domain, or hash and provides up to 50 free daily checks.

API documentation: https://rapidapi.com/codigo6-codigo6-default/api/leakinsight-api/

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
