### PR TITLE
Add Citability API

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,6 +504,7 @@
 | [CDNJS](https://api.cdnjs.com/libraries/jquery) | Library info on CDNJS | No | Yes | Unknown |
 | [ChatterBox](https://chatter-box.io/) | One API for meeting bots on Zoom, Meet & Teams | `apiKey` | Yes | Yes |
 | [Ciprand](https://github.com/polarspetroll/ciprand) | Secure random string generator | No | Yes | No |
+| [Citability](https://citability.ai/docs) | AI visibility scoring for domains: ADP, llms.txt, Schema.org, MCP endpoints | No | Yes | Yes |
 | [Cloudflare Trace](https://github.com/fawazahmed0/cloudflare-trace-api) | Get IP Address, Timestamp, User Agent, Country Code, IATA, HTTP Version, TLS/SSL Version & More | No | Yes | Yes |
 | [Codex](https://github.com/Jaagrav/CodeX) | Online Compiler for Various Languages | No | Yes | Unknown |
 | [Contentful Images](https://www.contentful.com/developers/docs/references/images-api/) | Used to retrieve and apply transformations to images | `apiKey`| Yes | Yes |


### PR DESCRIPTION
Adds Citability to the Development category.

**Citability** is an AI visibility scoring API. It scans any domain for ADP (Agent Discovery Protocol) compliance, llms.txt, robots.txt AI rules, Schema.org JSON-LD, MCP endpoints, and citation readiness across 44+ metrics.

- Public scan endpoint requires no auth
- HTTPS: Yes
- CORS: Yes (verified `Access-Control-Allow-Origin: *`)
- Documentation: https://citability.ai/docs
- OpenAPI spec: https://citability.ai/api/openapi.json (155 endpoints)

Description is 75 chars (under 100 limit). Entry placed alphabetically after Ciprand.