### PR TITLE
Add ParlayAPI to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1706,7 +1706,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://oddsmagnet.com/oddsdata) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
-| [ParlayAPI](https://parlay-api.com/docs) | Real-time betting odds across 21+ sportsbooks, DFS apps, exchanges, and prediction markets | `apiKey` | Yes | No |
+| [Parlay](https://parlay-api.com/docs) | Real-time sports betting odds from 21+ sportsbooks across 38+ sports with free tier (1K req/month) | `apiKey` | Yes | No |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey`| Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey`| Yes | Unknown |
 | [Sport Highlights](https://highlightly.net/documentation/sports/) | Real time Sport Highlights | `apiKey`| Yes | Unknown |

--- a/README.md
+++ b/README.md
@@ -1706,6 +1706,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://oddsmagnet.com/oddsdata) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
+| [ParlayAPI](https://parlay-api.com/docs) | Real-time betting odds across 21+ sportsbooks, DFS apps, exchanges, and prediction markets | `apiKey` | Yes | No |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey`| Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey`| Yes | Unknown |
 | [Sport Highlights](https://highlightly.net/documentation/sports/) | Real time Sport Highlights | `apiKey`| Yes | Unknown |


### PR DESCRIPTION
Adds [ParlayAPI](https://parlay-api.com/docs) under Sports & Fitness.

Real-time sports betting odds aggregation across 21+ sportsbooks (DraftKings, FanDuel, BetMGM, Caesars, Pinnacle, Bet365, Bovada, etc), DFS apps (PrizePicks, Underdog, Sleeper, Pick6), exchanges (Novig, ProphetX), and prediction markets (Kalshi, Polymarket). 38+ sports.

Free tier: 1,000 requests/month, no credit card required.

Inserted alphabetically between OpenLigaDB and Premier League Standings.

- [x] Description under 100 chars
- [x] Alphabetical order
- [x] HTTPS supported
- [x] Auth = apiKey (X-API-Key or apiKey query param)
- [x] CORS = No (server-side use; explicit origin allowlist for browser apps)
- [x] Free tier with no purchase required