### PR TITLE
Add Paycoin Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,7 @@
 | [OpenChainBench](https://openchainbench.com/api/openapi.json) | Open dataset of crypto infrastructure benchmarks: RPC latency, oracles, bridges, prediction markets | No | Yes |
 | [OpenSea](https://docs.opensea.io/reference/api-overview) | The Largest NFT Marketplace | `apiKey` | No |
 | [Ophis](https://docs.ophis.fi) | Natural-language intent parser for DEX swaps across 11 EVM chains | No | Unknown |
+| [Paycoin Index](https://paycoin.com) | Hourly index of stablecoin transfer costs across 9 chains, with daily history and per-source provenance | No | Yes |
 | [Poloniex](https://docs.poloniex.com) | US based digital asset exchange | `apiKey` | Unknown |
 | [Sharpe](https://sharpe.ai) | Crypto market data for funding, futures, options, arbitrage, narratives, and news | No | No |
 | [Solana JSON RPC](https://docs.solana.com/developing/clients/jsonrpc-api) | Provides various endpoints to interact with the Solana Blockchain | No | Unknown |


### PR DESCRIPTION
Adds the **Paycoin Index** to the Cryptocurrency section (alphabetical position, between Ophis and Poloniex).

- **What it is:** an automated, open-methodology index of stablecoin transfer costs (USDT/USDC) across 9 blockchain networks, rebuilt hourly from cited public sources.
- **API:** free JSON, no auth, no key: https://paycoin.com/data/latest.json (current snapshot with per-source provenance) plus daily history under `/data/history/`.
- **Docs:** field-by-field schema at https://paycoin.com/data/SCHEMA.md, computation documented at https://paycoin.com/methodology/.
- **Auth:** No · **CORS:** Yes (`access-control-allow-origin: *`, verified).

No token, no ads, no signup — a static, source-cited data observatory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)