### PR TITLE
Update Website Carbon link in Environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,7 +791,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Thames Water Open Data](https://data.thameswater.co.uk) | Open Data from the UK's largest water and wastewater services company | `apiKey` | Yes | Unknown |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Yes | Unknown |
 | [WattBuy](https://wattbuy.readme.io/reference/getting-started-with-your-api) | Electricity usage estimations, carbon footprint estimations, and utility data | `apiKey` | Yes | Yes |
-| [Website Carbon](https://api.websitecarbon.com/) | API to estimate the carbon footprint of loading web pages | No | Yes | Unknown |
+| [Website Carbon](https://docs.1clickimpact.com/website-carbon) | API to estimate the carbon footprint of loading web pages | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
<!-- Thank you for taking the time to work on a Pull Request for this project! -->
<!-- To ensure your PR is dealt with swiftly please check the following: -->

## Summary
Updates the link for the existing **Website Carbon** entry in the Environment section. The previously listed endpoint (`api.websitecarbon.com`) is no longer reachable as a public API — see attached screenshot.

The replacement points to active documentation for an equivalent endpoint covering the same use case (estimating the carbon footprint of loading web pages). No new entry is being added; the existing row's link is updated in place.

## Evidence
See attached screenshot of the prior endpoint
<img width="908" height="198" alt="Screenshot 2026-04-23 at 2 27 56 PM" src="https://github.com/user-attachments/assets/f6868de6-6a8a-47ff-ad8a-25c96156aac7" />

-   [X] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [X] My addition is ordered alphabetically
-   [X]  My submission has a useful description
-   [X]  The description does not have more than 100 characters
-   [X]  The description does not end with punctuation
-   [X]  Each table column is padded with one space on either side
-   [X]  I have searched the repository for any relevant issues or pull requests
-   [X]  Any category I am creating has the minimum requirement of 3 items
-   [X]  All changes have been [squashed][squash-link] into a single commit
