### PR TITLE
Add Not Human Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -1265,6 +1265,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Machinetutors](https://machinetutors.com/api/) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes | Yes |
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Yes | Unknown |
+| [Not Human Search](https://nothumansearch.ai/api/v1/check?url=example.com) | Search engine for discovering AI agent tools and MCP servers across 1,750+ sites | No | Yes | Yes |
 | [OpenAI](https://openai.com/index/openai-api) | Use AI models such as ChatGPT or DALL-E to experience the capabilities of AI | `apiKey` | Yes | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Yes | Unknown |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adding Not Human Search to the Machine Learning section.

Not Human Search is a free, public REST API and search engine for discovering AI agent tools and MCP servers. It indexes 1,750+ AI-accessible tools and provides structured search results.

- **API URL**: https://nothumansearch.ai/api/v1/check?url=example.com
- **Documentation**: https://nothumansearch.ai/openapi.yaml
- **Auth**: No
- **HTTPS**: Yes
- **CORS**: Yes