### PR TITLE
Add Strait of Hormuz Ship Monitor API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1977,6 +1977,7 @@
 | [Road511](https://road511.com) | Unified traffic data from 65 US/CA jurisdictions: events, cameras, signs, bridges, truck routes | `apiKey` | Yes | Yes |
 | [Sabre for Developers](https://developer.sabre.com/guides/travel-agency/quickstart/getting-started-in-travel) | Travel Search - Limited usage | `apiKey` | Yes | Unknown |
 | [Schiphol Airport](https://developer.schiphol.nl/) | Schiphol | `apiKey` | Yes | Unknown |
+| [Strait of Hormuz Ship Monitor](https://hormuz.data-tracking.net/llms.txt) | Live AIS vessel traffic, crossings and oil flow through the Strait of Hormuz | No | Yes | No |
 | [Swedavia Airports](https://apideveloper.swedavia.se/) | Airport and flight information of Swedish Airports operated by Swedavia | `apiKey` | Yes | No |
 | [Tankerkoenig](https://creativecommons.tankerkoenig.de/swagger/) | German realtime gas/diesel prices | `apiKey` | Yes | Yes |
 | [Trackr TMS](https://rapidapi.com/jccm6/api/trackr-tms) | Trackr API makes it easy to create, assign, and track shipments, with driver support, movement history, and more | `apiKey` | Yes | No |


### PR DESCRIPTION
Adds **Strait of Hormuz Ship Monitor** to **Transportation** (alphabetical, between Schiphol Airport and Swedavia Airports).

Free, no-auth, self-serve JSON API for live and historical ship traffic through the Strait of Hormuz: AIS positions polled every 30 minutes for ~950 vessels across the Persian Gulf and Gulf of Oman, strait-crossing detection, vessel type/flag/DWT details, daily historical series, and estimated oil-flow volumes. Publicly available since March 2026.

- Docs link: machine-readable endpoint reference (`llms.txt`); human-oriented reference: https://github.com/marco83g-dotcom/hormuz-api
- Auth: No — no key or registration
- HTTPS: Yes
- CORS: No (verified: no `Access-Control-Allow-Origin` header)
