### PR TITLE
Add ReefAPI

### DIFF
--- a/db/resources.json
+++ b/db/resources.json
@@ -1,5 +1,5 @@
 {
-"count": 1603,
+"count": 1604,
 "entries": [
     {
         "API": "Advanced Multilanguage AI Translator (RapidAPI)",
@@ -3932,6 +3932,15 @@
         "HTTPS": true,
         "Cors": "yes",
         "Link": "https://quickchart.io/",
+        "Category": "Development"
+    },
+    {
+        "API": "ReefAPI",
+        "Description": "One API for 160+ live web-data sources (search, social, e-commerce, real estate, jobs, finance) as clean JSON",
+        "Auth": "apiKey",
+        "HTTPS": true,
+        "Cors": "yes",
+        "Link": "https://reefapi.com",
         "Category": "Development"
     },
     {


### PR DESCRIPTION
Adds **ReefAPI** to the Development category (alphabetical, between QuickChart and Rejax).

ReefAPI is one API for 160+ live web-data sources (search, social, e-commerce, real estate, jobs, travel, news, finance, company/domain/people intelligence) returned as clean JSON. Free tier (1,000 credits, no card).

- Homepage: https://reefapi.com
- Docs: https://reefapi.com/docs

Entry: apiKey auth, HTTPS yes, CORS yes. `count` bumped 1603 → 1604.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

