### PR TITLE
Add BrewPage API to Cloud Storage & File Sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@
 | API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [Box](https://developer.box.com/) | File Sharing and Storage | `OAuth`| Yes | Unknown |
+| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | Free HTML/Markdown/KV/JSON/file hosting with short URLs | No | Yes | Yes |
 | [Databricks](https://docs.databricks.com/api/workspace/introduction) | Manage Databricks workspaces, clusters, jobs, and notebooks via a Rest API | `apiKey` | Yes | Unknown |
 | [Delta Lake](https://docs.delta.io/latest/delta-apidoc.html) | Open-source storage framework enabling Lakehouse architecture with Spark, PrestoDB, Flink, Trino, Hive, and APIs | No | No | Unknown |
 | [ddownload](https://ddownload.com/api) | File Sharing and Storage | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds BrewPage to the **Cloud Storage & File Sharing** section.

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [BrewPage](https://kochetkov-ma.github.io/brewpage-openapi/) | Free HTML/Markdown/KV/JSON/file hosting with short URLs | No | Yes | Yes |

BrewPage (`https://brewpage.app`) is a free hosting platform for HTML/Markdown content, key-value entries, JSON documents, and arbitrary files. Reads require no auth; writes are gated by owner tokens returned by publish endpoints. OpenAPI 3.1 contract at `https://kochetkov-ma.github.io/brewpage-openapi/openapi.json`. MIT-licensed.

Entry inserted alphabetically between Box and Databricks.