### PR TITLE
Add API Status Check to Development section

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,6 +483,7 @@
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [API League](https://apileague.com) | World-class APIs in a single hub | `apiKey` | Yes | Yes |
+| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status and uptime monitoring for 270+ APIs and services | No | Yes | Yes |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey`| Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [API League](https://apileague.com) | World-class APIs in a single hub | `apiKey` | Yes | Yes |
-| [API Status Check](https://apistatuscheck.com/api/status) | Real-time status and uptime monitoring for 270+ APIs and services | No | Yes | Yes |
+| [API Status Check](https://apistatuscheck.com) | Real-time status and uptime monitoring for 270+ APIs and services | No | Yes | Yes |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |
 | [ApiFlash](https://apiflash.com/) | Chrome based screenshot API for developers | `apiKey`| Yes | Unknown |
 | [APIs.guru](https://apis.guru/api-doc/) | Wikipedia for Web APIs, OpenAPI/Swagger specs for public APIs | No | Yes | Unknown |


### PR DESCRIPTION
## API Status Check

**Link:** https://apistatuscheck.com/api/status

**Description:** Real-time status and uptime monitoring for 270+ APIs and services (OpenAI, Stripe, AWS, GitHub, Cloudflare, etc.) with response time tracking and status badges.

**Auth:** No (completely free, no API key required)
**HTTPS:** Yes
**CORS:** Yes

### Endpoints

- `/api/status` — All services with current status
- `/api/{slug}` — Individual service status (e.g., `/api/github`, `/api/openai`)
- `/api/badge/{slug}` — SVG status badges for READMEs

Similar to how DigitalOcean Status is already listed, but covers 270+ third-party services rather than a single provider.