### PR TITLE
Add CrawlGraph API to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1376,6 +1376,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
+| [CrawlGraph](https://crawlgraph.com/docs/api) | Backlink and domain-link data from Common Crawl's open web graph | `apiKey` | Yes | No |
 | [DataStream](https://github.com/datastreamapp/api-docs) | An open access platform for sharing Canadian water quality data | `apiKey` | Yes | Yes |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |
 | [French Address Search](https://geo.api.gouv.fr/adresse) | Address search via the French Government | No | Yes | Unknown |


### PR DESCRIPTION
Adds CrawlGraph to the Open Data section (alphabetical order).

CrawlGraph exposes backlink / domain-link data derived from Common Crawl's open hyperlink graph (about 120M domains, 4.4B links, refreshed quarterly) over a JSON REST API with an OpenAPI spec (https://crawlgraph.com/api/v1/openapi.json).

Free tier: 15 calls/month with a self-serve API key (emailed, no purchase or device required) - request at https://crawlgraph.com/docs/api. HTTPS yes; CORS is restricted, so listed as No.

Disclosure: I am the maintainer of the API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

