### PR TITLE
Add VaultVision API

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Trading View](https://www.tradingview.com/rest-api-spec/) | Market price, data, graph for brokers and traders | `OAuth` | Yes | Unknown |
 | [Tron Network](https://developers.tron.network/reference/api-key) | Provides various endpoints to interact with the Tron Blockchain | No | Yes | Unknown |
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Yes | Unknown |
+| [VaultVision](https://vaultvision.tech/developers) | Read-only Hyperliquid vault data, risk rankings, and research signals | No | Yes | Yes |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Yes | Unknown |
 | [ZMOK](https://docs.zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Yes | Unknown |
 


### PR DESCRIPTION
Adds VaultVision to the Cryptocurrency section as a public, self-serve API.

The linked developer page documents a live read-only API and OpenAPI contract. No authentication is required, HTTPS is enforced, and browser requests are supported with `Access-Control-Allow-Origin: *`.

Verification performed:
- developer documentation returns HTTP 200
- live API endpoint returns HTTP 200
- OpenAPI JSON parses successfully
- CORS response header verified
- no existing VaultVision issue or PR found

- [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The description does not have more than 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been squashed into a single commit