### PR TITLE
Add Longevity World Cup API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1207,6 +1207,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Infermedica](https://developer.infermedica.com/docs/) | NLP based symptom checker and patient triage API for health diagnosis from text | `apiKey` | Yes | Yes |
 | [LAPIS](https://cov-spectrum.ethz.ch/public) | SARS-CoV-2 genomic sequences from public sources | No | Yes | Yes |
 | [Lexigram](https://docs.lexigram.io/) | NLP that extracts mentions of clinical concepts from text, gives access to clinical ontology | `apiKey` | Yes | Unknown |
+| [Longevity World Cup](https://longevityworldcup.com/llms-full.txt) | Public biological-age competition data and rankings | No | Yes | Yes |
 | [Makeup](http://makeup-api.herokuapp.com/) | Makeup Information | No | No | Unknown |
 | [MyVaccination](https://documenter.getpostman.com/view/16605343/Tzm8GG7u) | Vaccination data for Malaysia | No | Yes | Unknown |
 | [NPPES](https://npiregistry.cms.hhs.gov/registry/help-api) | National Plan & Provider Enumeration System, info on healthcare providers registered in US | No | Yes | Unknown |


### PR DESCRIPTION
## Summary
- adds Longevity World Cup to the Health section
- lists it as no-auth, HTTPS, and CORS-enabled

## Verification
- checked `https://longevityworldcup.com/api/data/athletes` returns HTTP 200 JSON
- checked `https://longevityworldcup.com/llms-full.txt` returns HTTP 200 docs/context