### PR TITLE
Add FormForge

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,6 +515,7 @@
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [Form Creation API](https://apyhub.com/utility/reformify-form-api) | Create and manage customizable forms within your applications | `apiKey` | Yes | Yes |
+| [FormForge](https://formforge-api.vercel.app) | Generate styled, accessible HTML forms from JSON definitions with validation | No | Yes | Yes |
 [Format JSON Online Dummy API](https://formatjsononline.com/dummy-api) | A free tool to generate dummy JSON data for testing and prototyping.| No  | Yes | Yes |
 | [Generate Full Webpage Screenshot](https://apyhub.com/utility/generate-webpage-screenshot) | Dynamically capture full page screenshots of websites.| `apiKey` | Yes | Yes |
 | [Gcore CDN](https://docs.gcore.com/cdn) | Make your app fast and responsive for a global audience with Gcore CDN. | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adding FormForge to the Development category. Generates styled, accessible HTML forms from JSON definitions.

- **URL:** https://formforge-api.vercel.app
- **Auth:** No (free tier, no signup)
- **HTTPS:** Yes
- **CORS:** Yes
- **Free tier:** 20 forms/day

4 themes, 10 field types, WCAG accessible, built-in validation.

```bash
curl -X POST https://formforge-api.vercel.app/api/json-to-form \
  -H "Content-Type: application/json" \
  -d '{"title":"Contact","theme":"modern","fields":[{"name":"email","type":"email","label":"Email","required":true}]}'
```