### PR TITLE
Remove Open Skills API entry - Issue #635

### DIFF
--- a/db/resources.json
+++ b/db/resources.json
@@ -8345,15 +8345,6 @@
         "Category": "Jobs"
     },
     {
-        "API": "Open Skills",
-        "Description": "Job titles, skills and related jobs data",
-        "Auth": "",
-        "HTTPS": false,
-        "Cors": "unknown",
-        "Link": "https://github.com/workforce-data-initiative/skills-api/wiki/API-Overview",
-        "Category": "Jobs"
-    },
-    {
         "API": "Reed",
         "Description": "Job board aggregator",
         "Auth": "apiKey",


### PR DESCRIPTION
The Open Skills API (Workforce Data Initiative) appears to be down with requests failing to endpoints. This API has been no longer maintained and should be removed from the database to prevent broken links for users.

Closes #635

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [ ] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [ ] My addition is ordered alphabetically
-   [ ] My submission has a useful description
-   [ ] The description does not have more than 100 characters
-   [ ] The description does not end with punctuation
-   [ ] Each table column is padded with one space on either side
-   [ ] I have searched the repository for any relevant issues or pull requests
-   [ ] Any category I am creating has the minimum requirement of 3 items
-   [ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Open Skills API entry from the Jobs category because the service is down and no longer maintained. This prevents broken links in the resources list.

<sup>Written for commit 18acbca2ebc6b6ac26aee2035e42c2db6b7bf4d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

