### PR TITLE
Add Frostbyte Geolocation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1006,6 +1006,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [CountryStateCity](https://countrystatecity.in/) | World countries, states, regions, provinces, cities & towns in JSON, SQL, XML, YAML, & CSV format | `apiKey` | Yes | Yes |
 | [Ducks Unlimited](https://gis.ducks.org/datasets/du-university-chapters/api) | API explorer that gives a query URL with a JSON response of locations and cities | No | Yes | No |
 | [FreeGeoIP](https://freegeoip.app/) | Free geo ip information, no registration required. 15k/hour rate limit | No | Yes | Yes |
+| [Frostbyte Geolocation](https://agent-gateway-kappa.vercel.app/docs) | IP geolocation with country, city, timezone, and coordinates | `apiKey` | Yes | Yes |
 | [GeoApi](https://api.gouv.fr/api/geoapi.html) | French geographical data | No | Yes | Unknown |
 | [Geoapify](https://www.geoapify.com/api/geocoding-api/) | Forward and reverse geocoding, address autocomplete | `apiKey` | Yes | Yes |
 | [Geocod.io](https://www.geocod.io/) | Address geocoding / reverse geocoding in bulk | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Frostbyte Geolocation to the Geocoding section. Provides IP geolocation data including country, city, timezone, and coordinates. Free tier with 200 credits, no signup required for basic endpoints.