### PR TITLE
Add Sharpe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@
 | [OKEx](https://okx.com/okx-api) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
 | [OpenSea](https://docs.opensea.io/reference/api-overview) | The Largest NFT Marketplace | `apiKey` | Yes | No |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
+| [Sharpe](https://www.sharpe.ai/docs/free-api) | Crypto market data for funding, futures, options, arbitrage, narratives, and news | No | Yes | No |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |
 | [Technical Analysis](https://technical-analysis-api.com) | Cryptocurrency prices and technical analysis | `apiKey` | Yes | No |
 | [Trading View](https://www.tradingview.com/rest-api-spec/) | Market price, data, graph for brokers and traders | `OAuth` | Yes | Unknown |


### PR DESCRIPTION
Summary
- Adds Sharpe to the Cryptocurrency section.
- Uses the documented free API URL.
- Keeps the description under 100 characters and without ending punctuation.

Checklist
- [x] Formatted according to the contributing guide.
- [x] Ordered alphabetically.
- [x] Description is short and useful.
- [x] Description does not end with punctuation.
- [x] Searched existing PRs and issues for Sharpe.
- [x] Squashed into a single commit.

Verification
- Checked the free API docs on 2026-05-14: https://www.sharpe.ai/docs/free-api
- Confirmed the funding-rates endpoint returns 200 over HTTPS without an API key.
- Confirmed the API endpoint does not expose an access-control allow-origin header, so CORS is set to No.
- Ran git diff --check.

Disclosure
I am affiliated with Sharpe.
