### PR TITLE
Add launch.pics API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1469,6 +1469,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Giphy](https://developers.giphy.com/docs/) | Get all your gifs | `apiKey` | Yes | Unknown |
 | [Google Photos](https://developers.google.com/photos) | Integrate Google Photos with your apps or devices | `OAuth`| Yes | Unknown |
 | [Imgur](https://apidocs.imgur.com/) | Images | `OAuth`| Yes | Unknown |
+| [launch.pics](https://launch.pics/api/) | Free AI image processing API with 39 endpoints and visual workflow builder | No | Yes | Yes |
 | [Lorem Picsum](https://picsum.photos/) | Images from Unsplash | No | Yes | Unknown |
 | [ObjectCut](https://objectcut.com/) | Image Background removal | `apiKey` | Yes | Yes |
 | [Pexels](https://www.pexels.com/api) | Free Stock Photos and Videos | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add launch.pics to Photography

[launch.pics](https://launch.pics) is a free AI image processing API with 39 endpoints and a visual workflow builder.

- **Auth**: No (free, no signup required)
- **HTTPS**: Yes
- **CORS**: Yes
- **API docs**: https://launch.pics/api/
- **GitHub**: https://github.com/keptlive/launch.pics

Added to the Photography section in alphabetical order, following the contribution guidelines.