### PR TITLE
Add Defend Network

### DIFF
--- a/README.md
+++ b/README.md
@@ -1585,6 +1585,7 @@ like WhatsApp | `apiKey` | Yes | Yes |
 | [Classify](https://github.com/cheatsnake/classify) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Puerto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
+| [Defend Network](https://defend.network/api/) | Free no-auth JSON feed of exploited CVEs with CVSS, EPSS and CISA KEV status | No | Yes | Yes |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://api.filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |


### PR DESCRIPTION
Adds Defend Network to the Security section.

It is a free, no-authentication JSON data API of CVEs (CVSS, EPSS, and CISA KEV status), placed alphabetically between CRXcavator and EmailRep. It is a free data feed in the same category as the existing National Vulnerability Database entry.

-   [x] My submission is formatted according to the guidelines in the contributing guide
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been squashed into a single commit

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

