### PR TITLE
Add cogDepot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 | [Chatwith](https://chatwith.tools) | Build custom ChatGPT-style AI chatbots trained on your website and files, integrated with 5000+ apps — no coding, live in minutes. | `apiKey`| Yes | Yes |
 | [Clarifai](https://docs.clarifai.com/api-guide/api-overview) | Computer Vision | `OAuth`| Yes | Unknown |
 | [Cloudmersive](https://www.cloudmersive.com/image-recognition-and-processing-api) | Image captioning, face recognition, NSFW classification | `apiKey` | Yes | Yes |
+| [cogDepot](https://cogdepot.com) | Marketplace API for AI agents to post service listings, negotiate terms, and finalize deals, with an A2A Agent Card and JSON-RPC endpoint | `apiKey` | Yes | No |
 | [Cohere](https://docs.cohere.ai/) | Harness the power of language understanding. Join the developers and businesses who are using Cohere to generate, categorize and organize text at a scale that was previously unimaginable. | `apiKey` | Yes | Yes |
 | [CustomGPT.ai](https://docs.customgpt.ai/reference/i-api-homepage) | RAG API with RESTful endpoints, comprehensive SDKs, and enterprise-grade reliability. | `apiKey` | Yes | Yes |
 | [Dialogflow](https://cloud.google.com/dialogflow/docs/) | Natural Language Processing | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds cogDepot to the **AI** section, alphabetically between Cloudmersive and Cohere.

| Column | Value |
|---|---|
| API | [cogDepot](https://cogdepot.com) |
| Description | Marketplace API for AI agents to post service listings, negotiate terms, and finalize deals, with an A2A Agent Card and JSON-RPC endpoint |
| Auth | `apiKey` (`x-api-key` header) |
| HTTPS | Yes |
| CORS | No |

Against the acceptance criteria:

- **Self-serve** - sign-up at https://cogdepot.com/auth/signup issues the key immediately. No waitlist, no sales gate.
- **Custom domain** - `cogdepot.com`, not a shared hosting subdomain.
- **Clean URL** - homepage link, no query parameters.
- **Publicly reachable and documented** - human docs at https://cogdepot.com/docs, and a live unauthenticated OpenAPI 3.1 spec at https://api.cogdepot.com/openapi.json.
- **Main product only** - the API is the product; the web storefront exists only so an operator can create an account and buy credits.
- **Not already listed** - no existing entry or prior PR for this domain.

CORS is `No` and verified rather than assumed - no `Access-Control-Allow-*`
header is returned on any endpoint:

```
$ curl -sI -H 'Origin: https://example.com' https://api.cogdepot.com/openapi.json | grep -ic access-control
0
```

That is deliberate: the API key is a secret and belongs on a server, so the API
is intended for server-side and agent-process callers rather than browsers.


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1071?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

