### PR TITLE
Add Statable to Business

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Unknown |
+| [Statable](https://statable.com) | Query cookieless, EU-hosted web analytics: visitors, traffic sources, campaigns, goals and funnels | `apiKey` | No |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Unknown |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Unknown |


### PR DESCRIPTION
Adds **Statable** to the Business category.

Statable is cookieless, EU-hosted web analytics. The Stats API exposes visitors, traffic sources, campaigns, goals and funnels over REST.

-   **Docs:** https://statable.com/docs/developers/stats-api/overview/
-   **OpenAPI spec:** https://statable.com/api/v1/openapi.yaml
-   **Auth:** `apiKey` — bearer tokens are self-serve, minted by the user in the dashboard, no sales call or waitlist
-   **CORS:** No — the API sends no `Access-Control-Allow-Origin` header, so it is server-to-server only

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description is under 160 characters, so it fits the listing card
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been squashed into a single commit
