### PR TITLE
Add College ROI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,6 +1378,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [BotsArchive](https://botsarchive.com/docs.html) | JSON formatted details about Telegram Bots available in database | No | Yes | Unknown |
 | [Callook.info](https://callook.info) | United States ham radio callsigns | No | Yes | Unknown |
 | [CARTO](https://carto.com/) | Location Information Prediction | `apiKey` | Yes | Unknown |
+| [College ROI](https://le-teen.com/api) | Lifetime ROI of US colleges and majors, static JSON, CC BY 4.0 | No | Yes | Yes |
 | [CollegeScoreCard.ed.gov](https://collegescorecard.ed.gov/data/) | Data on higher education institutions in the United States | No | Yes | Unknown |
 | [DataStream](https://github.com/datastreamapp/api-docs) | An open access platform for sharing Canadian water quality data | `apiKey` | Yes | Yes |
 | [Enigma Public](https://developers.enigma.com/docs) | Broadest collection of public data | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Adds College ROI to Open Data: free, keyless, CORS-open static JSON API for the lifetime return on investment of US colleges and majors (30-year NPV per school, ROI stats per major/subfield), from public FREOPP/IPEDS/BEA data. Docs: https://le-teen.com/api · OpenAPI 3.1: https://le-teen.com/api/v1/openapi.json · custom domain, self-serve, no auth. Underlying dataset CC BY 4.0, Zenodo DOI 10.5281/zenodo.21351603. Disclosure: I maintain this API.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

