### PR TITLE
Add plynx API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Napster](https://developer.napster.com/api/v2.2) | Music | `apiKey` | Yes | Yes |
 | [Openwhyd](https://openwhyd.github.io/openwhyd/API) | Download curated playlists of streaming tracks (YouTube, SoundCloud, etc...) | No | Yes | No |
 | [Phishin](https://phish.in/api-docs) | A web-based archive of legal live audio recordings of the improvisational rock band Phish | `apiKey` | Yes | No |
+| [plynx](https://dashboard-ruddy-beta.vercel.app/docs) | AI-interpreted song metadata, 15 structured attributes, and 768-dim embeddings for 63,000+ songs | `apiKey` | Yes | Yes |
 | [Radio Browser](https://api.radio-browser.info/) | List of internet radio stations | No | Yes | Yes |
 | [Songkick](https://www.songkick.com/developer/) | Music Events | `apiKey` | Yes | Unknown |
 | [Songlink / Odesli](https://www.notion.so/API-d0ebe08a5e304a55928405eb682f6741) | Get all the services on which a song is available | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Add plynx to Music

plynx Music Intelligence API provides AI-interpreted song metadata for 63,000+ songs. Each song goes through a multi-stage pipeline: prose interpretation, structurization into 15 attributes (genre, mood, energy, tempo, valence, etc.), and 768-dimensional embedding via OpenAI text-embedding-3-small.

It serves as a Spotify Audio Features alternative with richer semantic data — structured attributes, natural language descriptions, and vector embeddings suitable for recommendation systems, playlist generation, and music analysis.

- **Category:** Music
- **Auth:** apiKey
- **HTTPS:** Yes
- **CORS:** Yes
- **Docs:** https://dashboard-ruddy-beta.vercel.app/docs