### PR TITLE
Add LinkShrink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1862,6 +1862,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Cutt.ly](https://cutt.ly/api-documentation/cuttly-links-api) | URL shortener service | `apiKey` | Yes | Unknown |
 | [Free Url Shortener](https://ulvis.net/developer.html) | Free URL Shortener offers a powerful API to interact with other sites | No | Yes | Unknown |
 | [Kutt](https://docs.kutt.it/) | Free Modern URL Shortener | `apiKey` | Yes | Yes |
+| [LinkShrink](https://linkshrink.dev/docs) | Free privacy-first URL shortener API | No | Yes | Yes |
 | [Manyapis.com](https://manyapis.com/products/short-url) | Free URL shortener API with up to 50 requests per day  | Yes | Yes | Yes |
 | [Mgnet.me](http://mgnet.me/api.html) | Torrent URL shorten API | No | Yes | No |
 | [Ogli](https://app.ogli.sh) | Generate short links like any other shortener but with custom OG/meta tags for perfect previews. Ideal for SPAs, apps, and anyone who wants control over what gets shared. | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [LinkShrink](https://linkshrink.dev) to the URL Shorteners section.

LinkShrink is a free privacy-first URL shortener API. No tracking, anonymous click stats, QR codes for shortened URLs, bulk shortening, custom aliases, and link expiry. 20 requests/minute per IP. No API key required.

- [x] Added to **URL Shorteners** section
- [x] Alphabetical order maintained (after Kutt, before Manyapis.com)
- [x] Auth: `No` — no API key required, free forever
- [x] HTTPS: `Yes`
- [x] CORS: `Yes`
- [x] Description under 100 characters
- [x] Link points to documentation page
- [x] Not a duplicate of existing entries