### PR TITLE
Add BankHolidayCheck API

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@
 | API | Description | Auth | CORS |
 |---|---|---|---|
 | [Abstract Public Holidays](https://www.abstractapi.com/holidays-api) | Data on national, regional, and religious holidays via API | `apiKey` | Yes |
+| [BankHolidayCheck](https://bankholidaycheck.com/holiday-api) | Bank and public holidays for 246 countries, in five languages | No | Yes |
 | [Calendarific](https://calendarific.com/) | Worldwide Holidays | `apiKey` | Unknown |
 | [Czech Namedays Calendar](https://svatky.adresa.info) | Lookup for a name and returns nameday date | No | Unknown |
 | [DigiDates](https://digidates.de/en/) | Various date and time calculations | No | Yes |


### PR DESCRIPTION
Adds **BankHolidayCheck** to the Calendar section: free bank and public holiday API for 150+ countries with holiday names in five languages (en, es, fr, de, pt). Year calendars, next-holiday and per-date banks-closed checks. No key required, CORS enabled, 500 requests/day free. OpenAPI spec and examples: https://github.com/IPNOVA/free-apis/tree/main/bank-holidays

**Disclosure:** I operate this API (IPNOVA SYSTEMS LTD).

- [x] Formatted according to the contributing guide
- [x] Ordered alphabetically
- [x] Description under 100 characters, no ending punctuation
- [x] Searched existing issues and pull requests for duplicates
- [x] Single commit