### PR TITLE
Add Blacktop Motorsport API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1811,6 +1811,7 @@
 | [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey` | Yes |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes |
 | [Basketball Highlights API](https://highlightly.net/documentation/basketball/) | Real time basketball video highlights | `apiKey` | Unknown |
+| [Blacktop Motorsport API](https://ocblacktop.com/api) | Motorsport results, standings and schedules, with live timing for F1, NASCAR, IndyCar and WRC | `apiKey` | Yes |
 | [City Bikes](https://api.citybik.es/v2/) | City Bikes around the world | No | Unknown |
 | [Cloudbet](https://www.cloudbet.com/api/) | Official Cloudbet API provides real-time sports odds and betting API to place bets programmatically | `apiKey` | Yes |
 | [CollegeFootballData.com](https://collegefootballdata.com) | Unofficial detailed American college football statistics, records, and results API | `apiKey` | Unknown |


### PR DESCRIPTION
Adds the Blacktop Motorsport API to the Sports & Fitness category.

Self-serve motorsport data API with a free tier (7,500 requests/month, no credit card) and paid plans for live timing. Public OpenAPI docs at https://ocblacktop.com/api.

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description is under 160 characters, so it fits the listing card
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit