### PR TITLE
Add OGForge API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Imgur](https://apidocs.imgur.com/) | Images | `OAuth`| Yes | Unknown |
 | [Lorem Picsum](https://picsum.photos/) | Images from Unsplash | No | Yes | Unknown |
 | [ObjectCut](https://objectcut.com/) | Image Background removal | `apiKey` | Yes | Yes |
+| [OGForge](https://ogforge.dev/docs) | Free Open Graph image generator API | No | Yes | Yes |
 | [Pexels](https://www.pexels.com/api) | Free Stock Photos and Videos | `apiKey` | Yes | Yes |
 | [PhotoRoom](https://www.photoroom.com/api/) | Remove background from images | `apiKey` | Yes | Unknown |
 | [Pixabay](https://pixabay.com/sk/service/about/api/) | Photography | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Added [OGForge](https://ogforge.dev) to the Development section.

OGForge is a free Open Graph image generator API. Creates dynamic 1200x630 social preview images with 6 themes, 1,668 icons, and PNG/SVG/WebP output. 30 requests/minute per IP. No API key required.

- [x] Added to **Development** section
- [x] Alphabetical order maintained (after npm Registry, before OneSignal)
- [x] Auth: `No` — no API key required, free forever
- [x] HTTPS: `Yes`
- [x] CORS: `Yes`
- [x] Description under 100 characters
- [x] Link points to documentation page
- [x] Not a duplicate of existing entries