### PR TITLE
Add Cambio Uruguay API

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [1Forge](https://1forge.com/forex-data-api/api-documentation) | Forex currency market data | `apiKey` | Yes | Unknown |
 | [Amdoren](https://www.amdoren.com/currency-api/) | Free currency API with over 150 currencies | `apiKey` | Yes | Unknown |
 | [Bank of Russia](https://www.cbr.ru/development/SXML/) | Exchange rates and currency conversion | No | Yes | Unknown |
+| [Cambio Uruguay](https://cambio-uruguay.com) | Real-time buy/sell rates from every Uruguayan exchange house, with conversion and history | No | Yes | Yes |
 | [Currencyapi](https://currencyapi.com) | Currency Conversion API and cryptocurrency prices, updated minutely | `apiKey` | Yes | Yes |
 | [Currency-api](https://github.com/fawazahmed0/currency-api#readme) | Free Currency Exchange Rates API with 150+ Currencies & No Rate Limits | No | Yes | Yes |
 | [CurrencyFreaks](https://currencyfreaks.com/) | Provides current and historical currency exchange rates with free plan 1K requests/month | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds **Cambio Uruguay** to the **Currency Exchange** section (edited `README.md` only — `/db` left untouched per the guidelines).

| Field | Value |
|---|---|
| API | https://api.cambio-uruguay.com |
| Docs/Site | https://cambio-uruguay.com |
| Auth | No |
| HTTPS | Yes |
| CORS | Yes |

Free, no-auth REST API aggregating **real-time buy/sell exchange rates from every Uruguayan casa de cambio (exchange house)**, plus currency conversion and historical rate series. JSON responses.

Checklist:
- [x] Main product, publicly reachable now, documented
- [x] Custom domain (`cambio-uruguay.com`), not a shared subdomain
- [x] Full free access, no key / account / device purchase
- [x] One link, added in alphabetical order (after *Bank of Russia*)
- [x] Description under 100 characters, name does not end with "API"

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

