### PR TITLE
Add Window Sticker API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2013,6 +2013,7 @@
 | [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | No |
 | [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Unknown |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes |
+| [Window Sticker](https://windowsticker.org/api-docs) | Original factory Monroney label PDF and full spec decode by VIN | No | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds one entry to the Vehicle section.

**Window Sticker** — https://windowsticker.org/api-docs

Returns the original factory window sticker (Monroney label) as a PDF for a
17-character US VIN, plus a full NHTSA vPIC specification decode.

- `Auth`: `No` — no key, no registration, no rate-limit tier
- `CORS`: `Yes` — responses send `Access-Control-Allow-Origin: *`

Endpoints:

- `GET /api/v1/vin/{VIN}` — JSON decode and sticker availability
- `GET /api/sticker/{VIN}` — the PDF itself
- OpenAPI 3.1 description at `/openapi.json`

Example:

```
curl https://windowsticker.org/api/v1/vin/JF1GUAFC1T8203971?sticker=false
```

Original PDFs are available for 13 makes (the GM, Ford and Stellantis brands plus
Subaru); every other VIN returns the specification decode only, which the docs
state plainly.

- [x] One link added
- [x] Alphabetical order within the section (after Smartcar)
- [x] Description is 63 characters
- [x] Single commit