### PR TITLE
Add BuildData API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,6 +1093,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
+| [BuildData](https://builddata.ca) | Canadian construction and development data from 17 cities | `apiKey` | Yes | Unknown |
 | [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |
 | [City, Berlin](https://daten.berlin.de/) | Berlin(DE) City Open Data | No | Yes | Unknown |
 | [City, Gdańsk](https://ckan.multimediagdansk.pl/en) | Gdańsk (PL) City Open Data | No | Yes | Unknown |


### PR DESCRIPTION
Canadian building permits from 17 cities, normalized and geocoded. Free tier available.

- [x] Formatted correctly (link, description, auth, HTTPS, CORS)
- [x] Alphabetically ordered within section
- [x] Description is under 100 characters
- [x] One space padding on each side of every column