### PR TITLE
Add DexPaprika to Cryptocurrency

### DIFF
--- a/db/resources.json
+++ b/db/resources.json
@@ -1946,6 +1946,15 @@
         "Category": "Cryptocurrency"
     },
     {
+        "API": "DexPaprika",
+        "Description": "Free DEX and DeFi data — pools, tokens, OHLCV, and trades across all chains",
+        "Auth": "",
+        "HTTPS": true,
+        "Cors": "yes",
+        "Link": "https://api.dexpaprika.com",
+        "Category": "Cryptocurrency"
+    },
+    {
         "API": "CoinRanking",
         "Description": "Live Cryptocurrency data",
         "Auth": "apiKey",


### PR DESCRIPTION
Adds DexPaprika to the Cryptocurrency category in resources.json.

Free DEX and DeFi data API — pools, tokens, OHLCV, and trades across all chains. No auth, HTTPS, CORS enabled.

CoinPaprika (same team) is already listed.