### PR TITLE
Add Live Tennis API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1783,6 +1783,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Hockey Highlights](https://highlightly.net/documentation/hockey/) | Real time hockey highlights | `apiKey` | Yes | Unknown |
 | [iSports API](https://isportsapi.com/) | Provide live and historical sports data of global competitions, like live score, fixtures, player & match stats, database etc. | `apiKey` | No | Yes |
 | [JCDecaux Bike](https://developer.jcdecaux.com/) | JCDecaux's self-service bicycles | `apiKey`| Yes | Unknown |
+| [Live Tennis API](https://docs.livetennisapi.com) | Live tennis scores, historical results, market odds and AI win-probability for ATP, WTA, Challenger and ITF | `apiKey` | Yes | Yes |
 | [Lumify](https://lumify.ai/docs) | Real-time sports intelligence: scores, odds, betting splits & AI bet analysis across 8 sports | `apiKey` | Yes | No |
 | [MLB Records and Stats](https://appac.github.io/mlb-data-api-docs/) | Current and historical MLB statistics | No | No | Unknown |
 | [NBA Data](https://rapidapi.com/api-sports/api/api-nba/) | All NBA Stats DATA, Games, Livescore, Standings, Statistics | `apiKey`| Yes | Unknown |


### PR DESCRIPTION
## What API does this PR add?

**Live Tennis API** — live tennis scores, historical results, market odds and AI win-probability for ATP, WTA, Challenger and ITF, over REST + WebSocket.

- Docs: https://docs.livetennisapi.com
- Self-serve: free tier, sign up and call — no waitlist or sales gate
- Auth: `apiKey`
- HTTPS: Yes
- CORS: Yes (`Access-Control-Allow-Origin: *`)
- Custom domain, publicly reachable now

Inserted alphabetically in **Sports & Fitness** (between JCDecaux Bike and Lumify).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

