### PR TITLE
Add Clinical Trials Directory API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1184,6 +1184,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 ### Health
 | API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
+| [Clinical Trials Directory](https://trials.starfile.org/api) | Every clinical trial registered with ClinicalTrials.gov, indexed by condition and sponsor | No | Yes | Yes |
 | [CMS.gov](https://data.cms.gov/provider-data/) | Access to the data from the CMS - medicare.gov | `apiKey` | Yes | Unknown |
 | [Coronavirus in the UK](https://coronavirus.data.gov.uk/details/developers-guide) | UK Government coronavirus data, including deaths and cases by region | No | Yes | Unknown |
 | [Covid Tracking Project](https://covidtracking.com/data/api/version-2) | Covid-19 data for the US | No | Yes | No |


### PR DESCRIPTION
Free, no-auth, CORS-enabled JSON API for all 581,105 clinical trials registered with ClinicalTrials.gov.

- **Auth**: None
- **HTTPS**: Yes
- **CORS**: Yes
- **Source**: ClinicalTrials.gov API v2 (public domain)
- **Example**: https://trials.starfile.org/api/trial/NCT06512883