### PR TITLE
Add US Federal Contracts & Grants API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [PolitiData](https://politidata.ca) | Canadian political financing, lobbying registrations and communications | `apiKey` | Yes | Unknown |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Yes | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth`| Yes | Unknown |
+| [US Federal Contracts & Grants](https://government-data-api.onrender.com/docs) | US federal contracts, grants, and agency spending data from USASpending.gov | No | Yes | Yes |
 | [USAspending.gov](https://api.usaspending.gov/) | US federal spending data | No | Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Add US Federal Contracts & Grants API

This PR adds the Government Contracts & Grants API to the Government section.

### API Details
- **Name**: US Federal Contracts & Grants
- **URL**: https://government-data-api.onrender.com/docs
- **Description**: US federal contracts, grants, and agency spending data from USASpending.gov
- **Auth**: No (free, no API key required)
- **HTTPS**: Yes
- **CORS**: Yes

### About the API
This API provides programmatic access to millions of US federal government contracts and grants updated daily from USASpending.gov. Perfect for procurement research, compliance tools, grant-finding applications, and government transparency projects.

**Endpoints**: /contracts, /grants, /agencies, /health

Alphabetically sorted before USAspending.gov.