### PR TITLE
Add Pexafy API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,6 +1594,7 @@
 | [Imgur](https://apidocs.imgur.com/) | Images | `OAuth` | Unknown |
 | [Lorem Picsum](https://picsum.photos/) | Images from Unsplash | No | Unknown |
 | [ObjectCut](https://objectcut.com/) | Image Background removal | `apiKey` | Yes |
+| [Pexafy](https://docs.pexafy.com) | Semantic image search across 9+ free stock photo sources (Unsplash, Pexels, Pixabay & more), one unified JSON schema, plain-language and reverse image search | `apiKey` | Yes |
 | [Pexels](https://www.pexels.com/api) | Free Stock Photos and Videos | `apiKey` | Yes |
 | [PhotoRoom](https://www.photoroom.com/api/) | Remove background from images | `apiKey` | Unknown |
 | [Pixabay](https://pixabay.com/sk/service/about/api/) | Photography | `apiKey` | Unknown |


### PR DESCRIPTION
Adds Pexafy to the Photography section, placed alphabetically between ObjectCut and Pexels.

One REST endpoint that searches nine free stock photo sources at once (Unsplash, Pexels, Pixabay, Kaboompics, Burst, StockSnap, Picjumbo, Skitterphoto, NegativeSpace) and returns a single normalised JSON schema. Queries are matched on meaning rather than tags, and reverse image search is supported.

- Auth: `apiKey`, issued instantly with no application review
- CORS: enabled on the public read endpoints
- Free tier: 5,000 requests/month
- Description is 157 characters, under the 160 limit in the contributing guide