### PR TITLE
Add ProteinBenchmark to Food & Drink

### DIFF
--- a/README.md
+++ b/README.md
@@ -930,6 +930,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [LCBO](https://lcbo.dev/) | Alcohol | No | Yes | Yes |
 | [Open Brewery DB](https://www.openbrewerydb.org) | Breweries, Cideries and Craft Beer Bottle Shops | No | Yes | Yes |
 | [Open Food Facts](https://world.openfoodfacts.org/data) | Food Products Database | No | Yes | Unknown |
+| [ProteinBenchmark](https://proteinbenchmark.com/api) | Protein, density scores and DIAAS-adjusted metrics for ~200 foods, powders and snacks | No | Yes | Yes |
 | [PunkAPI](https://github.com/alxiw/punkapi) | BrewDog's DIY Dog beer catalogue as an API | No | Yes | Yes |
 | [Spoonacular](https://spoonacular.com/food-api) | Recipes, Food Products, and Meal Planning | `apiKey` | Yes | Unknown |
 | [Status Pizza](https://status.pizza) | Pizza for every HTTP Status | No | Yes | Unknown |


### PR DESCRIPTION
Adds ProteinBenchmark to Food & Drink.

Free, read-only JSON API for protein content, protein-density scores, and
DIAAS-bioavailability-adjusted metrics of ~200 food products (snacks, powders,
restaurant items). Custom domain, clean URL, publicly documented.

- Auth: No
- HTTPS: Yes
- CORS: Yes (Access-Control-Allow-Origin: *)
- Docs: https://proteinbenchmark.com/api
- OpenAPI 3.1: https://proteinbenchmark.com/openapi.yaml

Alphabetical placement in Food & Drink between Open Food Facts and PunkAPI.
Only the README is edited; the /db folder is left untouched per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1011?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

