### PR TITLE
Add FAA N-Number Registry API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1803,6 +1803,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Boston MBTA Transit](https://www.mbta.com/developers/v3-api) | Stations and predicted arrivals for MBTA | `apiKey` | Yes | Unknown |
 | [Community Transit](https://github.com/transitland/transitland-datastore/blob/master/README.md#api-endpoints) | Transitland API | No | Yes | Unknown |
 | [CTS](https://api.cts-strasbourg.eu/) | CTS Realtime API | `apiKey` | Yes | Yes |
+| [FAA N-Number Registry](https://n-number.starfile.org/api) | Every FAA-registered civil aircraft in the United States, lookup by N-number or Mode S hex code | No | Yes | Yes |
 | [facha](https://docs.api.facha.dev/) | Aircraft Tracking, AIS Ship Tracking, Temporary Email Detection, IP GeoLocation, Package Tracking  | No | Yes | Unknown |
 | [Flight Fare Search](https://rapidapi.com/farish978/api/flight-fare-search) | Search for realtime flight fares across destinations | `apiKey` | Yes | Yes |
 | [Fuel Prices at Spanish Gas Stations](https://datos.gob.es/en/apidata) | Provides information about fuel prices at gas stations in Spain | No | Yes | No |


### PR DESCRIPTION
Free, no-auth, CORS-enabled JSON API for all 311,570 FAA-registered civil aircraft in the United States. Lookup by N-number or Mode S/ADS-B hex. Source: FAA Releasable Aircraft Database (public domain). Example: https://n-number.starfile.org/api/aircraft/N12345