### PR TITLE
Add FreqBlog Music API to Music section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Deezer](https://developers.deezer.com/api) | Music | `OAuth`| Yes | Unknown |
 | [Discogs](https://www.discogs.com/developers) | Music | `OAuth`| Yes | Unknown |
 | [Freesound](https://freesound.org/docs/api/) | Music Samples | `apiKey` | Yes | Unknown |
+| [FreqBlog Music API](https://freqblog.com/) | BPM, key, energy, loudness, time signature for tracks by name + artist | `apiKey` | Yes | Unknown |
 | [Gaana](https://github.com/cyberboysumanjay/GaanaAPI) | API to retrieve song information from Gaana | No | Yes | Unknown |
 | [Genius](https://docs.genius.com) | Crowdsourced lyrics and music knowledge | `OAuth`| Yes | Unknown |
 | [Genrenator](https://binaryjazz.us/genrenator-api/) | Music genre generator | No | Yes | Unknown |


### PR DESCRIPTION
Adding [FreqBlog Music API](https://freqblog.com/) to the Music section. It returns BPM, key, energy, loudness and time signature for tracks looked up by name + artist — useful as a replacement for Spotify's deprecated `audio_features` endpoint.

Free tier with no card required (full free-tier access, not a trial).

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically (between Freesound and Gaana)
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters (70)
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items (Music section already exists)
-   [x] All changes have been squashed into a single commit