### PR TITLE
Add Football Charts API to Sports & Fitness

### DIFF
--- a/README.md
+++ b/README.md
@@ -1805,6 +1805,7 @@
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes |
+| [Football Charts](https://www.football-charts.com/developers) | Results, standings, fixtures, goal timing and model probabilities for 93 football leagues | `apiKey` | Yes |
 | [Football Highlights](https://highlightly.net/documentation/football/) | Real time football (soccer) highlights from over +950 leagues | `apiKey` | Unknown |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Unknown |


### PR DESCRIPTION
Free REST API: results, standings, fixtures, goal timing by minute and Dixon-Coles match probabilities for 93 football leagues (many lower tiers, four women's leagues).

- Free key (5,000 req/day) via `POST /api/v1/keys/register/`
- Auth: `X-API-Key` or `Authorization: Bearer`
- CORS: enabled
- Docs: https://www.football-charts.com/developers

Disclosure: I run the site.