### PR TITLE
Add OilPriceAPI to Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,6 +928,7 @@
 | [Metal Sentinel](https://metal-sentinel.com) | Real-time precious and base metals prices. One API. Zero cost | `apiKey` | Unknown |
 | [Mono](https://mono.co/) | Connect with users’ bank accounts and access transaction data in Africa | `apiKey` | Unknown |
 | [Moov](https://docs.moov.io/api/) | The Moov API makes it simple for platforms to send, receive, and store money | `apiKey` | Unknown |
+| [OilPriceAPI](https://www.oilpriceapi.com) | Crude oil, natural gas, refined product and marine fuel prices, each with its source timestamp | `apiKey` | Yes |
 | [Open Bank Project](https://www.openbankproject.com) | Enable account holders to interact with their banks using a wider range of applications and services | `apiKey` | Yes |
 | [OpenFIGI](https://www.openfigi.com/api) | Equity, index, futures, options symbology from Bloomberg LP | `apiKey` | Yes |
 | [ParityVend](https://www.ambeteco.com/ParityVend/) | Globalize your business by auto-adapting pricing for each visitor with Purchasing Power Parity | `apiKey` | Yes |


### PR DESCRIPTION
Adds [OilPriceAPI](https://www.oilpriceapi.com) to Finance.

```
| [OilPriceAPI](https://www.oilpriceapi.com) | Crude oil, natural gas, refined product and marine fuel prices, each with its source timestamp | `apiKey` | Yes |
```

Column values verified against the live API on 2026-08-25:

- **Auth** `apiKey` — `Authorization: Token YOUR_API_KEY`, documented at docs.oilpriceapi.com
- **CORS** Yes — `OPTIONS` with an `Origin` header returns `access-control-allow-origin` reflecting the request origin, alongside `access-control-allow-methods` and a preflight `max-age`

Against the acceptance criteria:

- **Self-serve** — free tier is 50 requests/day with no card and no sales gate; a stranger goes from the docs to a working call unaided
- **Publicly reachable and documented** — docs.oilpriceapi.com returns 200; Auth and CORS are both determinable from the docs
- **Main product only** — the API is the product
- **Custom domain** — oilpriceapi.com
- **Clean URL** — no query parameters

Coverage is crude benchmarks, natural gas, refined products, marine fuels, futures and carbon. The description names the source-timestamp behaviour because it is the part that affects how you consume it: every value carries the timestamp from its own source rather than the time we fetched it.