### PR TITLE
Add Road511

### DIFF
--- a/README.md
+++ b/README.md
@@ -1818,6 +1818,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Open Charge Map](https://openchargemap.org/site/develop/api) | Global public registry of electric vehicle charging locations | `apiKey` | Yes | Yes |
 | [Railway Transport for France](https://www.digital.sncf.com/startup/api) | SNCF public API | `apiKey` | Yes | Unknown |
 | [REFUGE Restrooms](https://www.refugerestrooms.org/api/docs/#!/restrooms) | Provides safe restroom access for transgender, intersex and gender nonconforming individuals | No | Yes | Unknown |
+| [Road511](https://road511.com/docs.html) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
 | [Swedavia Airports](https://apideveloper.swedavia.se/) | Airport and flight information of Swedish Airports operated by Swedavia | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds **Road511** — a unified REST/GeoJSON API that normalizes traffic data (events, cameras, DMS signs, bridge clearances, truck restrictions, EV charging, weather stations) from 65 US state and Canadian province 511 systems into a single interface.

Checklist:
- [x] One API per pull request
- [x] Entry is in alphabetical order (between REFUGE Restrooms and Sabre for Developers)
- [x] Description under 100 characters (95)
- [x] Entry format matches existing rows
- [x] HTTPS, CORS, and Auth fields verified