### PR TITLE
Add slot.report — free slot machine data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [RuneScape](https://runescape.wiki/w/Application_programming_interface) | RuneScape and OSRS RPGs information | No | Yes | No |
 | [Sakura CardCaptor](https://github.com/JessVel/sakura-card-captor-api) | Sakura CardCaptor Cards Information | No | Yes | Unknown |
 | [Scryfall](https://scryfall.com/docs/api) | Magic: The Gathering database | No | Yes | Yes |
+| [slot.report](https://slot.report/api/) | Online slot machine data: RTP, volatility, max win and features for 6,000+ games | No | Yes | Yes |
 | [SpaceTradersAPI](https://spacetraders.io?rel=pub-apis) | A playable inter-galactic space trading MMOAPI | `OAuth` | Yes | Yes |
 | [Steam](https://steamapi.xpaw.me/) | Steam Web API documentation | `apiKey`| Yes | No |
 | [Steam](https://github.com/Revadike/InternalSteamWebAPI/wiki) | Internal Steam Web API documentation | No | Yes | No |


### PR DESCRIPTION
Adds **slot.report** to the *Games & Comics* category.

- **Docs:** https://slot.report/api/ — endpoints under https://slot.report/api/v1/
- **Data:** 6,000+ online slot machine games from 80+ providers: RTP, volatility, max win, grid, features, mechanics, themes, release dates. Updated daily.
- **Auth:** No · **HTTPS:** Yes · **CORS:** Yes (`Access-Control-Allow-Origin: *`)
- **OpenAPI 3.1:** https://slot.report/api/openapi.json
- Completely free, no paid tier, static JSON.

Entry is alphabetically placed (between Scryfall and SpaceTradersAPI).