### PR TITLE
Add WoopSocial API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1682,6 +1682,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [TwitterApi.IO](https://twitterapi.io) | Access Twitter's Real-time & Historical Data with Unmatched Simplicity | `apiKey`| Yes | No |
 | [vk](https://vk.com/dev/sites) | Read and write vk data | `OAuth`| Yes | Unknown |
 | [Webex](https://developer.webex.com) | Team collaboration software | `OAuth`| Yes | Yes |
+| [WoopSocial](https://docs.woopsocial.com/) | Schedule and publish posts across social media platforms | `apiKey` | Yes | No |
 | [Zoom](https://developers.zoom.us/docs/api) | Video communication, web conferencing, chat, and webinars | `OAuth`| Yes | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adding WoopSocial to the **Social** list. WoopSocial provides an API for scheduling and publishing posts across social media platforms.

Proposed entry:

| API | Description | Auth | HTTPS | CORS |
|-----|-------------|------|-------|------|
| [WoopSocial](https://docs.woopsocial.com/) | Schedule and publish posts across social media platforms | `apiKey` | Yes | No |

Happy to adjust the wording or section if it does not fit the list's conventions.