### PR TITLE
Remove Random Stuff API (broken link)

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,7 +583,6 @@
 | [QR code Generator](https://docs.openqr.io/) | Static and Dynamic QR code generator with custom and unique QR code design | `apiKey` | Yes | Unknown |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Yes | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes | Yes |
-| [Random Stuff](https://api-docs.pgamerx.com/) | Can be used to get AI Response, jokes, memes, and much more at lightning-fast speed | `apiKey`| Yes | Yes |
 | [Rejax](https://rejax.io/) | Reverse AJAX service to notify clients | `apiKey`| Yes | No |
 | [Render API](https://render.com/docs/api) | Lets you programmatically manage your Render services (web apps, APIs, and static sites) including deployments, scaling, and configuration | `apiKey`| Yes | Unknown |
 | [ReqRes](https://reqres.in/) | A hosted REST-API ready to respond to your AJAX requests | No | Yes | Unknown |


### PR DESCRIPTION
Hi maintainers,

This is my first contribution as a college student learning open-source.

**What I removed:**
- Random Stuff API from the Development category.
- Reason: The link https://api-docs.pgamerx.com/ is broken (returns 404 or no longer available).
- Justification: Verified on [today's date] - link does not load and no docs are accessible.

**Checks performed:**
- Confirmed broken link by testing in browser.
- No other changes made.
- Followed CONTRIBUTING.md rules.

Thank you for reviewing! Happy to discuss if needed.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the "Random Stuff" API entry from the Development category. The docs link (https://api-docs.pgamerx.com/) returns 404, so the listing was removed to keep the list accurate.

<sup>Written for commit 902fa8f472a7dabfbc874b3cea0ae4395e7a7c7e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

