### PR TITLE
Add ProblemsByVin to Vehicle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1921,6 +1921,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Kelley Blue Book](http://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | Yes | No |
 | [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | Yes | No |
 | [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Yes | Unknown |
+| [ProblemsByVin](https://problemsbyvin.com/data/) | Owner complaints, recalls, and failure-mileage statistics from the U.S. NHTSA record by vehicle year, make, and model, published as open CC-BY JSON datasets | No | Yes | Yes |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth`| Yes | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds **ProblemsByVin** to the Vehicle category.

- **What it is:** a free, no-auth API surfacing the U.S. NHTSA owner-complaint, recall, and failure-mileage record organized by vehicle year/make/model, published as open CC-BY JSON datasets.
- **Docs / catalog:** https://problemsbyvin.com/data/ (machine-readable manifest at https://problemsbyvin.com/data/catalog.json)

Criteria check:
- Custom domain (`problemsbyvin.com`, not a shared subdomain) ✓
- Self-serve, publicly reachable now, no signup/waitlist ✓
- Auth: **No** · HTTPS: **Yes** · CORS: **Yes** (verified: `catalog.json` returns `application/json` with `Access-Control-Allow-Origin: *`) ✓
- Clean URL, no query params ✓
- Alphabetical order preserved (inserted after NHTSA) ✓

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

