### PR TITLE
Add Memesio API

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [JokeAPI](https://jokeapi.dev/) | Jokes in multiple formats | No | Yes | Yes |
 | [Keanu Reeves Whoa](https://whoa.onrender.com/) | JSON API for every "whoa" said by actor Keanu Reeves in his movies | No | Yes | Unknown |
 | [Meme Maker](https://mememaker.github.io/API/) | REST API for create your own meme | No | Yes | Unknown |
+| [Memesio](https://memesio.com/developers/api) | Meme creation API with templates, editable captions and hosted share links | No | Yes | No |
 | [Multilingual AI Zodiac](https://rapidapi.com/vintarok-vintarok-default/api/multilingual-ai-zodiac-customized-horoscopes-for-all-signs) | Personalized daily horoscopes and zodiac insights in 100+ languages | `apiKey` | Yes | Yes |
 | [Official Joke](https://official-joke-api.appspot.com/) | API for random and programming jokes | No | Yes | Unknown |
 | [Random Dad Joke](https://icanhazdadjoke.com/) | API for largest selection of dad jokes on the internet | No | Yes | Unknown |


### PR DESCRIPTION
## Description

Adds Memesio to the Entertainment category.

Memesio provides a documented meme creation API with public template discovery, captioned meme creation, hosted share links, and OpenAPI metadata.

## Checks

- [x] One API added
- [x] Category: Entertainment
- [x] API documentation: https://memesio.com/developers/api
- [x] Auth: No for public/rate-limited template discovery and basic creation
- [x] HTTPS: Yes
- [x] CORS: No observed in Origin checks
- [x] Description is under 100 characters and has no ending punctuation

Local validation: `git diff --check` and custom row checks passed.
