### PR TITLE
Add StackData SaaS Pricing API

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth`| Yes | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth`| Yes | Unknown |
+| [StackData SaaS Pricing](https://greg-rg-git.github.io/stackdata-store/api/) | Verified pricing data for 797 SaaS tools across 13 categories | No | Yes | Yes |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Yes | Unknown |
 | [Tenders in Hungary](https://tenders.guru/hu/api) | Get data for procurements in Hungary in JSON format | No | Yes | Unknown |
 | [Tenders in Poland](https://tenders.guru/pl/api) | Get data for procurements in Poland in JSON format | No | Yes | Unknown |


### PR DESCRIPTION
## About the API

**Name:** StackData SaaS Pricing
**URL:** https://greg-rg-git.github.io/stackdata-store/api/
**Category:** Business
**Auth:** No
**HTTPS:** Yes
**CORS:** Yes

## What it does

Free JSON API providing verified pricing data for 797 SaaS tools across 13 categories. Useful for developers building pricing comparison tools, benchmarking dashboards, or analytics products.

## Checklist

- [x] Entry is alphabetically ordered within the Business section (between Square and SwiftKanban)
- [x] Description is under 100 characters (63 chars)
- [x] API name does not end with "API"
- [x] One entry per PR
- [x] PR title in format "Add Api-name API"
- [x] API has full free access (no auth required)
- [x] HTTPS supported
- [x] CORS supported