### PR TITLE
Add DownStatus API

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,7 @@
 | [DigitalOcean Status](https://status.digitalocean.com/api) | Status of all DigitalOcean services | No | Yes | Unknown |
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey`| Yes | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Yes | Unknown |
+| [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes | Yes |
 | [Form Creation API](https://apyhub.com/utility/reformify-form-api) | Create and manage customizable forms within your applications | `apiKey` | Yes | Yes |
 | [FormForge](https://formforge-api.vercel.app) | Generate styled, accessible HTML forms from JSON definitions with validation | No | Yes | Yes |


### PR DESCRIPTION
## What does this add?

Adds [DownStatus](https://isitdownstatus.com) to the **Development** section.

**DownStatus** is a free JSON API providing real-time status for 90+ popular services (GitHub, AWS, Discord, Cloudflare, Stripe, and more).

- No API key required
- HTTPS
- CORS supported