### PR TITLE
Add MentionsAPI to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth`| Yes | Unknown |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth`| Yes | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth`| Yes | Unknown |
+| [MentionsAPI](https://mentionsapi.com/docs/api/check) | Check brand mentions, ranks and citations across AI search surfaces (ChatGPT, Claude, Gemini, Perplexity, AI Overviews) | `apiKey` | Yes | Unknown |
 | [NioLeads](https://nioleads.com/apidoc) | LinkedIn Email Finder and Email Verifier | `apiKey` | Yes | Yes |
 | [Instatus](https://instatus.com/help/api) | Post to and update maintenance and incidents on your status page through an HTTP REST API | `apiKey` | Yes | Unknown |
 | [Logo.dev](https://www.logo.dev) | Automated company logo API that updates daily. Transform any domain or company name into verified logos. | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds MentionsAPI under **Business** (alphabetical, after Google Analytics).

- **What it does:** checks whether a brand is mentioned - with ranks and citations - across AI search surfaces (ChatGPT, Claude, Gemini, Perplexity, Google AI Overviews, Bing Copilot)
- **Auth:** apiKey (Bearer), free $1 signup credit with no card
- **HTTPS:** yes
- **Docs:** https://mentionsapi.com/docs/api/check (OpenAPI 3.1 at https://mentionsapi.com/openapi.json)