### PR TITLE
Add ERstat API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1334,6 +1334,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [COVID-19 Tracker Canada](https://api.covid19tracker.ca/docs/1.0/overview) | Details on Covid-19 cases across Canada | No | Yes | Unknown |
 | [COVID-19 Tracker Sri Lanka](https://www.hpb.health.gov.lk/en/api-documentation) | Provides situation of the COVID-19 patients reported in Sri Lanka | No | Yes | Unknown |
 | [Dataflow Kit COVID-19](https://covid-19.dataflowkit.com) | COVID-19 live statistics into sites per hour | No | Yes | Unknown |
+| [ERstat](https://erstat.ca/developers) | Live Canadian emergency room closures and service disruptions, by province | `apiKey` | Yes | Yes |
 | [FoodData Central](https://fdc.nal.usda.gov/) | National Nutrient Database for Standard Reference | `apiKey` | Yes | Unknown |
 | [Healthcare.gov](https://www.healthcare.gov/developers/) | Educational content about the US Health Insurance Marketplace | No | Yes | Unknown |
 | [Humanitarian Data Exchange](https://data.humdata.org/) | Humanitarian Data Exchange (HDX) is open platform for sharing data across crises and organisations | No | Yes | Unknown |


### PR DESCRIPTION
Adds [ERstat](https://erstat.ca/developers) to **Health**.

- Live Canadian emergency room closures and service disruptions as JSON, plus per-province coverage of live wait-time reporting. Aggregated from official health-authority sources in every province.
- Free tier with a free API key (`X-API-Key`), non-commercial use with attribution. HTTPS yes, CORS yes.
- OpenAPI spec: https://erstat.ca/api/v1/openapi.json