### PR TITLE
Add PDFSpark

### DIFF
--- a/README.md
+++ b/README.md
@@ -694,6 +694,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Pdfblocks](https://pdfblocks.com) | Generate PDF documents using API | `apiKey` | Yes | Yes |
 | [PDFEndpoint](https://pdfendpoint.com) | HTML and URL to PDF API | `apiKey` | Yes | No |
 | [PDFGate](https://pdfgate.com/html-to-pdf-api) | HTML to PDF API with support for custom headers, footers, fillable form fields, and encryption | `apiKey` | Yes | Yes |
+| [PDFSpark](https://pdfspark.softvoyagers.com/) | Free HTML and URL to PDF conversion API | No | Yes | Yes |
 | [Pocket](https://getpocket.com/developer/) | Bookmarking service | `OAuth`| Yes | Unknown |
 | [Podio](https://developers.podio.com) | File sharing and productivity | `OAuth`| Yes | Unknown |
 | [PrexView](https://prexview.com) | Data from XML or JSON to PDF, HTML or Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding PDFSpark to the Documents & Productivity section.

**PDFSpark** (pdfspark.softvoyagers.com) — Free HTML and URL to PDF conversion API. No API key required, free forever.

- Auth: No
- HTTPS: Yes
- CORS: Yes