### PR TITLE
Add PayCrunch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1466,6 +1466,7 @@
 | [openAFRICA](https://africaopendata.org/) | Large datasets repository of African open data | No | Unknown |
 | [OpenCorporates](https://api.opencorporates.com/documentation/API-Reference) | Data on corporate entities and directors in many countries | `apiKey` | Unknown |
 | [OpenSanctions](https://www.opensanctions.org/docs/api/) | Data on international sanctions, crime and politically exposed persons | No | Yes |
+| [PayCrunch](https://paycrunch.co/api.html) | US wages for 1,008 occupations and by state, from BLS OEWS May 2025, static JSON, CC BY 4.0 | No | Yes |
 | [Recreation Information Database](https://ridb.recreation.gov/) | Recreational areas, federal lands, historic sites, museums, and other attractions/resources(US) | `apiKey` | Unknown |
 | [Salary Explorer](https://salarywiki.com/api) | Wages and employment for every US occupation by state and metro area, from Bureau of Labor Statistics survey data, with cost-of-living adjustment | No | Yes |
 | [Scoop.it](https://www.scoop.it/dev) | Content Curation Service | `apiKey` | Unknown |


### PR DESCRIPTION
- [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
- [x] The description is under 160 characters, so it fits the listing card
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] Any category I am creating has the minimum requirement of 3 items
- [x] All changes have been squashed into a single commit

Static JSON wage data for 1,008 US occupations: 10th percentile, median, 90th percentile, and the best-paying state for each, from the BLS Occupational Employment and Wage Statistics May 2025 release. Also returns median and 90th percentile by state for 352 occupations (11,548 area rows), which BLS publishes only inside spreadsheets. No account, no key, no rate limit — every endpoint is a file on a CDN. CC BY 4.0. OpenAPI 3.1 spec at https://paycrunch.co/openapi.json.

One note on the homepage rule: I linked https://paycrunch.co/api.html rather than the site root, because the root is a salary lookup site and this listing is for the API — /api.html is the API's own landing page, with the endpoint list, licence and terms, not a deep link into docs. Happy to change it to https://paycrunch.co if you'd rather the listing screenshot show the parent site.

Roughly a quarter of the job records cover titles BLS does not track separately. Those carry `"estimated": true` and a disclaimer field saying they must not be cited as BLS figures, so the two are always distinguishable in the response.