### PR TITLE
Add TCGApi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -974,6 +974,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey`| Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |
+| [TCGApi](https://tcgapi.dev/introduction/) | Trading card game prices and historical data across 89+ games | `apiKey` | Yes | No |
 | [TCGdex](https://www.tcgdex.net/docs) | Multi languages Pokémon TCG Information | No | Yes | Yes |
 | [Tebex](https://docs.tebex.io/plugin/) | Tebex API for information about game purchases | `X-Mashape-Key` | Yes | No |
 | [TETR.IO](https://tetr.io/about/api/) | TETR.IO Tetra Channel API | No | Yes | Unknown |


### PR DESCRIPTION
Adds TCGApi to the Games & Comics section.

TCGApi provides trading card game pricing data sourced from TCGPlayer for 89+ games (Pokemon, Magic: The Gathering, Yu-Gi-Oh!, Lorcana, One Piece, Flesh and Blood, and many others). Free tier of 100 requests/day, real-time and historical pricing, set/card metadata, OpenAPI 3.1 spec.

- Free tier: yes (100 req/day, no card required)
- Auth: API key via `X-API-Key` header
- HTTPS: yes
- CORS: no (origin restricted to tcgapi.dev)
- Documentation: https://tcgapi.dev/introduction/

Inserted alphabetically between Steam and TCGdex in the Games & Comics section.