### PR TITLE
Add AI Dev Jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1217,6 +1217,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [Adzuna](https://developer.adzuna.com/overview) | Job board aggregator | `apiKey` | Yes | Unknown |
+| [AI Dev Jobs](https://aidevboard.com/api/v1/jobs) | AI and ML engineering job board with 6,100+ positions across 321 companies | No | Yes | Yes |
 | [Arbeitnow](https://documenter.getpostman.com/view/18545278/UVJbJdKh) | API for Job board aggregator in Europe / Remote | No | Yes | Yes |
 | [Arbeitsamt](https://jobsuche.api.bund.dev/) | API for the "Arbeitsamt", which is a german Job board aggregator | `OAuth`| Yes | Unknown |
 | [Careerjet](https://www.careerjet.com/partners/api/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adding AI Dev Jobs to the Jobs section.

AI Dev Jobs is a free, public REST API for AI and ML engineering job listings. It indexes 6,100+ positions across 321 companies with no authentication required.

- **API URL**: https://aidevboard.com/api/v1/jobs
- **Documentation**: https://aidevboard.com/openapi.yaml
- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes