### PR TITLE
Fix pr-review-automation CI failure

### DIFF
--- a/.github/workflows/pr-review-automation.yml
+++ b/.github/workflows/pr-review-automation.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: 20
 
       - name: Install deps (if needed)
-        run: npm install @actions/github
+        run: npm install @actions/github@^6.0.0
 
       - name: Run PR review automation
         run: node scripts/pr-review-automation.js


### PR DESCRIPTION
## Problem

The `pr-review-automation` CI check is failing on **every PR** with:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in
node_modules/@actions/github/package.json
```

This is because `npm install @actions/github` now installs v9, which is ESM-only (`"type": "module"` with only `"import"` exports). The script `scripts/pr-review-automation.js` uses CommonJS `require()`, which is incompatible with the ESM-only package.

## Fix

Pin `@actions/github` to `^6.0.0`, the last version that supports CommonJS `require()`.

## Verification

Checked that PRs #727, #728, #729, #731, #732 (and all other open PRs) all have the same failure. Recently merged PRs (#671, #670) also show the same CI failure, confirming it's a repo-wide issue unrelated to PR content.