### PR TITLE
Fix ScanMalware row: CORS is Yes

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@
 | [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Unknown |
 | [Metacert](https://metacert.com/) | Metacert Link Flagging | `apiKey` | Unknown |
 | [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes |
-| [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | No |
+| [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | Yes |
 | [URLhaus](https://urlhaus-api.abuse.ch/) | Bulk queries and Download Malware Samples | No | Yes |
 | [URLScan.io](https://urlscan.io/about-api/) | Scan and Analyse URLs | `apiKey` | Unknown |
 | [Verisys Antivirus API](https://www.ionxsolutions.com/products/antivirus-api) | Antivirus as a service - REST API that scans provided files for malware and NSFW content | `apiKey` | Yes |


### PR DESCRIPTION
Disclosure: I work on this. ScanMalware is run by Triop AB in Sweden.

Corrects one field on the ScanMalware row added in #1104: CORS `No` → `Yes`.

When I opened #1104 I tested CORS rather than trusting our own docs, and no `Access-Control-Allow-Origin` was returned for any origin, so I listed `No`. That turned out to be a misconfiguration on our side rather than a deliberate choice. It is now fixed, so the row understates the API.

```bash
curl -sD- -o/dev/null 'https://scanmalware.com/api/v1/recent?limit=1' \
  -H 'Origin: https://example.com' | grep -i access-control
# access-control-allow-origin: *

curl -so/dev/null -w '%{http_code}\n' -X OPTIONS 'https://scanmalware.com/api/v1/recent' \
  -H 'Origin: https://example.com' -H 'Access-Control-Request-Method: GET'
# 200
```

`Access-Control-Allow-Credentials` is deliberately not sent, since a wildcard origin must not be combined with credentials. Auth and HTTPS are unchanged. One line changed, nothing else touched.
