### PR TITLE
Add Marvel Cinematic Universe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1063,6 +1063,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey`| Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Yes | Unknown |
 | [Magic The Gathering](https://magicthegathering.io/) | Magic The Gathering Game Information | No | Yes | Unknown |
+| [Marvel Cinematic Universe](https://augustomarcelo.github.io/mcuapi/) | Movies, TV shows, characters and in-universe chronological timeline | No | Yes | Yes |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | Yes | No |
 | [Minecraft ServerHub](https://minecraft-serverhub.com/developers) | Minecraft server status, player counts, MOTD, and live status badges | No | Yes | Yes |
 | [MMO Games](https://www.mmobomb.com/api) | MMO Games Database, News and Giveaways | No | Yes | No |


### PR DESCRIPTION
Adds a free, no-key REST API for Marvel Cinematic Universe data to **Games & Comics**,
ordered alphabetically between Magic The Gathering and Minecraft Server Status.

| API | Description | Auth | HTTPS | CORS |
| --- | --- | --- | --- | --- |
| [Marvel Cinematic Universe](https://augustomarcelo.github.io/mcuapi/) | Movies, TV shows, characters and in-universe chronological timeline | No | Yes | Yes |

57 movies, 56 TV show seasons, 302 characters, and a 113-entry chronological
timeline spanning five continuity branches (MCU, the FOX X-Men universe and the
Sony Spider-Man films).

- Read-only REST, no key and no signup
- `Access-Control-Allow-Origin: *`, so it works straight from the browser
- HATEOAS `_links` on every resource
- MIT licensed, source at https://github.com/AugustoMarcelo/mcuapi
- Swagger docs at https://mcuapi.up.railway.app/docs

Description is 67 characters, ends without punctuation, and I searched the
repository for duplicates before opening this.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

