### PR TITLE
Add AudD API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1299,6 +1299,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 |---|---|---|---|---|
 | [7digital](https://docs.7digital.com/reference) | Api of Music store 7digital | `OAuth`| Yes | Unknown |
 | [AI Mastering](https://aimastering.com/api_docs/) | Automated Music Mastering | `apiKey` | Yes | Yes |
+| [AudD](https://docs.audd.io) | Music recognition from audio files, URLs, and live streams | `apiKey` | Yes | Unknown |
 | [Audiomack](https://www.audiomack.com/data-api/docs) | Api of the streaming music hub Audiomack | `OAuth`| Yes | Unknown |
 | [Bandcamp](https://bandcamp.com/developer) | API of Music store Bandcamp | `OAuth`| Yes | Unknown |
 | [Bandsintown](https://app.swaggerhub.com/apis/Bandsintown/PublicAPI/3.0.0) | Music Events | No | Yes | Unknown |


### PR DESCRIPTION
Adds **AudD** to the Music category.

AudD is a music recognition API — identify songs from audio files, URLs, raw audio, video, and live streams, matched against a large reference database. It has a free tier (300 free recognitions on signup, no card, plus a public `test` token), so it meets the free-access guideline.

- Documentation: https://docs.audd.io
- Auth: apiKey (API token) · HTTPS: Yes

Added alphabetically in the Music section; description under 100 characters; single squashed commit.