### PR TITLE
Add Warnely API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1384,6 +1384,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [University of Oslo](https://data.uio.no/) | Courses, lecture videos, detailed information for courses etc. for the University of Oslo (Norway) | No | Yes | Unknown |
 | [UPC database](https://upcdatabase.org/api) | More than 1.5 million barcode numbers from all around the world | `apiKey` | Yes | Unknown |
 | [Urban Observatory](https://urbanobservatory.ac.uk) | The largest set of publicly available real time urban data in the UK | No | No | No |
+| [Warnely](https://warnely.com/developers) | Composite travel-safety scores for 180 countries (FCDO + US State + GPI + WGI + live wire) | No | Yes | Yes |
 | [Wikidata](https://www.wikidata.org/w/api.php?action=help) | Collaboratively edited knowledge base operated by the Wikimedia Foundation | `OAuth`| Yes | Unknown |
 | [Wikipedia](https://www.mediawiki.org/wiki/API:Main_page) | Mediawiki Encyclopedia | No | Yes | Unknown |
 | [Yelp](https://www.yelp.com/developers) | Find Local Business | `OAuth`| Yes | Unknown |


### PR DESCRIPTION
Adds Warnely to the **Open Data** section.

## API entry

| API | Description | Auth | HTTPS | CORS |
|---|---|---|---|---|
| [Warnely](https://warnely.com/developers) | Composite travel-safety scores for 180 countries (FCDO + US State + GPI + WGI + live wire) | No | Yes | Yes |

## Details

- **Base URL**: `https://warnely.com/api/v1`
- **OpenAPI 3.1 spec**: https://warnely.com/openapi.json
- **Auth**: None
- **CORS**: Open
- **HTTPS**: Yes
- **License**: CC BY 4.0

## Sample

```
curl https://warnely.com/api/v1/countries/TH
```