### PR TITLE
Add iGaming Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,7 @@
 | [Humor](https://humorapi.com) | Humor, Jokes, and Memes | `apiKey` | Unknown |
 | [Hypixel](https://api.hypixel.net/) | Hypixel player stats | `apiKey` | Unknown |
 | [Hyrule Compendium](https://github.com/gadhagod/Hyrule-Compendium-API) | Data on all interactive items from The Legend of Zelda: BOTW | No | Unknown |
+| [iGaming Tools](https://i-gaming.tools/) | Slot data: RTP, volatility, max win, mechanics, plus provider catalogues, news and demand | `apiKey` | Unknown |
 | [IGDB.com](https://api-docs.igdb.com) | Video Game Database | `apiKey` | Unknown |
 | [Italian Jokes](https://italian-jokes.vercel.app/) | JSON API for getting jokes about Italians | No | Unknown |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes |


### PR DESCRIPTION
Adding iGaming Tools — a structured game data API.

Free tier available without a credit card: create an account and issue a key at https://i-gaming.tools/account/ — no payment details required. Full OpenAPI 3 schema: https://i-gaming.tools/docs/openapi.json

Auth: apiKey (Authorization header). Added between Hyrule Compendium and IGDB.com in Games & Comics.

- [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
- [x] The description is under 160 characters, so it fits the listing card
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit