### PR TITLE
Add LinkMeta

### DIFF
--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@
 | [JSONbin.io](https://jsonbin.io) | Free JSON storage service. Ideal for small scale Web apps, Websites and Mobile apps | `apiKey`| Yes | Yes |
 | [JSONsilo.com](https://jsonsilo.com) | Hassle-free JSON hosting. Convert your JSON file to an API in minutes at no cost. | `apiKey` | Yes | Yes | No |
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes | Yes |
+| [LinkMeta](https://linkmeta.softvoyagers.com/) | Free URL metadata extraction for any webpage | No | Yes | Yes |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey`| Yes | Yes |
 | [Markdown to JSON API](https://apyhub.com/utility/converter-markdown-json) | Upload Markdown and get JSON with one API call | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adding LinkMeta to the Development section.

**LinkMeta** (linkmeta.softvoyagers.com) — Free URL metadata extraction for any webpage. No API key required, free forever.

- Auth: No
- HTTPS: Yes
- CORS: Yes