### PR TITLE
Add SnapAPI screenshot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,7 @@
 | [ScreenshotOne.com](https://screenshotone.com/) | Convert URLs, HTML, or Markdown into PNG, JPEG, WebP, or PDF with a simple screenshot API | `apiKey`| Yes | Yes |
 | [Screenshot Scout](https://screenshotscout.com/) | Screenshot API for developers that captures any URL in one HTTP request with predictable output | `apiKey` | Yes | Unknown |
 | [Scrnify](https://scrnify.com/docs) | Screenshot and video capture API to transform any URL into high-quality images and recordings | `apiKey`| Yes | Yes |
+| [SnapAPI](https://snapapi.pics) | Screenshot any website via REST API — JS rendering, full-page, PDF, and web scraping to markdown | `apiKey` | Yes | Yes |
 | [SearchApi](https://www.searchapi.io/) | Real-Time Google SERP API | `apiKey` | Yes | No |
 | [SEO Tags Generator API](https://apyhub.com/utility/sharpapi-generate-seo-tags) | The Generate SEO Tags API generates all the most important META tags based on any content | `apiKey` | Yes | Yes |
 | [Serialif Color](https://color.serialif.com/) | Color conversion, complementary, grayscale and contrasted text | No | Yes | No |


### PR DESCRIPTION
SnapAPI (https://snapapi.pics) is a REST API for website screenshots. Features:
- URL → screenshot in ~2 seconds
- JavaScript rendering (SPAs, dynamic content)
- Full-page screenshots
- PDF export
- Web scraping to markdown
- $19/mo = 5,000 screenshots

GitHub: https://github.com/Sleywill/snapapi-mcp-server