### PR TITLE
Add StackerScan API

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,7 @@
 | [SEC EDGAR Data](https://www.sec.gov/search-filings/edgar-application-programming-interfaces) | API to access annual reports of public US companies | No | Yes |
 | [SiftingIO](https://sifting.io/) | Market data for stocks, forex, crypto, commodities and DEX | `apiKey` | Yes |
 | [SmartAPI](https://smartapi.angelbroking.com/) | Gain access to set of <SmartAPI> and create end-to-end broking services | `apiKey` | Unknown |
+| [StackerScan](https://www.stackerscan.com) | Live and historical precious-metals spot prices, observed dealer premiums over spot, and the Goldback exchange rate | No | Yes |
 | [Statistics of the World](https://statisticsoftheworld.com/api-docs) | GDP, population, inflation & 440+ indicators for 218 countries | No | Yes |
 | [StockData](https://www.StockData.org) | Real-Time, Intraday & Historical Market Data, News and Sentiment API | `apiKey` | Yes |
 | [Stripe](https://stripe.com/docs/api) | Payment processing, subscriptions, and financial management | `apiKey` | Unknown |


### PR DESCRIPTION
Adds StackerScan to the Finance section.

| [StackerScan](https://www.stackerscan.com) | Live and historical precious-metals spot prices, observed dealer premiums over spot, and the Goldback exchange rate | No | Yes |

- Fully open read-only API: no authentication of any kind — documented at https://www.stackerscan.com/docs and in the OpenAPI 3.1 document at https://www.stackerscan.com/openapi.json
- CORS: every public endpoint answers `Access-Control-Allow-Origin: *` (stated in the docs)
- HTTPS on a custom domain, self-serve, publicly reachable now
- Alphabetical placement in Finance, one space padding per column, single squashed commit