### PR TITLE
Add AgentServices — x402-paid crypto/market data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [CoinRanking](https://developers.coinranking.com/api/documentation) | Live Cryptocurrency data | `apiKey` | Yes | Unknown |
 | [Coinremitter](https://coinremitter.com/docs) | Cryptocurrencies Payment & Prices | `apiKey` | Yes | Unknown |
 | [CoinStats](https://coinstats.app/api-docs/) | Blockchain and DeFi across 120+ chains, market, historical data, portfolio tracking, news, sentiment, MCP, and agent skills | `apiKey` | Yes | Yes |
+| [AgentServices](https://github.com/vbkotecha/aiservices-api) | Crypto prices, DeFi yields, on-chain analytics, market data with x402 micropayments | `x402` | Yes | Yes |
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |


### PR DESCRIPTION
AgentServices provides 54 services / 97 endpoints for crypto/market data: prices, OHLCV, DeFi yields, technical indicators, DEX swap quotes, on-chain analytics, prediction markets, trending tokens, gas tracker, news, social sentiment.

Uses HTTP 402 (x402) protocol for micropayments — no API keys, no registration. Pay-per-call with USDC on Base ($0.01-$0.05/call). Also available as MCP server (37 tools).

Added to the Cryptocurrency section alphabetically (after CoinStats).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

