### PR TITLE
Add ReefAPI to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -659,6 +659,7 @@
 | [QR code Generator](https://docs.openqr.io/) | Static and Dynamic QR code generator with custom and unique QR code design | `apiKey` | Unknown |
 | [Qrcode Monkey](https://www.qrcode-monkey.com/qr-code-api-with-logo/) | Integrate custom and unique looking QR codes into your system or workflow | No | Unknown |
 | [QuickChart](https://quickchart.io/) | Generate chart and graph images | No | Yes |
+| [ReefAPI](https://reefapi.com/) | One API for 185+ live web data sources including search, social, e-commerce, real estate, jobs and finance, returning clean JSON | `apiKey` | No |
 | [Render API](https://render.com/docs/api) | Lets you programmatically manage your Render services (web apps, APIs, and static sites) including deployments, scaling, and configuration | `apiKey` | Unknown |
 | [ReqRes](https://reqres.in/) | A hosted REST-API ready to respond to your AJAX requests | No | Unknown |
 | [Reserp](https://reserp.ai) | Send a Google Search URL and receive visible result blocks as structured JSON | `apiKey` | No |


### PR DESCRIPTION
Adds ReefAPI to the Development category.

ReefAPI is a single HTTP API over 185+ live web data sources (search, social, e-commerce, real estate, jobs, travel, news, finance), returning normalised JSON. There is a free tier, so it meets the free-access requirement.

Only `README.md` is touched. The previous attempt (#965) edited `db/resources.json`, which the bot correctly flagged as auto-generated - that has been avoided here.

- Auth: `apiKey`
- CORS: `No` (verified - no `Access-Control-*` headers are returned, and `OPTIONS` is not handled)
- URL points at the product homepage over HTTPS
- Placed alphabetically between QuickChart and Render API
