### PR TITLE
Add Harmonized Tariff Schedule API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1124,6 +1124,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [FEC](https://api.open.fec.gov/developers/) | Information on campaign donations in federal elections | `apiKey` | Yes | Unknown |
 | [Federal Register](https://www.federalregister.gov/reader-aids/developer-resources/rest-api) | The Daily Journal of the United States Government | No | Yes | Unknown |
 | [Gazette Data, UK](https://www.thegazette.co.uk/data) | UK official public record API | `OAuth`| Yes | Unknown |
+| [Harmonized Tariff Schedule](https://hts.starfile.org/api) | Every U.S. HTS import tariff code with duty rates, product descriptions, and chapter metadata | No | Yes | Yes |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
 | [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |
 | [National Park Service, US](https://www.nps.gov/subjects/developer/) | Data from the US National Park Service | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Free, no-auth, CORS-enabled JSON API for every U.S. HTS import tariff code (29,581 codes). Source: USITC (public record). Example: https://hts.starfile.org/api/code/0101.30.00.00