### PR TITLE
Add Salary Explorer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1479,6 +1479,7 @@
 | [OpenCorporates](https://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Unknown |
+| [Salary Explorer](https://salarywiki.com/api) | Wages and employment for every US occupation by state and metro area, from Bureau of Labor Statistics survey data, with cost-of-living adjustment | No | Yes |
 | [Scoop.it](https://www.scoop.it/dev) | Content Curation Service | `apiKey` | Unknown |
 | [Socrata](https://dev.socrata.com/) | Access to Open Data from Governments, Non-profits and NGOs around the world | `OAuth` | Yes |
 | [Sofiaplan](https://sofiaplan.bg/api/) | Access to urban research data for the Bulgarian capital Sofia | No | Yes |


### PR DESCRIPTION
Adds Salary Explorer to **Open Data**.

| | |
|---|---|
| Homepage | https://salarywiki.com/api |
| Auth | No — no key, no signup, no rate limit |
| CORS | Yes — `Access-Control-Allow-Origin: *`, preflight returns 204 |
| OpenAPI | https://salarywiki.com/openapi.json |

Occupational wage statistics from the US Bureau of Labor Statistics OEWS survey: median, mean and 10th/25th/75th/90th percentile wages plus employment counts, for every detailed SOC occupation across 50 states, DC, 393 metropolitan and 137 nonmetropolitan areas.

The reason it is not a restatement of a government table: every wage also carries an adjustment for regional price parities from the Bureau of Economic Analysis. BLS publishes wages, BEA publishes price levels, and neither publishes the join.

Example — registered nurses in Texas:

```
curl "https://salarywiki.com/api/v1/salary?soc=29-1141&area=48"
```

Underlying data is a work of the US federal government and in the public domain (17 U.S.C. §105); the derived columns are released CC0. Not affiliated with or endorsed by either agency.

Placed in Open Data rather than Jobs because it is reference statistics rather than a job board, and rather than Finance because the existing salary entry there covers market compensation benchmarks from a different source.