### PR TITLE
Add Mobula API

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | Yes | No |
 | [MercadoBitcoin](https://api.mercadobitcoin.net/api/v4/docs) | Brazilian Cryptocurrency Information | No | Yes | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Yes | Unknown |
+| [Mobula](https://docs.mobula.io/) | Real-time onchain market data, wallet portfolios, and trading streams across multiple chains | `apiKey` | Yes | Yes |
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://okx.com/okx-api) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Mobula to the Cryptocurrency section.

- Real-time onchain market data, wallet portfolios, and trading streams across multiple chains
- Docs: https://docs.mobula.io/
- Auth: `apiKey` (free tier available)
- HTTPS: Yes
- CORS: Yes

Inserted alphabetically between Messari and Nexchange.