### PR TITLE
Add GridNews API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1410,6 +1410,7 @@
 | [Finlight](https://finlight.me) | Realtime financial news with sentiment and article content | `apiKey` | Unknown |
 | [Free News API](https://freenewsapi.io) | Search and retrieve news articles with full-text search, filters and cursor pagination | `apiKey` | No |
 | [GNews](https://gnews.io/) | Search for news from various sources | `apiKey` | Yes |
+| [GridNews](https://gridnews.io) | Market news, press releases, and sentiment analysis tagged by ticker symbol | `apiKey` | Yes |
 | [HackerNews Node](https://github.com/EdixonAlberto/api-hackernews-node) | Api to get related articles about Node.js in Hacker News | `apiKey` | No |
 | [HasData: Structured Web Data APIs](https://hasdata.com) | Real-time Google News, SERP, and Web Scraping APIs. Extract structured public data from any news outlet or search engine at scale without blocks | `apiKey` | No |
 | [Inshorts News](https://github.com/cyberboysumanjay/Inshorts-News-API) | Provides news from inshorts | No | Unknown |


### PR DESCRIPTION
Adds [GridNews](https://gridnews.io) to the News category (alphabetically after GNews).

Market news, press releases, and sentiment tagged by ticker. Free tier with API key.

**Affiliation:** I maintain GridNews.

Made with [Cursor](https://cursor.com)