### PR TITLE
Add 0xArchive API

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,6 +425,7 @@
 ### Cryptocurrency
 | API | Description | Auth | CORS |
 |---|---|---|---|
+| [0xArchive](https://0xarchive.io) | Real-time and historical Hyperliquid and Lighter market data | `apiKey` | No |
 | [1inch](https://business.1inch.com/) | API for querying decentralize exchange | `apiKey` | Yes |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Unknown |


### PR DESCRIPTION
Adds 0xArchive to the **Cryptocurrency** section.

0xArchive provides self-serve real-time and historical Hyperliquid and Lighter market data through REST, WebSocket, MCP, SDKs, CLI, and replay. A permanent free tier is available.

-   [x] My submission meets the What we accept criteria in the contributing guide
-   [x] My submission is formatted according to the guidelines in the contributing guide
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API homepage
-   [x] The description is under 160 characters
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for relevant issues and pull requests
-   [x] No category is being created; Cryptocurrency already exists
-   [x] All changes are contained in a single commit

## Verification

- Homepage, documentation, pricing, and OpenAPI surfaces return successfully
- The entry has four columns in the repository's required format
- `apiKey` accurately describes authentication
- `No` accurately describes arbitrary third-party browser CORS access
- The change adds one README row and no unrelated edits
