### PR TITLE
Add Amazonscraperapi API

### DIFF
--- a/README.md
+++ b/README.md
@@ -478,6 +478,7 @@
 | [Abstract Screenshot](https://www.abstractapi.com/website-screenshot-api) | Take programmatic screenshots of web pages from any website | `apiKey`| Yes | Yes |
 | [Agent Gateway](https://agent-gateway-kappa.vercel.app) | 34+ AI agent infrastructure services including memory, wallets, and scheduling | `apiKey` | Yes | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes | Yes |
+| [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | Yes | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Yes | Unknown |
 | [API League](https://apileague.com) | World-class APIs in a single hub | `apiKey` | Yes | Yes |
 | [ApicAgent](https://www.apicagent.com) | Extract device details from user-agent string | No | Yes | Yes |


### PR DESCRIPTION
**What is this project?**
Amazonscraperapi is a managed REST API for scraping Amazon product detail pages, search results, and batch ASIN lookups. It uses residential proxies, a TLS-impersonation backend, and provides clean JSON output for downstream pipelines.

**Why is it useful?**
Amazon hardened its anti-bot stack significantly through 2025-2026, breaking most self-hosted scrapers. This API handles the proxy + fingerprint + retry layer behind a simple REST interface with an apiKey header. 1000 free requests on signup, no credit card.

**How does it comply with the rules?**
- [x] Free for use (1000 free requests, plus a free /asin-lookup tool)
- [x] HTTPS support
- [x] Authentication via apiKey header
- [x] Single-line entry in alphabetical order in the Development section
- [x] No marketing language; matches existing tone (ScrapeNinja, ScraperApi, ScrapingAnt, ScrapingBee, ScrapingDog, WebScraping.AI, ZenRows are listed in the same section)