### PR TITLE
Add PDFSpark API

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Notion](https://developers.notion.com/docs/getting-started) | Integrate with Notion | `OAuth`| Yes | Unknown |
 | [OCR AI](https://ocrai.xyz) | Document validation API using OCR and AI. Automatically extracts data from documents  and compares it with user-provided data to verify consistency | `apiKey`| Yes | No |
 | [PandaDoc](https://developers.pandadoc.com) | DocGen and eSignatures API | `apiKey` | Yes | No |
+| [PDFSpark](https://pdfspark.dev/docs) | Free HTML and URL to PDF conversion API | No | Yes | Yes |
 | [Paraphrase Text API](https://apyhub.com/utility/sharpapi-paraphrase-text) | The Paraphrase Text Generator API generates a paraphrased version of the provided text | `apiKey` | Yes | Yes |
 | [Pdfblocks](https://pdfblocks.com) | Generate PDF documents using API | `apiKey` | Yes | Yes |
 | [PDFEndpoint](https://pdfendpoint.com) | HTML and URL to PDF API | `apiKey` | Yes | No |


### PR DESCRIPTION
Added [PDFSpark](https://pdfspark.dev) to the Documents & Productivity section.

PDFSpark is a free HTML/URL to PDF conversion API with merge, split, watermarks, encryption, and custom page formats. 20 requests/minute per IP. No API key required.

- [x] Added to **Documents & Productivity** section
- [x] Alphabetical order maintained (after PDFGate, before Pocket)
- [x] Auth: `No` — no API key required, free forever
- [x] HTTPS: `Yes`
- [x] CORS: `Yes`
- [x] Description under 100 characters
- [x] Link points to documentation page
- [x] Not a duplicate of existing entries