### PR TITLE
Add Prismix Status API to AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@
 | [NLP Cloud](https://nlpcloud.io) | NLP API using spaCy and transformers for NER, sentiments, classification, summarization, and more | `apiKey` | Unknown |
 | [OpenAI](https://openai.com/index/openai-api) | Use AI models such as ChatGPT or DALL-E to experience the capabilities of AI | `apiKey` | Yes |
 | [Perspective](https://perspectiveapi.com) | NLP API to return probability that if text is toxic, obscene, insulting or threatening | `apiKey` | Unknown |
+| [Prismix Status API](https://prismix.dev/api-docs) | Real-time uptime and incident status for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini) | No | Yes |
 | [Roboflow Universe](https://universe.roboflow.com) | Pre-trained computer vision models | `apiKey` | Yes |
 | [SkyBiometry](https://skybiometry.com/documentation/) | Face Detection, Face Recognition and Face Grouping | `apiKey` | Unknown |
 | [Spam Hunter](https://spam-hunter.ru/) | Free service to classify text as spam using ML | `apiKey` | Yes |


### PR DESCRIPTION
Adds Prismix Status API to the AI section.

Real-time uptime and incident status for 75+ AI services (OpenAI, Anthropic, Cursor, Gemini, Groq, Mistral, Cohere and others) as JSON — no auth required, CORS enabled (verified live: Access-Control-Allow-Origin: * on the endpoint).

Docs: https://prismix.dev/api-docs

---

- [x] Add one link per Pull Request
- [x] Followed alphabetical ordering within the AI section
- [x] Each table column padded with one space on either side
- [x] PR title in the format `Add Api-name API`
- [x] Description under 160 characters
- [x] URL points to the API's homepage, starts with `https://`
- [x] Auth and CORS verified against the live endpoint, not assumed