### PR TITLE
Add OrbitalWiki to Science & Math

### DIFF
--- a/README.md
+++ b/README.md
@@ -1669,6 +1669,7 @@
 | [Numbers](http://numbersapi.com) | Facts about numbers | No | No | No |
 | [Open Notify](http://open-notify.org/Open-Notify-API/) | ISS astronauts, current location, etc | No | No | No |
 | [Open Science Framework](https://developer.osf.io) | Repository and archive for study designs, research materials, data, manuscripts, etc | `OAuth` | Yes | Unknown |
+| [OrbitalWiki](https://www.orbitalwiki.com) | Catalog of 16,000+ satellites with the source cited for every field: orbital elements, operators, NORAD/COSPAR IDs | No | Yes | Yes |
 | [Purple Air](https://www2.purpleair.com/) | Real Time Air Quality Monitoring | No | Yes | Unknown |
 | [Satellite Passes](https://sat.terrestre.ar) | Find satellite passes | No | Yes | Yes |
 | [SHARE](https://share.osf.io/api/v2/) | A free, open, dataset about research and scholarly activities | No | Yes | No |


### PR DESCRIPTION
Adds OrbitalWiki, a public catalogue of objects in Earth orbit with a free read-only REST API.

**Entry**

```
| [OrbitalWiki](https://www.orbitalwiki.com) | Catalog of 16,000+ satellites with the source cited for every field: orbital elements, operators, NORAD/COSPAR IDs | No | Yes | Yes |
```

**Against the checklist**

- Publicly reachable and documented: docs at https://www.orbitalwiki.com/developers
- Self-serve: the public endpoints answer with no signup at all. A key only raises the rate limit
- Custom domain, no query parameters in the URL
- Main product in its own right, not a feature of something larger

**Field values, verified rather than assumed**

- `Auth: No` — `curl https://www.orbitalwiki.com/api/v1/satellites?limit=1` returns 200 with no credentials
- `HTTPS: Yes`
- `CORS: Yes` — the response carries `Access-Control-Allow-Origin: *`

**What it does that the other satellite entries here do not**

The existing space entries each cover one slice: Launch Library 2 covers launches, TLE serves orbital elements, Satellite Passes computes visibility. OrbitalWiki merges CelesTrak orbital elements, Jonathan McDowell's GCAT launch catalogue, Wikidata metadata and SatNOGS radio records into one record per object, and every field in the response says which of those it came from. Where the sources disagree or are silent it returns `unknown` rather than picking a value, so a consumer can tell a real gap from a confident guess. Responses also carry `X-OrbitalWiki-Sources` and `X-OrbitalWiki-License` headers.

Alphabetical position kept: inserted between Open Science Framework and Purple Air.