### PR TITLE
Add FluentEDI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,6 +578,7 @@
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Unknown |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes |
+| [FluentEDI](https://fluentedi.com) | Deterministic tools for AI agents: X12 EDI, check digits, time, cron, JSON repair | No | Yes |
 | [Form Creation API](https://apyhub.com/utility/reformify-form-api) | Create and manage customizable forms within your applications | `apiKey` | Yes |
 | [FormForge](https://formforge-api.vercel.app) | Generate styled, accessible HTML forms from JSON definitions with validation | No | Yes |
 [Format JSON Online Dummy API](https://formatjsononline.com/dummy-api) | A free tool to generate dummy JSON data for testing and prototyping.| No  | Yes | Yes |


### PR DESCRIPTION
Adds FluentEDI to **Development**.

- **Auth: No** — no key, no signup, no rate limit
- **HTTPS**, CORS enabled for all origins
- **Custom domain** (`fluentedi.com`), not a shared subdomain
- **Clean URL**, no query parameters
- One API in this PR, and it is the main product

A free HTTP API of deterministic tools intended for AI agents. Coverage is deepest in retail X12 EDI — parsing 850 purchase orders, 856 ASNs, 810 invoices and 997 acknowledgments, generating a valid 856, and GS1 check digits — alongside timezone and date arithmetic, cron schedules, JSON repair, JSONPath, canonical JSON, signature verification, unit and colour conversion, and DNS.

Not a paid or freemium service, and there is no paid tier to upsell to. Every tool is read-only and idempotent.

```
curl 'https://fluentedi.com/v1/time/now?timezone=Asia/Tokyo'
curl 'https://fluentedi.com/v1/gs1/checkdigit?code=036000291452'
```

OpenAPI 3.1: https://fluentedi.com/openapi.json