### PR TITLE
Add Neotimo DGFiP Mirror to Government

### DIFF
--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Interpol Red Notices](https://interpol.api.bund.dev/) | Access and search Interpol Red Notices | No | Yes | Unknown |
 | [Istanbul (İBB) Open Data](https://data.ibb.gov.tr) | Data sets from the İstanbul Metropolitan Municipality (İBB) | No | Yes | Unknown |
 | [National Park Service, US](https://www.nps.gov/subjects/developer/) | Data from the US National Park Service | `apiKey` | Yes | Yes |
+| [Neotimo DGFiP Mirror](https://neotimo.com/annuaire-dgfip) | French DGFiP registry of certified e-invoicing platforms (Plateformes Agréées), searchable by SIRET | No | Yes | Unknown |
 | [Open Government, ACT](https://www.data.act.gov.au/) | Australian Capital Territory Open Data | No | Yes | Unknown |
 | [Open Government, Argentina](https://datos.gob.ar/) | Argentina Government Open Data | No | Yes | Unknown |
 | [Open Government, Australia](https://www.data.gov.au/) | Australian Government Open Data | No | Yes | Unknown |


### PR DESCRIPTION
Adds **Neotimo DGFiP Mirror** to the Government section.

It's a free public mirror of the French DGFiP registry of *Plateformes Agréées* — the platforms certified for electronic invoicing, which becomes mandatory in France from September 2026.

- No authentication
- Search by SIRET / SIREN
- REST API, 10 requests/min/IP
- Daily sync with the official DGFiP data

One entry added, alphabetical ordering within the section preserved.
