### PR TITLE
Add Frostbyte API

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |
+| [Frostbyte](https://agent-gateway-kappa.vercel.app/docs) | Real-time crypto prices for 500+ tokens with free tier | `apiKey` | Yes | Yes |
 | [Gateio](https://www.gate.io/api2) | API provides spot, margin and futures trading operations | `apiKey` | Yes | Unknown |
 | [Gemini](https://docs.gemini.com/rest-api/) | Cryptocurrencies Exchange | No | Yes | Unknown |
 | [Huobi](https://huobiapi.github.io/docs/spot/v1/en/) | Seychelles based cryptocurrency exchange | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Frostbyte to the Cryptocurrency section. Frostbyte provides real-time prices for 500+ cryptocurrency tokens through a REST API with a free tier (200 credits).