### PR TITLE
Add Moonlora — free moon data API (Science & Math)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1660,6 +1660,7 @@ registers. Search all active companies worldwide, including directors, owners, e
 | [ITIS](https://www.itis.gov/ws_description.html) | Integrated Taxonomic Information System | No | Yes | Unknown |
 | [Launch Library 2](https://thespacedevs.com/llapi) | Spaceflight launches and events database | No | Yes | Yes |
 | [Materials Platform for Data Science](https://mpds.io) | Curated experimental data for materials science | `apiKey` | Yes | No |
+| [Moonlora](https://moonlora.com/developers) | Moon phases, illumination, moon signs, full/new moon dates (1900–2100), moonrise/moonset by coordinates | No | Yes | Yes |
 | [NASA](https://api.nasa.gov) | NASA data, including imagery | No | Yes | No |
 | [NASA ADS](https://ui.adsabs.harvard.edu/help/api/api-docs.html) | NASA Astrophysics Data System | `OAuth`| Yes | Yes |
 | [Newton](https://newton.vercel.app) | Symbolic and Arithmetic Math Calculator | No | Yes | No |


### PR DESCRIPTION
Adds Moonlora to **Science & Math** (alphabetical order).

- Free moon data API: phases, illumination, moon signs, full/new moon dates (1900–2100), moonrise/moonset by coordinates
- Auth: No · HTTPS: Yes · CORS: Yes
- OpenAPI 3.1: https://moonlora.com/api/openapi.json · Docs: https://moonlora.com/developers
- Bonus for AI tooling: the same engine is exposed as a hosted MCP server (https://moonlora.com/api/mcp)

I run this API. It's computed data (Meeus algorithm), CDN-served, no key or signup — attribution link required.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

