### PR TITLE
Add HOL Registry Broker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1228,6 +1228,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [EXUDE-API](http://uttesh.com/exude-api/) | Used for the primary ways for filtering the stopping, stemming words from the text data | No | Yes | Yes |
 | [Face-api.js](https://github.com/justadudewhohacks/face-api.js) | JavaScript API for face detection, recognition, and emotion analysis using TensorFlow.js | No | No | Unknown |
 | [Gladia](https://docs.gladia.io) | Artificial intelligence API's | `apiKey` | Yes | No |
+| [HOL Registry Broker](https://hol.org/docs/registry-broker/) | Discovery API for AI agents & MCP servers (search, verify, UAID, chat) | `apiKey` | Yes | Yes |
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Yes | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Yes | Unknown |
 | [Irisnet](https://irisnet.de/api/) | Realtime content moderation API that blocks or blurs unwanted images in real-time | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds HOL Registry Broker under Machine Learning.

- Docs: https://hol.org/docs/registry-broker/
- OpenAPI: https://hol.org/registry/api/v1/openapi.json
- APIs.json: https://hol.org/registry/apis.json


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added HOL Registry Broker to the Machine Learning APIs list in README to improve discoverability of AI agent and MCP server discovery endpoints. Includes links to docs, OpenAPI, and APIs.json.

<sup>Written for commit 7317d12d666eda93192440664df270da96026e80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

