### PR TITLE
Add Lacuna API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1372,6 +1372,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Jamendo](https://developer.jamendo.com/v3.0/docs) | Music | `OAuth`| Yes | Unknown |
 | [JioSaavn](https://github.com/cyberboysumanjay/JioSaavnAPI) | API to retrieve song information, album meta data and many more from JioSaavn | No | Yes | Unknown |
 | [KKBOX](https://developer.kkbox.com) | Get music libraries, playlists, charts, and perform out of KKBOX's platform | `OAuth`| Yes | Unknown |
+| [Lacuna](https://lacuna.fm) | AI music generation: full songs with vocals and lyrics, or instrumentals | `apiKey` | Yes | Unknown |
 | [LastFm](https://www.last.fm/api) | Music | `apiKey` | Yes | Unknown |
 | [LRCLIB](https://lrclib.net/docs) | Crowdsourced lyrics | No | Yes | Yes |
 | [Mixcloud](https://www.mixcloud.com/developers/) | Music | `OAuth`| Yes | Yes |

--- a/README.md
+++ b/README.md
@@ -1404,6 +1404,7 @@
 | [Jamendo](https://developer.jamendo.com/v3.0/docs) | Music | `OAuth` | Unknown |
 | [JioSaavn](https://github.com/cyberboysumanjay/JioSaavnAPI) | API to retrieve song information, album meta data and many more from JioSaavn | No | Unknown |
 | [KKBOX](https://developer.kkbox.com) | Get music libraries, playlists, charts, and perform out of KKBOX's platform | `OAuth` | Unknown |
+| [Lacuna](https://lacuna.fm) | AI music generation: full songs with vocals and lyrics, or instrumentals | `apiKey` | Unknown |
 | [LastFm](https://www.last.fm/api) | Music | `apiKey` | Unknown |
 | [LRCLIB](https://lrclib.net/docs) | Crowdsourced lyrics | No | Yes |
 | [Mixcloud](https://www.mixcloud.com/developers/) | Music | `OAuth` | Yes |


### PR DESCRIPTION
Adds **Lacuna** to the Music section.

Lacuna is an AI music generation API: create full songs with vocals and lyrics, or instrumentals, via a documented REST API (docs at https://lacuna.fm/docs/api). Self-serve signup, API keys issued from the dashboard, paid plans (subscription credits). Official open-source TypeScript SDK, CLI, and MCP server: https://github.com/JOYLINK-LTD/lacuna-toolkit

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description does not have more than 100 characters
-   [x] The description does not end with punctuation
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been squashed into a single commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

