### PR TITLE
Add ClearTrace API

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
 | [Bscscan](https://bscscan.com/apis) | Binance Smart Chain explorer API | `apiKey` | Yes | Yes |
 | [Chainlink](https://chain.link/developer-resources) | Build hybrid smart contracts with Chainlink | No | Yes | Unknown |
 | [Chainpoint](https://tierion.com/chainpoint/) | Chainpoint is a global network for anchoring data to the Bitcoin blockchain | No | Yes | Unknown |
+| [ClearTrace](https://cleartracedata.com/docs) | Cross-frontend DEX attribution and execution quality data across Ethereum and L2s | No | Yes | Yes |
 | [Covalent](https://www.covalenthq.com/docs/api/) | Multi-blockchain data aggregator platform | `apiKey` | Yes | Unknown |
 | [Etherscan](https://etherscan.io/apis) | Ethereum explorer API | `apiKey` | Yes | Yes |
 | [GetBlock](https://getblock.io/) | Blockchain RPC Node provider that supports over 50 multiple blockchains | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds ClearTrace to the Blockchain section: a free, keyless REST API for cross-frontend DEX attribution and execution-quality data (slippage benchmarks, user revert rates, MEV sandwich detection, contract profiles) across Ethereum, Base, Arbitrum, and Optimism.

Docs: https://cleartracedata.com/docs (self-serve, publicly reachable, custom domain, no query params). Auth: No. HTTPS: Yes. CORS: Yes (verified: Access-Control-Allow-Origin: *).

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1057?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

