### PR TITLE
Add MetaScrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,6 +564,7 @@
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey`| Yes | Yes |
 | [Markdown to JSON API](https://apyhub.com/utility/converter-markdown-json) | Upload Markdown and get JSON with one API call | `apiKey` | Yes | Yes |
 | [Markdown to HTML API](https://apyhub.com/utility/converter-md-html) | This API lets you upload and transform a Markdown file to HTML | `apiKey` | Yes | Yes |
+| [MetaScrape](https://metascrape.shanecode.org) | Extract metadata, Open Graph tags, and structured data from any URL | `apiKey` | Yes | Yes |
 | [MicroENV](https://microenv.com/) | Fake Rest API for developers | No | Yes | Unknown |
 | [Mocky](https://designer.mocky.io/) | Mock user defined test JSON for REST API endpoints | No | Yes | Yes |
 | [MY IP](https://www.myip.com/api-docs/) | Get IP address information | No | Yes | Unknown |


### PR DESCRIPTION
## Add MetaScrape

MetaScrape is a metadata extraction API that retrieves Open Graph tags, structured data (JSON-LD), and standard HTML meta tags from any URL. It's built for developers who need clean, parsed metadata without running headless browsers.

- **Category:** Development
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** 100 requests/month (no credit card required)
- **Docs:** https://metascrape.shanecode.org

Entry is alphabetically placed between "Markdown to HTML API" and "MicroENV" in the Development section.