### PR TITLE
Add XiuRouter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@
 | [Unplugg](https://unplu.gg/test_api.html) | Forecasting API for timeseries data | `apiKey` | Unknown |
 | [WaveSpeedAI](https://wavespeed.ai) | Generate images, video and audio from 900+ open and commercial models (FLUX, Seedream, Kling, Wan) through one async REST API | `apiKey` | Yes |
 | [WolframAlpha](https://products.wolframalpha.com/api/) | Provides specific answers to questions using data and algorithms | `apiKey` | Unknown |
+| [XiuRouter](https://router.xiu.ai/) | Route requests to leading AI models through one API with native OpenAI, Anthropic, and Gemini protocols | `apiKey` | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
## Summary

- Add XiuRouter to the AI API list.
- Link to the product homepage and document API key authentication and CORS support.

## Validation

- Confirmed the homepage, quickstart, and API compatibility docs return HTTP 200.
- Confirmed unauthenticated `/v1/models` returns HTTP 401.
- Confirmed CORS preflight returns `Access-Control-Allow-Origin: *`.
- Verified the README diff contains one alphabetically placed entry and the description is under 160 characters.
