### PR TITLE
Add DomScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Complete Criminal Checks](https://completecriminalchecks.com/Developers) | Provides data of offenders from all U.S. States and Puerto Rico | `apiKey` | Yes | Yes |
 | [CRXcavator](https://crxcavator.io/apidocs) | Chrome extension risk scoring | `apiKey` | Yes | Unknown |
 | [Defend Network](https://defend.network/api/) | Free no-auth JSON feed of exploited CVEs with CVSS, EPSS and CISA KEV status | No | Yes | Yes |
+| [DomScan](https://domscan.net/docs) | Domain, DNS, WHOIS/RDAP, TLS, email, brand and web intelligence | `apiKey` | Yes | Yes |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Yes | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | Yes | No |
 | [FilterLists](https://api.filterlists.com) | Lists of filters for adblockers and firewalls | No | Yes | Unknown |


### PR DESCRIPTION
Adds DomScan to the Security section.

DomScan exposes a publicly documented, self-serve API for domain, DNS, WHOIS/RDAP, TLS, email, brand, and web intelligence. Authentication uses an API key; HTTPS and CORS are supported. A free monthly allowance is available without a card.

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description under 100 characters
- [x] The description does not end with punctuation
- [x] Each table column is padded with one space on either side
- [x] I searched the repository and open issues/PRs for duplicates
- [x] All changes are in a single commit

Validation: docs returned HTTP 200 and an API preflight returned `Access-Control-Allow-Origin: *`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

