### PR TITLE
Add Aviation Safety Data API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1916,6 +1916,7 @@
 | [airportsapi](https://airport-web.appspot.com/api/docs/) | Get name and website-URL for airports by ICAO code | No | Unknown |
 | [AIS Hub](https://www.aishub.net/api) | Real-time data of any marine and inland vessel equipped with AIS tracking system | `apiKey` | Unknown |
 | [Amadeus for Developers](https://developers.amadeus.com/self-service) | Travel Search - Limited usage | `OAuth` | Unknown |
+| [Aviation Safety Data](https://himaxym.com/developers) | 164,068 aircraft accident narratives from 128 official investigation authorities, plus FAA data | No | Yes |
 | [AviationAPI](https://docs.aviationapi.com) | FAA Aeronautical Charts and Publications, Airport Information, and Airport Weather | No | No |
 | [AZ511](https://www.az511.com/developers/doc) | Access traffic data from the ADOT API | `apiKey` | Unknown |
 | [BC Ferries](https://www.bcferriesapi.ca) | Sailing times and capacities for BC Ferries | No | Yes |


### PR DESCRIPTION
Adds **Aviation Safety Data** to the Transportation section.

- **Homepage / docs:** https://himaxym.com/developers
- **OpenAPI 3.0 spec:** https://himaxym.com/api/v1/data/openapi.json
- **Auth:** `No` — every GET endpoint answers without an `Authorization` header at the keyless tier (100 requests/day/IP). A free self-serve key raises that to 1,000/day; there is no waitlist and no sales gate.
- **CORS:** `Yes` (`access-control-allow-origin: *`)
- Custom domain, https, clean URL, no query parameters.

Works from a stranger's terminal right now:

```
curl 'https://himaxym.com/api/v1/data/events?fatal=1&limit=5'
curl 'https://himaxym.com/api/v1/data/wildlife-strikes'
```

Read-only JSON over 164,068 accident narratives aggregated from 128 official investigation authorities (NTSB, ATSB, AAIB, BEA, MAK and national agencies), deduplicated into one occurrence-level dataset, plus the FAA wildlife-strike, laser-incident and drone-sighting datasets. Every record carries its source, attribution and licence.