### PR TITLE
Add Rendobar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1939,6 +1939,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Mux](https://www.mux.com/) | Mux Video is an API that enables developers to build unique live and on-demand video experiences | `apiKey` | Yes | Unknown |
 | [Open Movie Database](http://www.omdbapi.com/) | Movie information | `apiKey` | Yes | Unknown |
 | [Rendi](https://rendi.dev) | FFmpeg API | `apiKey` | Yes | No |
+| [Rendobar](https://rendobar.com/docs) | Serverless FFmpeg in the cloud for video and audio transcoding, trimming and conversion | `apiKey` | Yes | No |
 | [Ron Swanson Quotes](https://github.com/jamesseanwright/ron-swanson-quotes#ron-swanson-quotes-api) | Television | No | Yes | Unknown |
 | [Rules of Acquisition](https://rulesofacquisition.herokuapp.com/) | Ferengi Rules of Acquisition from Star Trek with episode references | No | Yes | Unknown |
 | [Shoof Aflam](https://shoofaflam.tv/api-docs/) | Arabic streaming guide — search 14,000+ movies/series, platform availability across 18 services | No | Yes | Yes |


### PR DESCRIPTION
## Summary
Adds Rendobar to the Video section. It's a serverless API for running FFmpeg jobs in the cloud (transcode, trim and convert video/audio) without managing your own infrastructure.

## Details
- docs: `https://rendobar.com/docs`
- auth: `apiKey` (Authorization header)
- https: `Yes`
- cors: `No` — the API only allows its own app origin (`app.rendobar.com`), so third-party browser calls are blocked
- free tier: $5 in credits on signup, no credit card

## Validation
- `curl -sL -o /dev/null -w '%{http_code}' https://rendobar.com/docs` -> `200`
- `curl -s -o /dev/null -w '%{http_code}' https://api.rendobar.com/jobs` -> `401` (auth required)
- `curl -s -D - -X OPTIONS -H 'Origin: https://example.com' -H 'Access-Control-Request-Method: POST' https://api.rendobar.com/jobs` -> `access-control-allow-origin: https://app.rendobar.com`, so CORS is `No` for outside origins

---

-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] All changes have been squashed into a single commit
