### PR TITLE
fix: DexPaprika covers 36 networks, not 35

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,7 +457,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [CryptAPI](https://docs.cryptapi.io/) | Cryptocurrency Payment Processor | No | Yes | Unknown |
 | [CryptoCompare](https://www.cryptocompare.com/api#) | Cryptocurrencies Comparison | No | Yes | Unknown |
 | [CryptoMarket](https://api.exchange.cryptomkt.com/) | Cryptocurrencies Trading platform | `apiKey` | Yes | Yes |
-| [DexPaprika](https://docs.dexpaprika.com) | DEX pools, tokens, prices and OHLCV across 35 blockchain networks | No | Yes | No |
+| [DexPaprika](https://docs.dexpaprika.com) | DEX pools, tokens, prices and OHLCV across 36 blockchain networks | No | Yes | No |
 | [dYdX](https://docs.dydx.exchange/) | Decentralized cryptocurrency exchange | `apiKey` | Yes | Unknown |
 | [Ethplorer](https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API) | Ethereum tokens, balances, addresses, history of transactions, contracts, and custom structures | `apiKey` | Yes | Unknown |
 | [EXMO](https://documenter.getpostman.com/view/10287440/SzYXWKPi) | Cryptocurrencies exchange based in UK | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
One number, in README.md.

The DexPaprika row says 35 blockchain networks. It served 35 when the entry was written; it serves 36 now:

```
$ curl -s https://api.dexpaprika.com/stats
{"chains":36,"factories":234,"pools":37708848,"tokens":34770365}
```

I checked the other three columns rather than assuming, and all are correct as they stand, so this PR changes nothing else:

- **Auth: No** is right, the API works with no key.
- **HTTPS: Yes** is right.
- **CORS: No** is right. The API sends no `Access-Control-Allow-Origin` header at all:

```
$ curl -s -D - -o /dev/null -H "Origin: https://example.com" https://api.dexpaprika.com/networks | grep -i access-control
(no output)
```

Noting for the record that my earlier attempt at this list, #755, was closed because I put the edit in the auto-generated `/db` folder. This one is in README.md.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->
