### PR TITLE
Add IqbalAPI to Books

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@
 | [Gutendex](https://gutendex.com/) | Web-API for fetching data from Project Gutenberg Books Library | No | Yes | Unknown |
 | [Harry Potter](https://github.com/fedeperin/potterapi) | API to get data from Harry Potter books, movies and characters | No | Yes | Yes |
 | [Holy Bible API](https://holy-bible-api.com/docs) | Free Bible API serving 800+ text translations and 40+ audio translations | No | Yes | No
+| [IqbalAPI](https://iqbal-api-docs.up.railway.app) | Allama Iqbal's Urdu poetry with English translations, search, & random verse endpoints | No | Yes | Yes |
 | [Library Management](https://github.com/adam-dev2/library-management-api) | Manage users, books, authors, loans and reviews | No | Yes | Yes |
 | [Open Library](https://openlibrary.org/developers/api) | Books, book covers and related data | No | Yes | No |
 | [Penguin Publishing](http://www.penguinrandomhouse.biz/webservices/rest/) | Books, book covers and related data | No | Yes | Yes |


### PR DESCRIPTION
IqbalAPI is a free & open source API for serving Allama Iqbal's poetry from all 4 books of his Urdu poetry. Allama Iqbal is Pakistan's national poet and his work is considered among the finest in Urdu literature.

<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

-   [ ✓] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [ ✓ ] My addition is ordered alphabetically
-   [ ✓ ] My submission has a useful description
-   [ ✓ ] The description does not have more than 100 characters
-   [ ✓ ] The description does not end with punctuation
-   [ ✓ ] Each table column is padded with one space on either side
-   [ ✓ ] I have searched the repository for any relevant issues or pull requests
-   [ ✓ ] Any category I am creating has the minimum requirement of 3 items
-   [ ✓ ] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
