### PR TITLE
Add PanchangaAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1538,7 +1538,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | `OAuth` | Yes | Unknown |
-| [PanchangaAPI](https://api.moon-bot.cc/openapi.json) | Vedic astrology — Panchanga, birth charts, Dasha, compatibility, Muhurta, transits, festivals | `apiKey` | Yes | Yes |
+| [Panchanga](https://api.moon-bot.cc/openapi.json) | Vedic astrology — Panchanga, birth charts, Dasha, compatibility, Muhurta, transits, festivals | `apiKey` | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Satellite Passes](https://sat.terrestre.ar) | Find satellite passes | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
## Fixes: #749 Adds PanchangaAPI to the **Science & Math** section.

### API Details

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [PanchangaAPI](https://api.moon-bot.cc/openapi.json) | Vedic astrology — Panchanga, birth charts, Dasha, compatibility, Muhurta, transits, festivals | `apiKey` | Yes | Yes |

### Checklist
- [x] Added to the correct category: **Science & Math**
- [x] Entry is in alphabetical order
- [x] Description is under 100 characters
- [x] API has a free tier (2 requests/day)
- [x] Only `README.md` was modified (not `/db`)
- [x] PR title follows the format `Add Api-name API`
- [x] All commits are squashed into one
- [x] API has proper documentation at https://api.moon-bot.cc/openapi.json