### PR TITLE
Update APITube News API description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1392,7 +1392,7 @@
 ### News
 | API | Description | Auth | CORS |
 |---|---|---|---|
-| [APITube News API](https://apitube.io/) | Monitor news sources from around the world in real-time. Get the latest news articles from more than 500,000 news sources in 60 languages. | `apiKey` | Yes |
+| [APITube News API](https://apitube.io/) | Real-time and historical news from 300,000+ sources in 177 countries and 59 languages, enriched with sentiment, entities and topics, with 65+ search filters | `apiKey` | Yes |
 | [Associated Press](https://developer.ap.org/) | Search for news and metadata from Associated Press | `apiKey` | Unknown |
 | [Chronicling America](https://chroniclingamerica.loc.gov/about/api/) | Provides access to millions of pages of historic US newspapers from the Library of Congress | No | Unknown |
 | [Currents](https://currentsapi.services/) | Latest news published in various news sources, blogs and forums | `apiKey` | Yes |


### PR DESCRIPTION
Updates the description of the existing **APITube News API** entry in the `News` section. No new entry, no link change — the listing itself stays as it is.

### Why

The current description carries two numbers that no longer match the product's own site:

- `500,000 news sources` — apitube.io states **300,000+ sources** across its pages (the `500K+` figure only survives in one hero badge and is being phased out)
- `60 languages` — the current figure is **59 languages**, across **177 countries**

The new text also names what the API actually returns (sentiment, entities, topics, 65+ filters) instead of repeating "monitor news in real-time" twice.

### Change

```diff
-| [APITube News API](https://apitube.io/) | Monitor news sources from around the world in real-time. Get the latest news articles from more than 500,000 news sources in 60 languages. | `apiKey` | Yes |
+| [APITube News API](https://apitube.io/) | Real-time and historical news from 300,000+ sources in 177 countries and 59 languages, enriched with sentiment, entities and topics, with 65+ search filters | `apiKey` | Yes |
```

### Checklist

- [x] Description is 156 characters (under the 160 limit)
- [x] Link unchanged and still the product homepage, no query parameters, `https://`, returns 200
- [x] `Auth` (`apiKey`) and `CORS` (`Yes`) unchanged and still accurate
- [x] Alphabetical position unchanged, column padding unchanged
- [x] One link per PR, single squashed commit, targets `main`
- [x] Only `README.md` touched — `/db` left alone

Disclosure: I work on APITube, so this is a self-submitted correction to our own entry.