### PR TITLE
Add Bargo Congress Trades API

### DIFF
--- a/README.md
+++ b/README.md
@@ -855,6 +855,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Yes | Unknown |
 | [ArgentoFX](https://fastapiproject-1-eziw.onrender.com/docs) | Real-time foreign exchange rates for Argentina | No | Yes | Yes |
 | [Banco do Brasil](https://developers.bb.com.br) | All Banco do Brasil financial transaction APIs | `OAuth`| Yes | Yes |
+| [Bargo Congress Trades](https://www.bargo.ai/free-apis/congress) | U.S. Congress STOCK Act stock trades with per-trade performance | No | Yes | Yes |
 | [Billplz](https://www.billplz.com/api) | Payment platform | `apiKey` | Yes | Unknown |
 | [Binlist](https://binlist.net/) | Public access to a database of IIN/BIN information | No | Yes | Unknown |
 | [Boleto.Cloud](https://boleto.cloud/) | A api to generate boletos in Brazil | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Bargo Congress Trades API to the public API list.

Free tier limits from the docs:
- Keyless: 30 requests/day and 1,000 rows/day per IP
- Free API key: 1,000 requests/day and 25,000 rows/day

No credit card required.
