### PR TITLE
Add Animica API

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@
 ### Blockchain
 | API | Description | Auth | CORS |
 |---|---|---|---|
+| [Animica](https://explorer.animica.org) | Post-quantum proof-of-work L1 blockchain explorer REST API and node JSON-RPC, with OpenAPI and OpenRPC documents | No | Yes |
 | [Bitquery](https://graphql.bitquery.io/ide) | Onchain GraphQL APIs & DEX APIs | `apiKey` | Yes |
 | [Blockscout](https://docs.blockscout.com/devs/apis) | Multi-chain explorer for Ethereum and 100+ EVM chains | `apiKey` | Yes |
 | [Bscscan](https://bscscan.com/apis) | Binance Smart Chain explorer API | `apiKey` | Yes |


### PR DESCRIPTION
Adds Animica to **Blockchain**.

Free, no auth, CORS enabled. Explorer REST API for a live post-quantum proof-of-work L1 (head, blocks, transactions, addresses, rich list, circulating supply, mining info) — OpenAPI at https://explorer.animica.org/api/openapi.json — plus the node JSON-RPC at https://rpc.animica.org/rpc described by an OpenRPC document (141 methods) at https://rpc.animica.org/openrpc.json. Self-serve, custom domain, HTTPS.
