### PR TITLE
Add CosmyDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1519,6 +1519,7 @@
 |---|---|---|---|
 | [Advice Slip](https://api.adviceslip.com/) | Generate random advice slips | No | Unknown |
 | [akshaykumar-rest](https://akshaykumar-rest.vercel.app/) | Akshay Kumar for every HTTP status code | No | Yes |
+| [CosmyDay](https://cosmyday.com) | Natal charts, horoscopes, retrogrades, moon phases and eclipses computed from the Swiss Ephemeris | No | Yes |
 | [Dev.to](https://developers.forem.com/api) | Access Forem articles, users and other resources via API | `apiKey` | Unknown |
 | [FavQs.com](https://favqs.com/api) | FavQs allows you to collect, discover and share your favorite quotes | `apiKey` | Unknown |
 | [Human Design Hub](https://humandesignhub.app/en/docs) | Human Design bodygraph, transit, compatibility, and penta calculations | `apiKey` | No |


### PR DESCRIPTION
Adding CosmyDay to the Personality section.

It is a free astrology and astronomy data API. Every date it returns -- retrograde
stations, lunations, eclipses, ingresses and natal chart positions -- is computed
from the Swiss Ephemeris rather than copied from another site.

- Docs: https://cosmyday.com/api-docs (OpenAPI spec at https://cosmyday.com/openapi.json)
- Auth: none. `curl https://api.cosmyday.com/content/daily/leo` works with no key
- CORS: `access-control-allow-origin: *` on the public prefixes (`/content/*`,
  `/events/*`, `/health`, `/natal`)
- HTTPS, custom domain, self-serve, no waitlist or signup

Entry placed alphabetically within the section.
