### PR TITLE
Add LinkMeta API

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@
 | [JSONsilo.com](https://jsonsilo.com) | Hassle-free JSON hosting. Convert your JSON file to an API in minutes at no cost. | `apiKey` | Yes | Yes | No |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
 | [License-API](https://github.com/cmccandless/license-api/blob/master/README.md) | Unofficial REST API for choosealicense.com | No | Yes | No |
+| [LinkMeta](https://linkmeta.dev/docs) | Free URL metadata extraction for any webpage | No | Yes | Yes |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey`| Yes | Yes |
 | [Markdown to JSON API](https://apyhub.com/utility/converter-markdown-json) | Upload Markdown and get JSON with one API call | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added [LinkMeta](https://linkmeta.dev) to the Development section.

LinkMeta is a free URL metadata extraction API. Returns Open Graph tags, Twitter Cards, favicons, JSON-LD structured data, and SEO validation scores for any URL. No API key required.

- [x] Added to **Development** section
- [x] Alphabetical order maintained (after License-API, before Lua Decompiler)
- [x] Auth: `No` — no API key required, free forever
- [x] HTTPS: `Yes`
- [x] CORS: `Yes`
- [x] Description under 100 characters
- [x] Link points to documentation page
- [x] Not a duplicate of existing entries