### PR TITLE
Add Vedika API

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,6 +747,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Random Dad Joke](https://icanhazdadjoke.com/) | API for largest selection of dad jokes on the internet | No | Yes | Unknown |
 | [Random Useless Facts](https://uselessfacts.jsph.pl/) | Get useless, but true facts | No | Yes | Unknown |
 | [Techy](https://techy-api.vercel.app/) | JSON and Plaintext API for tech-savvy sounding phrases | No | Yes | Unknown |
+| [Vedika](https://vedika.io) | Vedic astrology API with birth charts, horoscopes, panchang, dasha, compatibility, and AI chatbot | `apiKey` | Yes | Yes |
 | [World Fun Facts (RapidAPI)](https://rapidapi.com/vintarok-vintarok-default/api/world-fun-facts-all-languages-support) | Fun and interesting facts with multi-language support | `apiKey` | Yes | Yes |
 | [Yo Momma Jokes](https://github.com/beanboi7/yomomma-apiv2) | REST API for Yo Momma Jokes | No | Yes | Unknown |
 


### PR DESCRIPTION
## Summary
- Adding [Vedika](https://vedika.io) to the **Entertainment** category (alongside Multilingual AI Zodiac)
- AI-powered Vedic astrology API with horoscopes, birth charts, compatibility analysis
- Supports 22 languages

## API Details
| Field | Value |
|-------|-------|
| **API** | [Vedika](https://vedika.io/docs) |
| **Description** | AI-powered Vedic astrology API with horoscopes, birth charts, compatibility in 22 languages |
| **Auth** | `apiKey` |
| **HTTPS** | Yes |
| **CORS** | Yes |

## Why This Belongs Here
- Similar to `Multilingual AI Zodiac` (existing horoscope API in Entertainment category)
- Free sandbox for development: https://vedika.io/sandbox
- Full documentation: https://vedika.io/docs
- OpenAPI spec: https://vedika.io/api-explorer

## Checklist
- [x] One API per PR
- [x] Alphabetical ordering (between Techy and World Fun Facts)
- [x] Description under 100 characters
- [x] Valid Auth, HTTPS, CORS values
- [x] Squashed commits
- [x] Target main branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)