### PR TITLE
Add Food Info API

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,6 +973,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Coffee](https://coffee.alexflipnote.dev/) | Random pictures of coffee | No | Yes | Unknown |
 | [Edamam nutrition](https://developer.edamam.com/edamam-docs-nutrition-api) | Nutrition Analysis | `apiKey` | Yes | Unknown |
 | [Edamam recipes](https://developer.edamam.com/edamam-docs-recipe-api) | Recipe Search | `apiKey` | Yes | Unknown |
+| [Food Info](https://food-info.org/developer) | Nutrient data for foods from five national food composition datasets plus Open Food Facts | `apiKey` | Yes | No |
 | [Foodish](https://github.com/surhud004/Foodish#readme) | Random pictures of food dishes | No | Yes | Yes |
 | [Jelly Belly Wiki](https://jelly-belly-wiki.netlify.app/) | Data about Jelly Belly beans- flavores, facts, history and more endpoints | No | Yes | Yes |
 | [Kroger](https://developer.kroger.com/reference) | Supermarket Data | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
Adds Food Info to Food & Drink.

Food Info exposes a documented, self-serve REST API over harmonised nutrient data for reference foods, drawn from five national food composition datasets (USDA FoodData Central, McCance & Widdowson's CoFID, ANSES Ciqual, DTU Frida and AUSNUT) plus Open Food Facts.

Against the criteria in CONTRIBUTING:

- Self-serve: sign up, create a key on the account page, call the API. No waitlist and no sales gate.
- Publicly reachable and documented: https://food-info.org/developer, with an OpenAPI 3 spec at https://api.food-info.org/api/v1/openapi.json
- Auth is apiKey via an X-Api-Key header. HTTPS only. CORS is disabled, so it is server-to-server.
- Freemium: a free tier of 10 requests/minute and 100/day, with paid tiers above it.
- Custom domain, clean URL, and the API is a product in its own right.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

