### PR TITLE
Add PublicDataHub to Open Data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1302,6 +1302,7 @@
 | [PolitiData](https://politidata.ca) | Canadian political financing, lobbying registrations and communications | `apiKey` | Unknown |
 | [PRC Exam Schedule](https://api.whenisthenextboardexam.com/docs/) | Unofficial Philippine Professional Regulation Commission's examination schedule | No | Yes |
 | [ProcureData](https://procuredata.ca) | Canadian federal procurement contracts, tenders and awards | `apiKey` | Unknown |
+| [PublicDataHub](https://publicdatahub.org) | US public schools, hospitals and federal agency budgets as JSON/CSV, with provenance on every record | No | Yes |
 | [Represent by Open North](https://represent.opennorth.ca/) | Find Canadian Government Representatives | No | Unknown |
 | [UK Companies House](https://developer.company-information.service.gov.uk/) | UK Companies House Data from the UK government | `OAuth` | Unknown |
 | [USAspending.gov](https://api.usaspending.gov/) | US federal spending data | No | Unknown |


### PR DESCRIPTION
PublicDataHub publishes United States federal reference data — public schools and school districts (NCES Common Core of Data), Medicare-certified hospitals (CMS Provider Data), and federal agency budgets (USAspending) — as per-record JSON and CSV. Every response carries the agency, dataset, licence and release date that produced it.

`GET https://publicdatahub.org/api/export/district/houston-isd.json`

- **Auth `No`** — no key, no registration, no rate limit on per-record endpoints
- **CORS `Yes`** — every export sends `Access-Control-Allow-Origin: *`
- HTTPS only; custom domain; OpenAPI 3.1 at `/openapi.json`, which describes only the endpoints that are live

Linked to the homepage rather than the docs page, per the contributing guide's note about the listing screenshot.

---

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API's homepage
- [x] The description is under 160 characters, so it fits the listing card
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items