### PR TITLE
Add USA Caller Lookup to Phone section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1532,6 +1532,7 @@
 | [Phone Specification](https://github.com/azharimm/phone-specs-api) | Rest Api for Phone specifications | No | Yes |
 | [Proweblook Phone Number Checker](https://proweblook.com/phone-number-validator) | Phone number validation | `apiKey` | Yes |
 | [Proweblook Whatsapp Contact Checker](https://proweblook.com/whatsapp-number-checker) | Whatsapp number validation | `apiKey` | Yes |
+| [USA Caller Lookup](https://www.usacallerlookup.com/api/) | US reverse phone lookup: carrier, location and FTC robocall complaint data, no key needed | No | Yes |
 | [Veriphone](https://veriphone.io) | Phone number validation & carrier lookup | `apiKey` | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds USA Caller Lookup, a free reverse phone lookup API for US numbers.

- Free, no API key, no signup, self-serve
- Returns carrier, city/state, toll-free flag, and FTC Do Not Call complaint aggregates (total complaints, robocall flags, reporting states, top subjects) per number, plus area code summaries and dataset-wide stats
- Docs: https://www.usacallerlookup.com/api/
- Auth: No | CORS: Yes (verified: Access-Control-Allow-Origin echoes the request origin)
- Data is CC0; underlying dataset also published openly
- Rate limit 60 req/min per IP, documented