### PR TITLE
Add Reserp API

### DIFF
--- a/README.md
+++ b/README.md
@@ -662,6 +662,7 @@
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes |
 | [Render API](https://render.com/docs/api) | Lets you programmatically manage your Render services (web apps, APIs, and static sites) including deployments, scaling, and configuration | `apiKey` | Unknown |
 | [ReqRes](https://reqres.in/) | A hosted REST-API ready to respond to your AJAX requests | No | Unknown |
+| [Reserp](https://reserp.ai) | Send a Google Search URL and receive visible result blocks as structured JSON | `apiKey` | No |
 | [RSS to JSON](https://github.com/ayusharma/RSS-to-JSON) | Returns RSS feed in JSON format using feed URL | No | Yes |
 | [ScrapeNinja](https://scrapeninja.net) | Scraping API with Chrome fingerprint and residential proxies | `apiKey` | Unknown |
 | [ScraperApi](https://www.scraperapi.com) | Easily build scalable web scrapers | `apiKey` | Unknown |


### PR DESCRIPTION
- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with https:// and points to the API homepage
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I searched the repository for relevant issues and pull requests
- [x] I am not creating a category
- [x] All changes are squashed into a single commit

Adds Reserp to the Development category. Reserp is a publicly documented, self-serve Google Search API. The homepage links to the API documentation and signup flow.

Disclosure: I am affiliated with Reserp.