### PR TITLE
Add Signals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1754,6 +1754,7 @@
 | [Product Hunt](https://api.producthunt.com/v2/docs) | The best new products in tech | `OAuth` | Unknown |
 | [Reddit](https://www.reddit.com/dev/api) | Homepage of the internet | `OAuth` | Unknown |
 | [Revolt](https://developers.revolt.chat) | Revolt open source Discord alternative | `apiKey` | Unknown |
+| [Signals](https://signals.sh) | Marketplace API to quote, place, and track Reddit and Quora promotion orders, with catalog and wallet endpoints | `apiKey` | No |
 | [Slack](https://api.slack.com/) | Team Instant Messaging | `OAuth` | Unknown |
 | [SocialClaw](https://getsocialclaw.com/) | Unified API to schedule and publish posts across X, LinkedIn, Instagram, Facebook Pages, TikTok, YouTube, Reddit, Pinterest, Discord, Telegram, and WordPress | `apiKey` | Yes |
 | [SocialData API](https://socialdata.tools) | Read Twitter data | `apiKey` | No |


### PR DESCRIPTION
Adds Signals to **Social**, placed alphabetically between Revolt and Slack.

| Field | Value |
|---|---|
| API | [Signals](https://signals.sh) |
| Description | Marketplace API to quote, place, and track Reddit and Quora promotion orders, with catalog and wallet endpoints |
| Auth | `apiKey` (bearer token, `Authorization: Bearer sgnl_live_...`) |
| CORS | `No` |

Against the criteria in CONTRIBUTING.md:

- **Self-serve.** Anyone can sign up at `signals.sh/signup`, mint a key at `/my-account/api-keys`, fund a wallet, and call the API. No waitlist, no partner approval, no contact-sales gate.
- **Publicly documented.** Human docs at https://signals.sh/docs/api and an OpenAPI 3.1.0 spec at https://signals.sh/docs/api/openapi.json covering six paths: catalog, catalog listings, order quote, place order, order detail, and wallet.
- **Auth and CORS determined from the live API**, not guessed. Keys are bearer tokens with a fixed permission set (`orders:create`, `orders:read`, `catalog:read`, `wallet:read`). An unauthenticated request to `https://app.signals.sh/api/external/catalog` with an `Origin` header returns 401 with no `Access-Control-Allow-Origin`, so CORS is `No` and the API is server-side only.
- **Paid.** Orders debit a prefunded wallet balance. CONTRIBUTING is explicit that paid and freemium APIs are welcome.
- **Custom domain**, clean URL, homepage linked rather than a deep docs page, description under 160 characters, one link in this PR, single squashed commit.

Disclosure: I work on Signals. Happy to adjust the section, wording, or the CORS call if you read it differently.
