### PR TITLE
Add PageShot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,6 +476,7 @@
 ### Development
 | API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
+| [PageShot](https://pageshot.site/docs) | Free webpage screenshot and capture API | No | Yes | Yes |
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |
 | [Abacus](https://abacus.jasoncameron.dev/) | Free and simple counting service. You can use it to track page hits and specific events | No | Yes | Yes |
 | [Abstract Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey`| Yes | Yes |


### PR DESCRIPTION
Added [PageShot](https://pageshot.site) to the Development section.

PageShot is a free screenshot and webpage capture API with full-page capture, custom viewports, batch processing, and HTML-to-PDF rendering. 30 requests/minute per IP. No API key required.

- [x] Added to **Development** section
- [x] Alphabetical order maintained (after OpenAPIHub, before PayUs-as-a-Service)
- [x] Auth: `No` — no API key required, free forever
- [x] HTTPS: `Yes`
- [x] CORS: `Yes`
- [x] Description under 100 characters
- [x] Link points to documentation page
- [x] Not a duplicate of existing entries