### PR TITLE
Add Fidro API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1676,6 +1676,7 @@
 | [DomScan](https://domscan.net/docs) | Domain, DNS, WHOIS/RDAP, TLS, email, brand and web intelligence | `apiKey` | Yes |
 | [EmailRep](https://docs.emailrep.io/) | Email address threat and risk prediction | No | Unknown |
 | [Escape](https://github.com/polarspetroll/EscapeAPI) | An API for escaping different kind of queries | No | No |
+| [Fidro](https://fidro.io) | Fraud detection API returning a weighted risk score from VPN, proxy, Tor and datacenter IP detection, email validation and Stripe payment signals | `apiKey` | Yes |
 | [FilterLists](https://api.filterlists.com) | Lists of filters for adblockers and firewalls | No | Unknown |
 | [FingerprintJS Pro](https://dev.fingerprintjs.com/docs) | Fraud detection API offering highly accurate browser fingerprinting | `apiKey` | Yes |
 | [FraudLabs Pro](https://www.fraudlabspro.com/developer/api/screen-order) | Screen order information using AI to detect frauds | `apiKey` | Unknown |


### PR DESCRIPTION
Adds Fidro to the Security section.

Fidro is a fraud detection API: one REST call returns a weighted risk score
with an allow, review or block recommendation, combining VPN, proxy, Tor and
datacenter IP detection with email validation and Stripe payment signals.

Auth is a Bearer API key and CORS is enabled; both are documented at
https://fidro.io/docs/api. Self-serve signup with a free tier, no sales gate.

Disclosure: I work on Fidro.

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description is under 160 characters, so it fits the listing card
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been [squashed][squash-link] into a single commit

[squash-link]: https://github.com/todotxt/todo.txt-android/wiki/Squash-All-Commits-Related-to-a-Single-Issue-into-a-Single-Commit
