### PR TITLE
Add CNPJ Aberto , as a brazilian company CNPJ search option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1101,6 +1101,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Yes | Unknown |
+| [CNPJ Aberto](https://cnpjaberto.com.br) | Serch Brazilian companies by CNPJ | No | Yes | Unknown | 
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Yes | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | Yes | No |
 | [Census.gov](https://www.census.gov/data/developers/data-sets.html) | The US Census Bureau provides various APIs and data sets on demographics and businesses | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds CNPJ Aberto (https://cnpjaberto.com.br/) to the CNPJ lookup section.

A free platform for consulting registration data of Brazilian companies (CNPJ, corporate name, CNAE, registration status, address, and shareholders) based on the Brazilian Federal Revenue’s public database. No captcha, no registration required, and no query limits.

## Checklist

- [x] My submission is formatted according to the guidelines in the [contributing guide](/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been [squashed][squash-link] into a single commit

