### PR TITLE
Add Coinnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,6 +385,7 @@
 | [Bybit](https://bybit-exchange.github.io/docs) | Cryptocurrency data feed and algorithmic trading | `apiKey` | Yes | Unknown |
 | [CoinAPI](https://docs.coinapi.io/) | All Currency Exchanges integrate under a single api | `apiKey` | Yes | No |
 | [Coinbase](https://developers.coinbase.com) | Bitcoin, Bitcoin Cash, Litecoin and Ethereum Prices | `apiKey` | Yes | Unknown |
+| [Coinnect](https://coinnect.bot/docs) | Open money transfer routing across fiat, crypto and P2P networks | `apiKey` | Yes | Yes |
 | [Coinbase Pro](https://docs.pro.coinbase.com/#api) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |
 | [CoinCap](https://docs.coincap.io/) | Real time Cryptocurrency prices through a RESTful API | No | Yes | Unknown |
 | [CoinDCX](https://docs.coindcx.com/) | Cryptocurrency Trading Platform | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
## Add Coinnect to Currency Exchange

[Coinnect](https://coinnect.bot/docs) is an open money transfer routing API that finds the cheapest path across fiat, crypto, and P2P networks. It uses Dijkstra's algorithm over 29K+ live edges from 80+ adapters.

- **API**: Coinnect
- **Description**: Open money transfer routing across fiat, crypto and P2P networks
- **Auth**: apiKey
- **HTTPS**: Yes
- **CORS**: Yes
- **Link**: https://coinnect.bot/docs
- **Category**: Currency Exchange