### PR TITLE
Add MobileAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 |---|---|---|---|---|
 | [Abstract Phone Validation](https://www.abstractapi.com/phone-validation-api) | Validate phone numbers globally | `apiKey` | Yes | Yes |
 | [Cloudmersive Validate](https://cloudmersive.com/phone-number-validation-API) | Validate international phone numbers | `apiKey` | Yes | Yes |
+| [MobileAPI](https://mobileapi.dev/docs/) | Smartphone, tablet, and wearable device specifications | `apiKey` | Yes | Yes |
 | [NumlookupAPI](https://numlookupapi.com) | Worldwide Phone Number Lookup & Verification API | `apiKey` | Yes | Yes |
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes | Yes |
 | [Proweblook Phone Number Checker](https://proweblook.com/phone-number-validator) | Phone number validation | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Added MobileAPI to the Phone category.

MobileAPI is a REST API providing device specifications, images, and pricing data for 27,000+ smartphones, tablets, smartwatches, and laptops. Free tier: 200 requests/month.

- [x] One API per pull request
- [x] Alphabetical ordering maintained
- [x] Placed in most relevant category (Phone)
- [x] API has a free tier
- [x] HTTPS supported
- [x] No duplicate