### PR TITLE
Add Urgences Québec to Health

### DIFF
--- a/README.md
+++ b/README.md
@@ -1324,6 +1324,7 @@
 | [Open Disease](https://disease.sh/) | API for Current cases and more stuff about COVID-19 and Influenza | No | Yes |
 | [openFDA](https://open.fda.gov) | Public FDA data about drugs, devices and foods | `apiKey` | Unknown |
 | [Psychologie et Sérénité](https://psychologieetserenite.com/api) | French psychology articles metadata and validated psychological tests catalog | No | Yes |
+| [Urgences Québec](https://sante.handled.tools) | Hourly crowding for the 120 emergency rooms of Quebec, with walk-in clinics and surgery delays | No | Yes |
 | [Verified Supplement Data](https://verifiedsupplementdata.com/api/v1/recommend/index.json) | Supplement dosing, form comparisons and drug-nutrient interactions with PubMed citations | No | Yes |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds Urgences Québec to Health.

It serves the Quebec health ministry's hourly emergency-room file as JSON: occupancy, people present, people waiting, average stretcher stay, for all 120 ERs. Two more endpoints cover walk-in clinics and surgery delays, and one returns a single ER's hourly history back to 10 August 2026 (the ministry's own file keeps 7 days).

- Auth: none
- CORS: `Access-Control-Allow-Origin: *` on every response
- Docs: https://sante.handled.tools/en/donnees — endpoints, field notes, licence
- Custom domain, https, no query parameters in the link

Endpoints:
- `GET /api/now`
- `GET /api/facilities`
- `GET /api/facility/<id>/history`
- `GET /api/cliniques`
- `GET /api/chirurgies`

ERstat is already in the section. It tracks closures across Canada behind an API key. This one is Quebec-only and reports crowding.
