### PR TITLE
Fix Scholar Sidekick entry: Auth, CORS and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@
 | [Quran](https://quran.api-docs.io/) | RESTful Quran API with multiple languages | No | Yes | Yes |
 | [Quran Cloud](https://alquran.cloud/api) | A RESTful Quran API to retrieve an Ayah, Surah, Juz or the entire Holy Quran | No | Yes | Yes |
 | [Quran-api](https://github.com/fawazahmed0/quran-api#readme) | Free Quran API Service with 90+ different languages and 400+ translations | No | Yes | Yes |
-| [Scholar Sidekick](https://scholar-sidekick.com/docs) | Resolve scholarly IDs (DOI, PMID, ISBN, arXiv) and format citations in multiple styles | `apiKey` | Yes | No |
+| [Scholar Sidekick](https://scholar-sidekick.com) | Resolve scholarly IDs (DOI, PMID, ISBN, arXiv) and format citations in multiple styles | No | Yes | Yes |
 | [Sefaria](https://developers.sefaria.org/reference/getting-started) | Jewish texts | No | Yes | Yes |
 | [Stephen King](https://stephen-king-api.onrender.com/) | The varied works and characters of the prolific author Stephen King | No | Yes | Unknown |
 | [The Bible](https://docs.api.bible) | Everything you need from the Bible in one discoverable place | `apiKey` | Yes | Unknown |


### PR DESCRIPTION
The Scholar Sidekick entry I submitted in #871 is wrong on the two fields a reader of this list skims for, and it links past the homepage. Correcting my own entry.

| Field | Listed | Correct | Evidence |
| --- | --- | --- | --- |
| Auth | `apiKey` | `No` | The API is anonymous by default — no key is required for the free tier. An anonymous `POST /api/format` returns `200`. |
| CORS | `No` | `Yes` | `OPTIONS /api/format` returns `access-control-allow-origin: *`, so it is callable directly from the browser. |
| Link | `/docs` | homepage | Per the formatting guidance: link the page you would send someone to first, not a docs deep link. |

Both of the first two understate the API in the direction that matters — as listed, a reader concludes they need to sign up for a key and cannot call it client-side, when neither is true.

Anyone can reproduce both:

```
curl -s -o /dev/null -w '%{http_code}\n' -X POST https://scholar-sidekick.com/api/format \
  -H 'content-type: application/json' \
  -d '{"text":"10.1056/nejmoa2033700","style":"vancouver","output":"text"}'

curl -sI -X OPTIONS https://scholar-sidekick.com/api/format \
  -H 'Origin: https://example.com' -H 'Access-Control-Request-Method: POST' | grep -i access-control
```

One row in `README.md`; `db/` left alone as it is generated.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

