### PR TITLE
Add Shoof Aflam

### DIFF
--- a/README.md
+++ b/README.md
@@ -1915,6 +1915,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Rendi](https://rendi.dev) | FFmpeg API | `apiKey` | Yes | No |
 | [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
 | [Rules of Acquisition](https://rulesofacquisition.herokuapp.com/) | Ferengi Rules of Acquisition from Star Trek with episode references | No | Yes | Unknown |
+| [Shoof Aflam](https://shoofaflam.tv/api-docs/) | Arabic streaming guide — search 14,000+ movies/series, platform availability across 18 services | No | Yes | Yes |
 | [Shotstack](https://shotstack.io/) | Cloud-based video editing API | `apiKey` | Yes | Unknown |
 | [Simkl](https://simkl.docs.apiary.io) | Movie, TV and Anime data | `apiKey` | Yes | Unknown |
 | [South Park Quotes](https://github.com/Thatskat/southpark-quotes-api) | Get some quotes from South Park, mmkay! | No | Yes | Unknown |


### PR DESCRIPTION
## Summary
- Adds [Shoof Aflam](https://shoofaflam.tv/api-docs/) to the **Video** category
- Arabic streaming guide API — search 14,000+ movies/series with platform availability across 18 streaming services (Shahid, Netflix, OSN+, etc.)
- Free, no auth required, HTTPS, CORS enabled

## Details
| Field | Value |
|-------|-------|
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| Docs | https://shoofaflam.tv/api-docs/ |