### PR TITLE
Add GetXAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1643,6 +1643,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Facebook](https://developers.facebook.com/) | Facebook Login, Share on FB, Social Plugins, Analytics and more | `OAuth`| Yes | Unknown |
 | [Foursquare](https://developer.foursquare.com/) | Interact with Foursquare users and places (geolocation-based checkins, photos, tips, events, etc) | `OAuth`| Yes | Unknown |
 | [Full Contact](https://docs.fullcontact.com/) | Get Social Media profiles and contact Information | `OAuth`| Yes | Unknown |
+| [GetXAPI](https://www.getxapi.com) | Twitter/X data API for read endpoints (search, profiles, follower graph, mentions, lists, communities, trends) and write endpoints (post tweets, like, retweet, follow, DM, articles). Public OpenAPI 3.1 spec at docs.getxapi.com/openapi.json | `apiKey` | Yes | Unknown |
 | [HackerNews](https://github.com/HackerNews/API) | Social news for CS and entrepreneurship | No | Yes | Unknown |
 | [Hashnode](https://hashnode.com) | A blogging platform built for developers | No | Yes | Unknown |
 | [Hashtag](https://mukeshsolanki.gitbook.io/hashtag-api/) | Generate Hashtags using a keyword or an Image | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds GetXAPI to the Social section.

GetXAPI is a Twitter / X data API. Read endpoints (search, profiles, follower graph, mentions, lists, communities, trends) and write endpoints (post tweets, like, retweet, follow, DM, articles). Bearer-token auth. Public OpenAPI 3.1 spec.

- Site: https://www.getxapi.com
- Docs: https://docs.getxapi.com
- Spec: https://docs.getxapi.com/openapi.json
- Wikidata: https://www.wikidata.org/wiki/Q139996278

Single-line entry, factual voice matching neighboring entries, inserted at the alphabetical position in the Social section.