### PR TITLE
Add Lumify API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1721,6 +1721,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
 | [iSports API](https://isportsapi.com/) | Provide live and historical sports data of global competitions, like live score, fixtures, player & match stats, database etc. | `apiKey` | No | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
+| [Lumify](https://lumify.ai/docs) | Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports | `apiKey` | Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |
 | [NBA GraphQL](https://nbaapi.com/graphql/) | Advanced NBA Player, Team, and Season Statistics and Data | No | Yes | Yes |


### PR DESCRIPTION
Adds **Lumify** to the **Sports & Fitness** section (placed alphabetically).

- **What it is:** an agent-ready sports intelligence API — real-time schedules, live scores, odds, and public betting splits across MLB, NFL, NBA, NHL, NCAAF, NCAAB, tennis, and soccer.
- **Docs:** https://lumify.ai/docs
- **Auth:** `apiKey` (Bearer)
- **HTTPS:** Yes  ·  **CORS:** No

Meets the contribution criteria: self-serve (instant trial key + free tier, no "contact sales" gate), publicly documented, custom domain (`lumify.ai`), and a clean docs URL with no query params.

Made with [Cursor](https://cursor.com)