### PR TITLE
Add MadeOnSol to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,7 @@
 | [INFURA Ethereum](https://www.infura.io/product/ethereum) | Interaction with the Ethereum mainnet and several testnets | `apiKey` | Yes |
 | [Kraken](https://docs.kraken.com/rest/) | Cryptocurrencies Exchange | `apiKey` | Unknown |
 | [KuCoin](https://docs.kucoin.com/) | Cryptocurrency Trading Platform | `apiKey` | Unknown |
+| [MadeOnSol](https://madeonsol.com) | Real-time Solana and Robinhood Chain data - KOL trades, deployer reputation, token risk, DEX streams | `apiKey` | Yes |
 | [Mempool](https://mempool.space/api) | Bitcoin API Service focusing on the transaction fee | No | No |
 | [MercadoBitcoin](https://api.mercadobitcoin.net/api/v4/docs) | Brazilian Cryptocurrency Information | No | Unknown |
 | [Messari](https://messari.io/api) | Provides API endpoints for thousands of crypto assets | No | Unknown |


### PR DESCRIPTION
Adds MadeOnSol (https://madeonsol.com) to the Cryptocurrency section.

- Real-time Solana + Robinhood Chain on-chain data API: KOL/smart-money trade feeds, deployer reputation, token risk, DEX WebSocket streams
- Free tier available (API key, 200 req/day) — full docs at https://madeonsol.com/developer
- Auth: `apiKey` · HTTPS · CORS enabled (`Access-Control-Allow-Origin: *`, verified)
- Alphabetical placement before Mempool

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HhTrrRwDyszBMg66wbiKH