### PR TITLE
Add India Predictions API

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,6 +877,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [IEX Cloud](https://iexcloud.io/docs/api/) | Realtime & Historical Stock and Market Data | `apiKey` | Yes | Yes |
 | [IG](https://labs.ig.com/gettingstarted) | Spreadbetting and CFD Market Data | `apiKey` | Yes | Unknown |
 | [IIN API](https://iinapi.com) | IIN API allows you to accurately identify the issuing bank, card type, country of origin, and other details from a credit or debit card number. This is essential for fraud prevention, payment processing, and customer verification. | `apiKey` | Yes | Yes |
+| [India Predictions](https://www.indiapredictions.com/data) | Aggregated Polymarket prediction-market odds for India (cricket, elections, crypto) | No | Yes | Yes |
 | [Indian Mutual Fund](https://www.mfapi.in/) | Get complete history of India Mutual Funds Data | No | Yes | Unknown |
 | [Intrinio](https://intrinio.com/) | A wide selection of financial data feeds | `apiKey` | Yes | Unknown |
 | [KeepRule](https://github.com/henu-wang/keeprule-api) | Investment principles and quotes from Buffett, Munger, and other masters | No | Yes | Yes |


### PR DESCRIPTION
Adding the **India Predictions** API under **Finance**.

A free, no-key, CORS-enabled JSON API that aggregates Polymarket prediction-market odds for India-focused markets (cricket/IPL, elections, RBI/Nifty, crypto, Bollywood).

- Endpoint: https://www.indiapredictions.com/api/markets
- Docs (linked in the entry): https://www.indiapredictions.com/data

**Checklist**

- [x] My addition is ordered alphabetically within the category
- [x] Useful description under 100 characters, no ending punctuation
- [x] Auth: No · HTTPS: Yes · CORS: Yes (verified)
- [x] Link points to documentation

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

