### PR TITLE
Add ChronoVerify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1588,6 +1588,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Botd](https://github.com/fingerprintjs/botd) | Botd is a browser library for JavaScript bot detection | `apiKey` | Yes | Yes |
 | [Bugcrowd](https://docs.bugcrowd.com/api/getting-started/) | Bugcrowd API for interacting and tracking the reported issues programmatically | `apiKey` | Yes | Unknown |
 | [Censys](https://search.censys.io/api) | Search engine for Internet connected host and devices | `apiKey` | Yes | No |
+| [ChronoVerify](https://chronoverify.com/method) | Image capture time and provenance verification: C2PA Content Credentials, EXIF, pixel forensics | No | Yes | No |
 | [Classify](https://github.com/cheatsnake/classify) | Encrypting & decrypting text messages | No | Yes | Yes |
 | [ClawSearch](https://api.clawsearch.cc) | Security-first search engine API for AI agent skills with Trust Score | No | Yes | Yes |
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Puerto Rico | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds ChronoVerify to the Security section (alphabetical order preserved, README only, /db untouched).

ChronoVerify is an image capture time and provenance verification API: it reads EXIF and XMP, cryptographically validates C2PA Content Credentials against the official trust lists, and runs classical pixel forensics, returning one plain-language verdict. The public endpoint is free and requires no authentication or signup (`curl -X POST https://chronoverify.com/v1/verify -F "url=..."`); a free API key (no card) is also available. Provenance validation, not a deepfake detector.

- Docs: https://chronoverify.com/method
- OpenAPI: https://chronoverify.com/openapi.json
- Auth: No (keyless public path; optional bearer key), HTTPS: Yes, CORS: No

Entry follows the table format, description under 100 characters, one link per PR, no duplicate found.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

