### PR TITLE
Add World Cup 2026 Tour API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1729,6 +1729,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [TheSportsDB](https://www.thesportsdb.com/api.php) | Crowd-Sourced Sports Data and Artwork | `apiKey`| Yes | Yes |
 | [Tredict](https://www.tredict.com/blog/oauth_docs/) | Get and set activities, health data and more | `OAuth` | Yes | Unknown |
 | [Wger](https://wger.de/en/software/api) | Workout manager data as exercises, muscles or equipment | `apiKey`| Yes | Unknown |
+| [World Cup 2026 Tour](https://ay-worldcup2026.zeabur.app/developers) | World Cup 2026 fixtures, local-time conversion, calendars, and share links | No | Yes | Yes |
 | [Your Move - Exercise API](https://ymove.app/exercise-api) | The complete exercise library and fitness API for your app. 698+ professional HD exercise videos with workout generation and program builder. | `apiKey` | Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds World Cup 2026 Tour to the Sports & Fitness section.\n\nIt is a free, no-auth public API for World Cup 2026 fixtures, local-time conversion, calendar links, and share links.\n\nDocs: https://ay-worldcup2026.zeabur.app/developers\nOpenAPI: https://ay-worldcup2026.zeabur.app/openapi.json

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

