### PR TITLE
Add Magento Watch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,6 +627,7 @@
 | [Kroki](https://kroki.io) | Creates diagrams from textual descriptions | No | Yes |
 | [Lua Decompiler](https://lua-decompiler.ferib.dev/) | Online Lua 5.1 Decompiler | No | Yes |
 | [MAC address vendor lookup](https://macaddress.io/api) | Retrieve vendor details and other information regarding a given MAC address or an OUI | `apiKey` | Yes |
+| [Magento Watch](https://magento.watch) | Release dates, end-of-life dates and system requirements for Magento Open Source, Adobe Commerce and Mage-OS versions | No | Yes |
 | [Markdown to HTML API](https://apyhub.com/utility/converter-md-html) | This API lets you upload and transform a Markdown file to HTML | `apiKey` | Yes |
 | [Markdown to JSON API](https://apyhub.com/utility/converter-markdown-json) | Upload Markdown and get JSON with one API call | `apiKey` | Yes |
 | [MetaScrape](https://metascrape.shanecode.org) | Extract metadata, Open Graph tags, and structured data from any URL | `apiKey` | Yes |


### PR DESCRIPTION
Adds **Magento Watch** to the `Development` category.

A free, no-auth JSON API for Magento ecosystem version lifecycle data — release dates, end-of-life dates, and PHP/MySQL/OpenSearch/Redis system requirements for Magento Open Source, Adobe Commerce and Mage-OS.

Against the What we accept criteria:

- **Custom domain** — served from `magento.watch`, not a shared platform subdomain.
- **Main product only** — the API is the product, not a feature of something larger.
- **Self-serve** — no signup, no waitlist, no key. `curl https://magento.watch/api/v1/magento-community/versions` works right now.
- **Publicly reachable and documented** — docs at https://magento.watch/api state Auth (`No`) and CORS (`Yes`) explicitly; responses send `access-control-allow-origin: *`.

- [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
- [x] The description is under 160 characters, so it fits the listing card
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit