### PR TITLE
Add BrewPage

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,7 @@
 | [Brainshop.ai](https://brainshop.ai/) | Make A Free A.I Brain | `apiKey`| Yes | Yes |
 | [Brand.dev](https://www.brand.dev/) | API to personalize your product with logos, colors, and company info from any domain | `apiKey`| Yes | Yes |
 | [Brave Search API](https://brave.com/search/api/) | An index of billions of pages in a single call | `apiKey`| Yes | No |
+| [BrewPage](https://brewpage.app) | Free instant hosting for HTML, Markdown, JSON, and files. No signup | No | Yes | No |
 | [BrowserCat](https://www.browsercat.com/) | Headless browser API for automation, scraping, and more | `apiKey` | Yes | Yes |
 | [Browshot](https://browshot.com/api/documentation) | Easily make screenshots of web pages in any screen size, as any device | `apiKey`| Yes | Yes |
 | [Cache Horse](https://cache.horse) | Combine/batch & cache multiple HTTP requests to save on API quotas, speed up & simplify your app | `apiKey` | Yes | Yes |


### PR DESCRIPTION
## Summary

- Added BrewPage API to the Development section
- BrewPage: Free instant hosting for HTML, Markdown, JSON, and files — no signup required
- Entry placed in alphabetical order between Brave Search API and BrowserCat

## Validation

- Auth: `No` (verified: public access via https://brewpage.app)
- HTTPS: `Yes` (confirmed)
- CORS: `No` (verified via preflight: cross-origin requests return 403)
- Entry conforms to formatting rules (100-char description limit, proper spacing)

## References

- Website: https://brewpage.app
- OpenAPI spec: https://raw.githubusercontent.com/kochetkov-ma/brewpage-openapi/main/openapi/openapi.yaml

---

Link validation (lychee-action) will run on PR submission via GitHub Actions.