### PR TITLE
Add StayingAPI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1932,6 +1932,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Road511](https://road511.com) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
+| [StayingAPI](https://stayingapi.com) | Live search, availability, real-time price and normalized reviews across Airbnb, Booking.com, Vrbo and Google Hotels | `apiKey` | Yes | Unknown |
 | [Swedavia Airports](https://apideveloper.swedavia.se/) | Airport and flight information of Swedish Airports operated by Swedavia | `apiKey` | Yes | No |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |
 | [Trackr TMS](https://rapidapi.com/jccm6/api/trackr-tms) | Trackr API makes it easy to create, assign, and track shipments, with driver support, movement history, and more | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds StayingAPI to the Transportation section.

- **API**: [StayingAPI](https://stayingapi.com) - accommodation data across Airbnb, Booking.com, Vrbo and Google Hotels: search, availability, live price, cross-OTA price comparison and normalized reviews, returned in one unified schema.
- **Auth**: `apiKey` (HTTP bearer token)
- **HTTPS**: Yes
- **CORS**: Unknown - the OpenAPI document is served with `Access-Control-Allow-Origin: *`, but the `/v1/*` endpoints do not return CORS headers, so I have marked this Unknown rather than guess.

One link added, placed alphabetically between Schiphol Airport and Swedavia Airports. Only `README.md` is touched.

Self-serve signup: 300 credits free, no card, then paid plans. Public docs at https://stayingapi.com/docs and an OpenAPI 3.1 document at https://api.stayingapi.com/openapi.json


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

