### PR TITLE
Add JobsPipe API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1285,6 +1285,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Himalayas](https://himalayas.app/api) | Remote job listings with salary, timezone, and location data | No | Yes | No |
 | [jobdata API](https://jobdataapi.com/) | Simple Job Data API | `apiKey` | Yes | Unknown |
 | [Jobs2Careers](http://api.jobs2careers.com/api/spec.pdf) | Job aggregator | `apiKey` | Yes | Unknown |
+| [JobsPipe](https://jobspipe.dev/docs) | Search live job postings from job boards and company career sites, plus tech stack detection by domain | `apiKey` | Yes | Yes |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Yes | Unknown |
 | [Jobicy](https://jobicy.com/jobs-rss-feed) | Remote Jobs API Feed | No | Yes | Unknown |
 | [Juju](http://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | No | Unknown |


### PR DESCRIPTION
Adds JobsPipe to the **Jobs** section.

| Field | Value |
|---|---|
| Docs | https://jobspipe.dev/docs |
| Auth | `apiKey` (Bearer token) |
| HTTPS | Yes |
| CORS | Yes |

**Checklist against the contribution criteria**

- **Self-serve** — sign up at jobspipe.dev, generate an API key in the dashboard, and call the API. No waitlist, no sales gate.
- **Publicly documented** — https://jobspipe.dev/docs covers authentication, endpoints, parameters and responses.
- **Custom domain** — `jobspipe.dev` / `api.jobspipe.dev`, not a shared subdomain.
- **CORS verified** — preflight echoes arbitrary origins, so it is callable from the browser:

  ```
  $ curl -sX OPTIONS -H 'Origin: https://example.com' \
      -H 'Access-Control-Request-Method: GET' \
      -i https://api.jobspipe.dev/v1/jobs/search
  HTTP/2 204
  access-control-allow-origin: https://example.com
  access-control-allow-methods: POST,GET,OPTIONS
  access-control-allow-headers: Content-Type,Authorization
  ```

- **Alphabetical order** — placed between `Jobs2Careers` and `Jooble`.
- One link, one commit, clean URL, name does not end in `API` and carries no TLD.

The API serves live job postings aggregated from job boards and company career sites (search by title, location, remote status and salary), plus a tech-stack detection endpoint that returns the technologies a given company domain runs.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1017?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

