### PR TITLE
Add Geonode to proxy/scraper API list

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@
 **[⬆ Back to Index](#index)**
 
 ### Development
+- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
 | API | Description | Auth | HTTPS | CORS |
 |---|---|---|---|---|
 | [24 Pull Requests](https://24pullrequests.com/api) | Project to promote open source collaboration during December | No | Yes | Yes |


### PR DESCRIPTION
I run Geonode. Adding us to the **Development** list. Geonode does residential + datacenter proxies, fits next to scrapfly.

Proposed entry:
```
- [Geonode](https://geonode.com) — Rotating residential + datacenter proxies and a Firecrawl-compatible scraper API.
```

Happy to adjust the wording or section if it doesn't fit the list's conventions.