### PR TITLE
Add Brazil CNPJ API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1229,6 +1229,7 @@
 | [BCLaws](https://www.bclaws.gov.bc.ca/civix/template/complete/api/index.html) | Access to the laws of British Columbia | No | Unknown |
 | [Brazil](https://brasilapi.com.br/) | Community driven API for Brazil Public Data | No | Yes |
 | [Brazil Central Bank Open Data](https://dadosabertos.bcb.gov.br/) | Brazil Central Bank Open Data | No | Unknown |
+| [Brazil CNPJ](https://cnpj.wiki/docs) | Query Brazilian companies by CNPJ with full Receita Federal registry data, no key required | No | Yes |
 | [Brazil Receita WS](https://www.receitaws.com.br/) | Consult companies by CNPJ for Brazilian companies | No | Unknown |
 | [Brazilian Chamber of Deputies Open Data](https://dadosabertos.camara.leg.br/swagger/api.html) | Provides legislative information in Apis XML and JSON, as well as files in various formats | No | No |
 | [BuildData](https://builddata.ca) | Canadian construction and development data from 17 cities | `apiKey` | Unknown |


### PR DESCRIPTION
Adds a free, keyless API for looking up Brazilian companies by CNPJ (the national business registry number), built on the Receita Federal open data release.

- **Endpoint:** `GET https://api.cnpj.wiki/v1/cnpj/:cnpj`
- **Docs:** https://cnpj.wiki/docs
- **OpenAPI:** https://api.cnpj.wiki/v1/openapi.json
- **Auth:** none — no signup, no API key
- **CORS:** enabled (`Access-Control-Allow-Origin: *`)
- **Rate limit:** 60 req/min per IP

Try it:

```
curl https://api.cnpj.wiki/v1/cnpj/00000000000191
```

Returns the full registry record: legal name, trade name, registration status, main and secondary CNAE activities, legal nature, address, and partners.

Placed in Government, in alphabetical order between `Brazil Central Bank Open Data` and `Brazil Receita WS`.
