### PR TITLE
Add Live Tennis to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1720,7 +1720,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
 | [iSports API](https://isportsapi.com/) | Provide live and historical sports data of global competitions, like live score, fixtures, player & match stats, database etc. | `apiKey` | No | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
-| [Live Tennis](https://livetennisapi.com) | Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket. Free plan available | `apiKey`| Yes | Yes |
+| [Live Tennis](https://livetennisapi.com) | Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket. Free plan available | `apiKey` | Yes | Yes |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |
 | [NBA GraphQL](https://nbaapi.com/graphql/) | Advanced NBA Player, Team, and Season Statistics and Data | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1720,6 +1720,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
 | [iSports API](https://isportsapi.com/) | Provide live and historical sports data of global competitions, like live score, fixtures, player & match stats, database etc. | `apiKey` | No | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
+| [Live Tennis](https://livetennisapi.com) | Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket. Free plan available | `apiKey`| Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |
 | [NBA GraphQL](https://nbaapi.com/graphql/) | Advanced NBA Player, Team, and Season Statistics and Data | No | Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1720,7 +1720,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
 | [iSports API](https://isportsapi.com/) | Provide live and historical sports data of global competitions, like live score, fixtures, player & match stats, database etc. | `apiKey` | No | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
-| [Live Tennis](https://livetennisapi.com) | Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket. Free plan available | `apiKey`| Yes | No |
+| [Live Tennis](https://livetennisapi.com) | Real-time tennis scores, players, fixtures and model win-probability for ATP, WTA, Challenger and ITF, over REST and WebSocket. Free plan available | `apiKey`| Yes | Yes |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |
 | [NBA GraphQL](https://nbaapi.com/graphql/) | Advanced NBA Player, Team, and Season Statistics and Data | No | Yes | Yes |


### PR DESCRIPTION
Adds **Live Tennis** to Sports & Fitness.

A real-time tennis data API — live and upcoming matches, scores, players, fixtures, model win-probability and match-winner market prices for ATP, WTA, Challenger and ITF, over REST and a WebSocket feed.

| Field | Value |
|---|---|
| Auth | `apiKey` (Bearer or `X-API-Key`) |
| HTTPS | Yes |
| CORS | **No** — verified against the live response headers, not assumed |
| Docs | <https://docs.livetennisapi.com> |
| OpenAPI 3.1 | <https://github.com/livetennisapi/openapi> |

Against the criteria in CONTRIBUTING.md:

- **Self-serve** — free plan, no card, no waitlist: <https://livetennisapi.com/subscribe/free>. A stranger can go from the docs to a working call unaided.
- **Free or paid** — freemium. Free covers live/upcoming matches, scores, players and fixtures at 1,000 req/day; market prices, model output and the WebSocket feed are paid.
- **Publicly reachable and documented** — `curl https://api.livetennisapi.com/api/public/v1/health` works right now with no key. Auth, HTTPS and CORS are all documented.
- **Main product only** — the API is the product, not a feature of something larger.

One line added, alphabetically between `JCDecaux Bike` and `MLB Records and Stats`. Official MIT-licensed SDKs exist for [JavaScript](https://github.com/livetennisapi/livetennisapi-js) and [Python](https://github.com/livetennisapi/livetennisapi-python), plus an [MCP server](https://github.com/livetennisapi/livetennisapi-mcp).

**Disclosure:** I maintain this API. Submitting it as a usable public API rather than as marketing — happy to adjust the wording or drop it if it doesn't fit.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

