### PR TITLE
Add Noozra News API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1349,6 +1349,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [NewsDataHub](https://newsdatahub.com) | NewsDataHub provides a production-ready REST API delivering near-real-time global news data at scale | `apiKey` | Yes | Yes |
 | [NewsMesh](https://newsmesh.co) | Access the news articles from trusted sources with real-time updates & powerful search capabilities | `apiKey` | Yes | Yes |
 | [NewsX](https://rapidapi.com/machaao-inc-machaao-inc-default/api/newsx/) | Get or Search Latest Breaking News with ML Powered Summaries 🤖| `apiKey` | Yes | Unknown |
+| [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |
 | [RiskSentinel](https://risksentinel.ai) | AI-powered news intelligence API delivering structured events with risk assessment, sentiment analysis, company impacts, geo tagging, ai generated summary and more | `apiKey` | Yes | No |
 | [Spaceflight News](https://spaceflightnewsapi.net) | Spaceflight related news 🚀| No | Yes | Yes |
 | [Substack API Wrapper](https://github.com/NHagar/substack_api) | Substack's newsletter platform now has an API wrapper, for easy access to latest posts | `No` | Yes | Unknown |


### PR DESCRIPTION
## What does this PR do?

Adds [Noozra](https://noozra.com/api) to the News category.

**Entry:**
`| [Noozra](https://noozra.com/api) | Free news headlines from 200+ curated RSS sources | No | Yes | Yes |`

## Verification

- Endpoint: `GET https://noozra.com/api/articles?limit=2` returns HTTP 200 with JSON news headlines
- Auth: No API key required (100 requests/day free, per IP, no signup)
- HTTPS: Yes
- CORS: Yes — response includes `Access-Control-Allow-Origin: *`
- Documentation: https://noozra.com/api

## Checklist

- [x] API is publicly accessible
- [x] API has free access (no key required for the free tier)
- [x] HTTPS is supported
- [x] Entry follows the correct format
- [x] Entry is placed alphabetically in the News section
- [x] Description is under 100 characters
- [x] PR title follows the required format `Add Api-name API`
- [x] One link per PR

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

