### PR TITLE
Remove discontinued Waifu.it API

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,6 @@
 | [Shikimori](https://shikimori.one/api/doc) | Anime discovery, tracking, forum, rates | `OAuth`| Yes | Unknown |
 | [Trace Moe](https://soruly.github.io/trace.moe-api/#/) | A useful tool to get the exact scene of an anime from a screenshot | No | Yes | No |
 | [Waifu.im](https://waifu.im/docs) | Get waifu pictures from an archive of over 4000 images and multiple tags | No | Yes | Yes |
-| [Waifu.it](https://docs.waifu.it) | Free RESTful API for Anime Quotes, Facts, Emotes, Gifs, Nekos, Waifus and More! | `apiKey` | Yes | Yes |
 | [Waifu.pics](https://waifu.pics/docs) | Image sharing platform for anime images | No | Yes | No |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Removes the "Waifu.it" entry from the Anime category.

**Reason:** The project has been discontinued. `https://docs.waifu.it` no longer serves its documentation — it now redirects to a domain-parking/ad page (`parklogicchannel.com`), which is a strong signal the domain was allowed to expire after the project shut down. This matches the community report filed via publicapis.dev.

Fixes #1090

- [x] I have searched the repository for any relevant issues or pull requests
- [x] All changes have been [squashed][squash-link] into a single commit
- [x] Each table column is padded with one space on either side (only a line removal, formatting of neighboring rows is unaffected)

_Not applicable — this PR removes a dead entry rather than adding one:_
- [ ] ~~My addition is ordered alphabetically~~
- [ ] ~~The URL points to the API's homepage~~
- [ ] ~~The description does not have more than 100 characters~~
- [ ] ~~Any category I am creating has the minimum requirement of 3 items~~

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit


<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/marcelscruz/public-apis/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

