### PR TITLE
Add WaveSpeedAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@
 | [TranscriptFetch](https://transcriptfetch.com) | YouTube transcript API for developers. Fetch captions from any video in production—no proxies, no IP blocks. Built for LLM, RAG, and MCP pipelines | `apiKey` | Yes |
 | [UnoRouter](https://unorouter.com) | OpenAI-compatible gateway routing chat/completions across 500+ models with a free tier | `apiKey` | Yes |
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Unknown |
+| [WaveSpeedAI](https://wavespeed.ai) | Generate images, video and audio from 900+ open and commercial models (FLUX, Seedream, Kling, Wan) through one async REST API | `apiKey` | Yes |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds WaveSpeedAI to the **AI** section.

- **Link:** https://wavespeed.ai (custom domain, homepage, no query params)
- **Auth:** `apiKey` — `Authorization: Bearer <key>`, self-serve key at https://wavespeed.ai/accesskey (no waitlist, no contact-sales gate)
- **CORS:** `Yes` — verified against `https://api.wavespeed.ai`, which returns `Access-Control-Allow-Origin: *` on both preflight and response
- **Docs:** https://wavespeed.ai/docs

WaveSpeedAI is a public inference API for generative media: ~900 image, video and audio models (FLUX, Seedream, Kling, Wan, and others) behind a single async submit/poll REST interface. Freemium — free credits on signup, pay-per-request after.

Placed in AI, which currently has no image or video generation entry. Alphabetical order preserved (between Unplugg and WolframAlpha); `README.md` only, `/db` untouched; single commit, single link.