### PR TITLE
Add ToolForte to Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,6 +698,7 @@
 | [Svix](https://www.svix.com) | Webhooks as a Service | `apiKey` | Unknown |
 | [TalorData](https://talordata.com) | Get structured results from Google, Bing, Yandex, and DuckDuckGo through one API, with fast, reliable responses | `apiKey` | No |
 | [Tolgee](https://tolgee.io) | Open-source localization (i18n) platform enabling you to translate you app fast | `apiKey` | No |
+| [ToolForte](https://toolforte.com/developers) | Deterministic utilities: IBAN/VAT validation, cron parsing, regex, diffs, Dutch holidays and test data | `apiKey` | Unknown |
 | [Tyk](https://tyk.io/open-source/) | Api and service management platform | `apiKey` | Yes |
 | [UserAgent](https://useragent.app) | User agent parsing API is designed to help you better understand and interact with your users. By identifying browser, device, and OS data from user agent strings, this API empowers you with accurate, real-time insights into your audience. | `apiKey` | Yes |
 | [Utilorax](https://utilorax.com/api) | 203 JSON endpoints: hashing, encoding, unit conversion, text, dates and file conversion | `apiKey` | Yes |


### PR DESCRIPTION
Adds ToolForte to the Development category in alphabetical order.

ToolForte offers a REST API with 20 deterministic utility endpoints for developers and AI agents: IBAN validation (mod-97), VAT calculation and EU VAT number format checks, Dutch public holidays and working-day math, cron parsing, regex testing, JSON/CSV/Base64/URL/Markdown transforms, text diffs, UUIDs, and Dutch test data generators.

- Docs: https://toolforte.com/developers
- OpenAPI 3.1 spec: https://toolforte.com/openapi.json
- Auth: `apiKey` (free tier: 1,000 calls/month), HTTPS only

🤖 Generated with [Claude Code](https://claude.com/claude-code)