### PR TITLE
Add Project Cost Estimator API

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,6 +337,7 @@
 | [markerapi](https://markerapi.com) | Trademark Search | No | Unknown |
 | [Mydentify](https://mydentify.com/openapi.json) | Startup-directory research and weekly product leaderboard data | No | Yes |
 | [NioLeads](https://nioleads.com/apidoc) | LinkedIn Email Finder and Email Verifier | `apiKey` | Yes |
+| [Project Cost Estimator](https://projectcostestimator.com/api-docs) | Cost, timeline and complexity estimates for website, ecommerce and app projects | `apiKey` | Yes |
 | [Redash](https://redash.io/help/user-guide/integrations-and-api/api) | Access your queries and dashboards on Redash | `apiKey` | Yes |
 | [Smartsheet](https://smartsheet.redoc.ly/) | Allows you to programmatically access and Smartsheet data and account information | `OAuth` | No |
 | [Square](https://developer.squareup.com/reference/square) | Easy way to take payments, manage refunds, and help customers checkout online | `OAuth` | Unknown |


### PR DESCRIPTION
Adds the Project Cost Estimator API under **Business**.

Returns cost, timeline and complexity estimates for website, ecommerce and app projects — the same calculation pipeline behind the public calculator, calibrated against 600+ project quotes and public rate benchmarks across 6 markets.

Against the criteria:

- **Publicly reachable and documented** — https://projectcostestimator.com/api-docs, with request/response examples and the auth scheme stated.
- **Self-serve** — a key is issued instantly by email. No signup, no waitlist, no partner approval, no "contact sales". Free tier is 100 requests/month.
- **Custom domain** — projectcostestimator.com, not a platform subdomain.
- **Clean URL** — no query parameters.
- **Auth** — `apiKey`, sent as `Authorization: Bearer pce_...`.
- **CORS** — Yes. There is also a keyless read-only endpoint, `https://projectcostestimator.com/api/cost-data`, returning the underlying benchmark dataset as JSON with `Access-Control-Allow-Origin: *` and no auth at all.

Entry inserted alphabetically in the Business table, one link, 4-column format.

Disclosure: I'm affiliated with this project.