### PR TITLE
Remove LCBO API, Add lcbo.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,7 +853,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
 | [Jelly Belly Wiki](https://jelly-belly-wiki.netlify.app/) | Data about Jelly Belly beans- flavores, facts, history and more endpoints | No | Yes | Yes |
 | [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |
-| [LCBO](https://lcboapi.com/) | Alcohol | `apiKey` | Yes | Unknown |
+| [LCBO](https://lcbo.dev/) | Alcohol | No | Yes | Yes |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
 | [PunkAPI](https://github.com/alxiw/punkapi) | BrewDog's DIY Dog beer catalogue as an API | No | Yes | Yes |


### PR DESCRIPTION
Removing lcboapi as is no longer online https://github.com/heycarsten/lcbo-api/issues/49 and adding lcbo.dev, as a replacement.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace the defunct LCBO API (lcboapi.com) with lcbo.dev and update the LCBO entry to match the new service. Auth changed to No, HTTPS to Yes, and CORS to Yes.

<sup>Written for commit 25dcd2047493f2ff8a5081dd6e3eecd414c9b786. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

