### PR TITLE
Add ScanMalware API

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@
 | [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Yes | Unknown |
 | [Metacert](https://metacert.com/) | Metacert Link Flagging | `apiKey` | Yes | Unknown |
 | [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes | Yes |
+| [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | Yes | No |
 | [URLhaus](https://urlhaus-api.abuse.ch/) | Bulk queries and Download Malware Samples | No | Yes | Yes |
 | [URLScan.io](https://urlscan.io/about-api/) | Scan and Analyse URLs | `apiKey` | Yes | Unknown |
 | [Verisys Antivirus API](https://www.ionxsolutions.com/products/antivirus-api) | Antivirus as a service - REST API that scans provided files for malware and NSFW content | `apiKey` | Yes | Yes |


### PR DESCRIPTION
Disclosure: I work on this. ScanMalware is run by Triop AB in Sweden.

Adds ScanMalware to `Anti-Malware`, inserted alphabetically between Scanii and URLhaus.

Submit a URL and it renders the page in a sandboxed browser, then reports phishing and malware verdicts, network requests, detected technologies, TLS/JARM fingerprints and a screenshot. Every scan is indexed, so results stay searchable by domain, IP, ASN, JARM or favicon hash. Docs: https://scanmalware.com/api-docs (OpenAPI JSON + Swagger UI). Self-serve, no signup, no waitlist; 600 req/min anonymously.

Field values were tested today rather than taken from the docs:

| Field | Value | How it was checked |
|---|---|---|
| Auth | No | `curl 'https://scanmalware.com/api/v1/recent?limit=1'` returns `200` and a full JSON body with no credentials |
| HTTPS | Yes | Served over HTTPS only |
| CORS | No | No `Access-Control-Allow-Origin` is returned for any origin, so a cross-origin browser request fails |

Against the guidelines: alphabetical order kept, one link, single squashed commit, columns padded one space either side, no trailing whitespace, homepage linked rather than a deep docs page, name carries no TLD and does not end in "API", description is 95 characters, `/db` untouched. Searched the README and past PRs/issues first; not currently listed.
