### PR TITLE
Add PredScope

### DIFF
--- a/README.md
+++ b/README.md
@@ -840,6 +840,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Plaid](https://plaid.com/) | Connect with user's bank accounts and access transaction data | `apiKey` | Yes | Unknown |
 | [Polygon](https://polygon.io/) | Historical stock market data | `apiKey` | Yes | Unknown |
 | [Portfolio Optimizer](https://portfoliooptimizer.io/) | Portfolio analysis and optimization | No | Yes | Yes |
+| [PredScope](https://predscope.com/api/markets.json) | Free prediction market odds and analytics data from Polymarket | No | Yes | Yes |
 | [Razorpay IFSC](https://razorpay.com/docs/) | Indian Financial Systems Code (Bank Branch Codes) | No | Yes | Unknown |
 | [Real Time Finance](https://github.com/Real-time-finance/finance-websocket-API/) | Websocket API to access realtime stock data | `apiKey` | No | Unknown |
 | [Realie Property Data API](https://www.realie.ai/real-estate-data-api) | Realie's property data is directly sourced from local municipalities and contains over 100 data fields. Realie covers the entire USA with 180 million parcels. | `apiKey` | Yes | No |


### PR DESCRIPTION
## Summary
- Adds [PredScope](https://predscope.com/api/markets.json) to the **Finance** category
- PredScope provides free prediction market odds and analytics data from Polymarket
- No authentication required, HTTPS supported, CORS enabled

## Details
| Field | Value |
|---|---|
| API | PredScope |
| Description | Free prediction market odds and analytics data from Polymarket |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |