### PR TITLE
Add OpenChainBench API

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,6 +409,7 @@
 | [Nexchange](https://nexchange2.docs.apiary.io/) | Automated cryptocurrency exchange service | No | No | Yes |
 | [NovaDax](https://doc.novadax.com/en-US/#introduction) | NovaDAX API to access all market data, trading management endpoints | `apiKey` | Yes | Unknown |
 | [OKEx](https://okx.com/okx-api) | Cryptocurrency exchange based in Seychelles | `apiKey` | Yes | Unknown |
+| [OpenChainBench](https://openchainbench.com/api/openapi.json) | Live crypto infra benchmarks: RPC latency, oracles, bridges, perp DEX, prediction markets | No | Yes | Yes |
 | [OpenSea](https://docs.opensea.io/reference/api-overview) | The Largest NFT Marketplace | `apiKey` | Yes | No |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Yes | Unknown |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Yes | Unknown |


### PR DESCRIPTION
Adds OpenChainBench to the Cryptocurrency section, placed alphabetically between OKEx and OpenSea.

- API: OpenChainBench
- Description: Live crypto infra benchmarks: RPC latency, oracles, bridges, perp DEX, prediction markets (91 chars)
- Auth: No (open endpoint, no key required)
- HTTPS: Yes
- CORS: Yes (verified via `access-control-allow-origin: *` header)
- Link: https://openchainbench.com/api/openapi.json (OpenAPI 3.1 spec)
- Homepage: https://openchainbench.com
- Data license: CC BY 4.0
- Free tier: Full free access, no paid tier or paywall

## Checklist

- [x] Alphabetical order maintained (between OKEx and OpenSea)
- [x] Description under 100 characters
- [x] Column padded with one space either side
- [x] Not a duplicate (searched existing entries)
- [x] Fully free API, no purchase required
- [x] Documentation available at https://openchainbench.com/methodology and OpenAPI spec at the link

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1003?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

