### PR TITLE
Add Padel Snipe World Atlas to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1706,6 +1706,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [NHL Records and Stats](https://gitlab.com/dword4/nhlapi) | NHL historical data and statistics | No | Yes | Unknown |
 | [Oddsmagnet](https://oddsmagnet.com/oddsdata) | Odds history from multiple UK bookmakers | No | Yes | Yes |
 | [OpenLigaDB](https://www.openligadb.de) | Crowd sourced sports league results | No | Yes | Yes |
+| [Padel Snipe World Atlas](https://padelsnipe.com/world) | 4,000+ padel clubs across 9 European countries with GPS, court counts, and platform info — CC-BY 4.0 | No | Yes | Yes |
 | [Premier League Standings ](https://rapidapi.com/heisenbug/api/premier-league-live-scores/) | All Current Premier League Standings and Statistics | `apiKey`| Yes | Unknown |
 | [Sport Data](https://sportdataapi.com) | Get sports data from all over the world | `apiKey`| Yes | Unknown |
 | [Sport Highlights](https://highlightly.net/documentation/sports/) | Real time Sport Highlights | `apiKey`| Yes | Unknown |


### PR DESCRIPTION
## API

**Padel Snipe World Atlas** — Open API listing every mapped padel club across Europe.

- **Endpoint** : https://padelsnipe.com/api/world/clubs
- **Docs** : https://padelsnipe.com/world/api
- **Visualization** : https://padelsnipe.com/world
- **License** : CC-BY 4.0
- **Officially listed on data.gouv.fr** : https://www.data.gouv.fr/datasets/atlas-des-clubs-de-padel-base-de-donnees-ouverte-cc-by-4-0/

## Specs

| Property | Value |
|---|---|
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |
| Pagination | No (single JSON, ~600 KB gzipped) |
| Rate limit | None published, CDN-cached 24h |

## Content

~4,000 padel clubs across 9 European countries (ES, IT, FR, UK, DE, BE, PT, NL, SE). Each record :

- GPS coordinates (latitude, longitude WGS84)
- Club name, city, postal code
- Indoor / outdoor court counts
- Booking platform (Playtomic or Anybuddy)
- Release pattern observation (when each club opens its booking slots)

## Why it fits Sports & Fitness

Padel is the fastest-growing racket sport in Europe. No equivalent public dataset existed — data was fragmented across booking platforms. The list already has entries for many sports (football, golf-adjacent, basketball, hockey...) — padel completes the racket-sports gap.

## Insertion

Alphabetically between **OpenLigaDB** and **Premier League Standings** in the Sports & Fitness section. Single-line table entry, no other changes.