### PR TITLE
Add Offendersearch to Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -1673,6 +1673,7 @@
 | [Mozilla http scanner](https://github.com/mozilla/http-observatory/blob/master/httpobs/docs/api.md) | Mozilla observatory http scanner | No | Unknown |
 | [Mozilla tls scanner](https://github.com/mozilla/tls-observatory#api-endpoints) | Mozilla observatory tls scanner | No | Unknown |
 | [National Vulnerability Database](https://nvd.nist.gov/vuln/Data-Feeds/JSON-feed-changelog) | U.S. National Vulnerability Database | No | Unknown |
+| [Offendersearch](https://offendersearch.app) | Search sex-offender records across all 58 US state, territory and tribal registries in one query; REST API plus open data | `apiKey` | Yes |
 | [OWASP ZAP](https://www.zaproxy.org/docs/api/) | Automated security testing API for web apps | No | Unknown |
 | [Passwordinator](https://github.com/fawazsullia/password-generator/) | Generate random passwords of varying complexities | No | Yes |
 | [PhishStats](https://phishstats.info/) | Phishing database | No | Unknown |


### PR DESCRIPTION
Adds Offendersearch to Security, alongside the existing Complete Criminal Checks entry. Searches sex-offender records across all 58 US state, territory and tribal registries in one API query; scored records with official registry citations. Free tier, apiKey, HTTPS. https://offendersearch.app
