### PR TITLE
Add TwitterAPI.io to Social

### DIFF
--- a/README.md
+++ b/README.md
@@ -1527,6 +1527,7 @@
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth`| Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth`| Yes | Unknown |
 | [Webex](https://developer.webex.com) | Team collaboration software | `OAuth`| Yes | Yes |
+| [TwitterApi.IO](https://twitterapi.io) | Access real-time and historical Twitter data | `apiKey`| Yes | No |
 
 **[⬆ Back to Index](#index)**
 

--- a/README.md
+++ b/README.md
@@ -1525,9 +1525,9 @@
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth`| Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth`| Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth`| Yes | No |
+| [TwitterApi.IO](https://twitterapi.io) | Access Twitter's Real-time & Historical Data with Unmatched Simplicity | `apiKey`| Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth`| Yes | Unknown |
 | [Webex](https://developer.webex.com) | Team collaboration software | `OAuth`| Yes | Yes |
-| [TwitterApi.IO](https://twitterapi.io) | Access real-time and historical Twitter data | `apiKey`| Yes | No |
 
 **[⬆ Back to Index](#index)**
 

--- a/README.md
+++ b/README.md
@@ -1525,6 +1525,7 @@
 | [Tumblr](https://www.tumblr.com/docs/en/api/v2) | Read and write Tumblr Data | `OAuth`| Yes | Unknown |
 | [Twitch](https://dev.twitch.tv/docs) | Game Streaming API | `OAuth`| Yes | Unknown |
 | [Twitter](https://developer.twitter.com/en/docs) | Read and write Twitter data | `OAuth`| Yes | No |
+| [TwitterAPI.io](https://twitterapi.io) | Real-time Twitter/X data — search tweets, user profiles, followers/followings, mentions, replies, quotes, retweeters, and trending topics. No OAuth, single API key, pay-per-call. Also delivered as a hosted MCP server (mcp.twitterapi.io/mcp) for Claude, Cursor, and other AI agents | `apiKey` | Yes | Unknown |
 | [TwitterApi.IO](https://twitterapi.io) | Access Twitter's Real-time & Historical Data with Unmatched Simplicity | `apiKey`| Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth`| Yes | Unknown |
 | [Webex](https://developer.webex.com) | Team collaboration software | `OAuth`| Yes | Yes |


### PR DESCRIPTION
Adds TwitterAPI.io to the **Social** category, alphabetical (after the official Twitter entry, before vk).

- URL: https://twitterapi.io
- Real-time Twitter/X data: search tweets, fetch user profiles, followers/followings, mentions, replies, quotes, retweeters, trending topics.
- Auth: `apiKey` (single header key, no OAuth, no app registration).
- HTTPS: Yes.
- Also delivered as a hosted MCP server (mcp.twitterapi.io/mcp) for AI agents in Claude, Cursor, and other MCP clients.
- Distinct from the existing official Twitter entry which requires OAuth + developer-platform approval.