### PR TITLE
Add HProxy Free Proxy List

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Heroku](https://devcenter.heroku.com/articles/platform-api-reference/) | REST API to programmatically create apps, provision add-ons and perform other task on Heroku | `OAuth` | Yes | Yes |
 | [Hoppscotch](https://hoppscotch.io/) | A lightweight, fast, and customizable app for testing and designing APIs. A free, fast, and beautiful  | No | Yes | Unknown |
 | [Host.io](https://host.io) | Domains Data API for Developers | `apiKey`| Yes | Yes |
+| [HProxy Free Proxy List](https://hproxy.com/api/proxy-list) | Free HTTP, HTTPS, SOCKS4 & SOCKS5 proxy list, updated frequently | No | Yes | Yes |
 | [HTTP2.Pro](https://http2.pro/doc/api) | Test endpoints for client and server HTTP/2 protocol support | No | Yes | Unknown |
 | [HTTPie](https://httpie.io) | a free command-line HTTP client for the API era | No | Yes | Unknown |
 | [Httpbin](https://httpbin.org/) | A Simple HTTP Request & Response Service | No | Yes | Yes |


### PR DESCRIPTION
Adds HProxy Free Proxy List to the Development category.

- Free to use, no API key and no signup required.
- Returns live HTTP, HTTPS, SOCKS4 & SOCKS5 proxies (txt / json / csv).
- HTTPS and CORS enabled.
- Does not require the purchase of any device or service.

Checklist:
- [x] Entry added alphabetically (between Host.io and HTTP2.Pro)
- [x] Description under 100 characters, no trailing punctuation
- [x] API is free, no paywall, no required purchase

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

