### PR TITLE
Add Random Profiles to Test Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1738,6 +1738,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Mockaroo](https://www.mockaroo.com/docs) | Generate fake data to JSON, CSV, TXT, SQL and XML | `apiKey` | Yes | Unknown |
 | [Random Data](https://random-data-api.com) | Random data generator | No | Yes | Unknown |
 | [Random Identity](https://rapidapi.com/edualc1018/api/random-identity-generator) | Random Identity Generator with custom response format | `apiKey` | Yes | Yes |
+| [Random Profiles](https://random-profiles.com) | Fake user profiles and companies with 100+ fields each | `apiKey` | Yes | Yes |
 | [Randommer](https://randommer.io/randommer-api) | Random data generator | `apiKey` | Yes | Yes |
 | [RandomUser](https://randomuser.me) | Generates and list user data | No | Yes | Unknown |
 | [RoboHash](https://robohash.org/) | Generate random robot/alien avatars | No | Yes | Unknown |


### PR DESCRIPTION
Adds [Random Profiles](https://random-profiles.com) to the **Test Data** section, placed alphabetically between `Random Identity` and `Randommer`.

- URL: https://random-profiles.com
- Docs / OpenAPI: https://random-profiles.com/openapi.json
- Auth: `apiKey` (free tier: 100 profiles + 500 images + 100 companies per day)
- HTTPS: Yes
- CORS: Yes

Random Profiles generates fake user profiles and companies for testing, seed data, and demo scenarios. 1,000 pre-seeded profiles with 100+ fields each (name, email, phone, address, job, financials, social, education, vehicle, relationships…), 1,000 AI-generated company logos, and a cross-resource graph linking profiles to companies as employees and colleagues.

Free tier available without credit card.