### PR TITLE
Add 54ch10 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@
 ### Anti-Malware
 | API | Description | Auth | CORS |
 |---|---|---|---|
+| [54ch10](https://54ch10.uk) | Pre-interact JSON risk briefs for address, token and URL | No | Yes |
 | [AbuseIPDB](https://docs.abuseipdb.com/) | IP/domain/URL reputation | `apiKey` | Unknown |
 | [AlienVault Open Threat Exchange (OTX)](https://otx.alienvault.com/api) | IP/domain/URL reputation | `apiKey` | Unknown |
 | [CAPEsandbox](https://capev2.readthedocs.io/en/latest/usage/api.html) | Malware execution and analysis | `apiKey` | Unknown |


### PR DESCRIPTION
## Add 54ch10

Adding **54ch10** to the Anti-Malware category.

**54ch10** is a public REST API that returns pre-interact JSON risk briefs for address, token, and URL (phishing / wallet heuristics). Analytics-only — not financial advice.

- **Homepage:** https://54ch10.uk
- **Docs:** https://54ch10.uk/AGENT.md
- **OpenAPI:** https://54ch10.uk/openapi.json
- **Auth:** No (free demo 20/UTC-day; optional Stripe key / x402)
- **HTTPS:** Yes
- **CORS:** Yes

Example:

```bash
curl -sS 'https://54ch10.uk/v1/brief/free?type=url&q=https://example.com'
```

- [x] Formatted per contributing guide
- [x] Alphabetically ordered
- [x] Useful description
- [x] Description under 160 characters
- [x] Each table column padded with one space on either side
- [x] Searched for duplicate issues/PRs
- [x] Custom domain (54ch10.uk)
- [x] All commits squashed into a single commit