### PR TITLE
Add WealthVille

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 | [Steem](https://developers.steem.io/) | Blockchain-based blogging and social media website | No | No | No |
 | [The Graph](https://thegraph.com) | Indexing protocol for querying networks like Ethereum with GraphQL | `apiKey` | Yes | Unknown |
 | [Watchdata](https://docs.watchdata.io) | Provide simple and reliable API access to Ethereum blockchain | `apiKey` | Yes | Unknown |
+| [WealthVille](https://wealthville.net/developers) | Liquidity pool scores and Enter/Hold/Exit verdicts for Solana and EVM chains | No | Yes | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds one row to `### Blockchain` in `README.md`. I have not touched `/db` — noted that it's auto-generated.

```
| [WealthVille](https://wealthville.net/developers) | Liquidity pool scores and Enter/Hold/Exit verdicts for Solana and EVM chains | No | Yes | Yes |
```

A keyless REST API returning a 0-100 score and an Enter/Hold/Exit verdict for DeFi liquidity pools — ~68,800 on Solana and 575 across Ethereum, Arbitrum, Base, Optimism, Polygon and BSC. There is also a public `/track-record` endpoint that reports misses alongside hits.

Against the checklist:

- **Custom domain** — yes, `wealthville.net`.
- **Self-serve, no waitlist** — yes; no signup at all, the endpoints are open.
- **Clean URL** — `https://wealthville.net/developers`, no query parameters.
- **Auth `No`** — no key required. An optional free partner key raises the rate limit from 60 to 600 req/min but gates nothing.
- **CORS `Yes`** — verified across every public endpoint:
  ```
  $ curl -sD- -o/dev/null -H 'Origin: https://example.com' https://wealthville.net/api/v1/pools/top?limit=1
  access-control-allow-origin: *
  ```
  Same on `/stats`, `/evm/pools`, `/signals/feed`, `/track-record`, `/scores/top` and `/openapi.json`.

Description is 76 characters and avoids adjectives. Disclosure: I maintain this project.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1039?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

