### PR TITLE
fix: update Magic The Gathering API URL to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes | Yes |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey`| Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
-| [Magic The Gathering](http://magicthegathering.io/) | Magic The Gathering Game Information | No | No | Unknown |
+| [Magic The Gathering](https://magicthegathering.io/) | Magic The Gathering Game Information | No | Yes | Unknown |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |
 | [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |
 | [mod.io](https://docs.mod.io) | Cross Platform Mod API | `apiKey`| Yes | Unknown |


### PR DESCRIPTION
## Summary
- Updated Magic The Gathering API entry to use `https://` instead of `http://`
- Set `HTTPS` field to `true` in `db/resources.json`
- Updated link and HTTPS column in `README.md`

Fixes #660

## Test plan
- [x] Verified `https://magicthegathering.io/` returns `HTTP/2 200`
- [x] Both `db/resources.json` and `README.md` updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)