### PR TITLE
Add Faktuj

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,6 +815,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [DolarAPI](https://dolarapi.com/docs/) | Real-time exchange rates for Latin American currencies | No | Yes | Yes |
 | [Earnings Feed](https://earningsfeed.com/api/docs) | SEC filings, insider transactions, institutional holdings | `apiKey` | Yes | No |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes | Yes |
+| [Faktuj](https://faktuj.pl/) | Free Polish VAT invoice generator API | No | Yes | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Yes | Unknown |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Yes | Unknown |
 | [Financial Data](https://financialdata.net/documentation) | Stock market and financial data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adding Faktuj to the Finance section.

**Faktuj** (faktuj.pl) — Free Polish VAT invoice generator API. No API key required, free forever.

- Auth: No
- HTTPS: Yes
- CORS: Yes