### PR TITLE
Add EuroRates API

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@
 | [CurrencyScoop](https://currencyscoop.com/api-documentation) | Real-time and historical currency rates JSON API | `apiKey` | Yes | Yes |
 | [Czech National Bank](https://www.cnb.cz/cs/financni_trhy/devizovy_trh/kurzy_devizoveho_trhu/denni_kurz.xml) | A collection of exchange rates | No | Yes | Unknown |
 | [Economia.Awesome](https://docs.awesomeapi.com.br/api-de-moedas) | Portuguese free currency prices and conversion with no rate limits | No | Yes | Unknown |
-| [EuroRates](https://euroratesapi.dev/) | Exchange rates for EUR pairs, historical and real-time data | NO | Yes | No |
+| [EuroRates](https://euroratesapi.dev/) | Exchange rates for EUR pairs, historical and real-time data | No | Yes | No |
 | [ExchangeRate-API](https://www.exchangerate-api.com) | Free currency conversion | `apiKey` | Yes | Yes |
 | [Exchangerate.host](https://exchangerate.host) | Free foreign exchange & crypto rates API | `apiKey` | Yes | Unknown |
 | [Frankfurter](https://www.frankfurter.app/docs) | Exchange rates, currency conversion and time series | No | Yes | Yes |


### PR DESCRIPTION
Add EuroRates, a fully free REST API providing real-time and historical exchange rates for EUR currency pairs from EBC (European Central Bank). 

It supports HTTPS, requires no authentication, and does not support CORS. 

The API includes public documentation and can be used without purchasing any device or paid service.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added EuroRates to the currency APIs list in README. It’s a free HTTPS API for EUR exchange rates (real-time and historical) with no authentication and no CORS support.

<sup>Written for commit eecf08632cdf1a9ce8eccc84e815de8f7ef00898. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

