### PR TITLE
Add Smartatest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@
 | [National Grid ESO](https://data.nationalgrideso.com/) | Open data from Great Britain’s Electricity System Operator | No | Unknown |
 | [OpenAQ](https://docs.openaq.org/) | Open air quality data | `apiKey` | Unknown |
 | [PM2.5 Open Data Portal](https://pm25.lass-net.org/#apis) | Open low-cost PM2.5 sensor data | No | Unknown |
+| [Smartatest](https://smartatest.se/api) | Calculators for home energy cost, lighting, air quality limits and GS1 barcode prefixes, in Swedish | No | Yes |
 | [Solematica](https://www.solematica.it/sviluppatori) | Compare Italian solar installer offers, energy prices (PUN/ARERA) and satellite roof data | No | No |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | No |
 | [Thames Water Open Data](https://data.thameswater.co.uk) | Open Data from the UK's largest water and wastewater services company | `apiKey` | Unknown |


### PR DESCRIPTION
Adds Smartatest to **Environment**.

- **Homepage**: https://smartatest.se/api
- **Auth**: `No` — no key, no signup
- **CORS**: `Yes` — `Access-Control-Allow-Origin: *`
- **OpenAPI**: https://smartatest.se/api/openapi.json (3.1.0, 26 paths)
- **Postman**: https://smartatest.se/api/postman.json

26 GET endpoints that calculate home energy running cost, lighting (lumen, colour temperature), carbon monoxide alarm thresholds and GS1 barcode prefix lookup. Responses are in Swedish.

Custom domain, publicly reachable, self-serve, documented per endpoint.