### PR TITLE
Add CoinStats API

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,7 +396,7 @@
 | [Coinpaprika](https://api.coinpaprika.com) | Cryptocurrencies prices, volume and more | No | Yes | Yes |
 | [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
 | [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |
-| [CoinStats](https://coinstats.app/api-docs/) | Blockchain and DeFi Across 120+ Chains, Market, Historical Data, Portfolio Tracking, News, Sentiment, MCP, and Agent Skills | `apiKey` | Yes | Yes |
+| [CoinStats](https://coinstats.app/api-docs/) | Blockchain and DeFi across 120+ chains, market, historical data, portfolio tracking, news, sentiment, MCP, and agent skills | `apiKey` | Yes | Yes |
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary
Re-adds CoinStats to the `Cryptocurrency` section in `README.md`.

## Why
The previous CoinStats listing used deprecated Postman documentation and was removed during the May 27, 2025 deprecated API cleanup. This update points to the current official CoinStats docs and reflects the current auth/CORS behavior.

## Details
- docs URL: `https://coinstats.app/api-docs/`
- auth: `apiKey` via `X-API-KEY`
- https: `Yes`
- cors: `Yes`
- free tier: documented in the official docs

## Validation
- `git diff --check -- README.md`
- `curl -s -o /dev/null -w 'docs_status=%{http_code}' https://coinstats.app/api-docs/` -> `200`
- `curl -s -o /dev/null -w 'api_status=%{http_code}' https://openapiv1.coinstats.app/coins` -> `401`
- `curl -s -D - -o /dev/null -X OPTIONS -H 'Origin: https://example.com' -H 'Access-Control-Request-Method: GET' https://openapiv1.coinstats.app/coins` -> `204` with `access-control-allow-origin: *`
