### PR TITLE
Add Filingrail API

### DIFF
--- a/README.md
+++ b/README.md
@@ -922,6 +922,7 @@
 | [Earnings Feed](https://earningsfeed.com/api/docs) | SEC filings, insider transactions, institutional holdings | `apiKey` | No |
 | [Econdb](https://www.econdb.com/api/) | Global macroeconomic data | No | Yes |
 | [Fed Treasury](https://fiscaldata.treasury.gov/api-documentation/) | U.S. Department of the Treasury Data | No | Unknown |
+| [Filingrail](https://filingrail.hudsonenterprisesllc.com) | SEC EDGAR filings, XBRL financials, Form 4 insider trades, 8-K events and 13F holdings, each record linked to its source filing | `apiKey` | Unknown |
 | [Finage](https://finage.co.uk) | Finage is a stock, currency, cryptocurrency, indices, and ETFs real-time & historical data provider | `apiKey` | Unknown |
 | [Financial Data](https://financialdata.net/documentation) | Stock market and financial data | `apiKey` | Unknown |
 | [Financial Modeling Prep](https://site.financialmodelingprep.com/developer/docs) | Realtime and historical stock data | `apiKey` | Unknown |


### PR DESCRIPTION
Adds Filingrail to **Finance**.

A REST API over SEC EDGAR: XBRL financials and history, Form 4 insider trades, 8-K material events with item codes, 13F institutional holdings, company search, and recent filings. Every record links back to the `sec.gov` filing it was derived from, so any figure can be checked against the original document.

Against the acceptance criteria:

- **Self-serve** — free tier is 50 requests/day, no card and no waitlist. A stranger goes from the docs to a working call on their own.
- **Publicly reachable and documented** — live now, with an OpenAPI spec, a Python SDK, and an MCP server on the official MCP registry.
- **Custom domain** — linked to the product homepage at `filingrail.hudsonenterprisesllc.com`, not a shared platform subdomain and not a deep docs link.
- **Main product only** — the API is the product, not a feature of something larger.
- **Auth / CORS** — `apiKey` via the RapidAPI gateway; CORS is not documented for the gateway, so listed as `Unknown` rather than guessed.

Checklist: one link, alphabetical (between Fed Treasury and Finage), columns padded, description 127 characters, name carries no TLD and does not end in "API", single squashed commit, and I searched the repo and existing PRs for duplicates first.