### PR TITLE
Remove Colormind API due to lack of HTTPS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,6 @@
 | [Art Institute of Chicago](https://api.artic.edu/docs/) | Art | No | Yes | Yes |
 | [Art Search](https://artsearch.io) | Search and discover art with semantic AI search | `apiKey` | Yes | Yes |
 | [ColorMagic](https://colormagic.app/api) | Color Palette Generator | No | Yes | Yes |
-| [Colormind](http://colormind.io/api-access/) | Color scheme generator | No | No | Unknown |
 | [ColourLovers](http://www.colourlovers.com/api) | Get various patterns, palettes and images | No | Yes | Unknown |
 | [Cooper Hewitt](https://collection.cooperhewitt.org/api) | Smithsonian Design Museum | `apiKey` | Yes | Unknown |
 | [Dribbble](https://developer.dribbble.com) | Discover the world’s top designers & creatives | `OAuth`| Yes | Unknown |


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit


---
Colormind API does not support HTTPS.

Verified that https://colormind.io/api-access/ returns 404,
while the API works only over HTTP.

Removing the entry to keep the list secure and consistent.

Fixes #662



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the Colormind API entry because it lacks HTTPS (HTTPS endpoint returns 404; only works over HTTP). This keeps the list secure and consistent.

Fixes #662

<sup>Written for commit c549d78d081b23a21886dfeb2e461cf68377019a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

