### PR TITLE
Add Stellary

### DIFF
--- a/README.md
+++ b/README.md
@@ -775,6 +775,7 @@
 | [RenderPDF.io](https://renderpdf.io) | HTML to PDF crazy fast, 500 pdfs/month + CDN-ready | `apiKey` | Yes |
 | [ReportForge](https://reportforge-api.vercel.app) | Generate styled HTML reports from CSV or JSON data with built-in templates | No | Yes |
 | [Restpack](https://restpack.io/) | Provides screenshot, HTML to PDF and content extraction APIs | `apiKey` | Unknown |
+| [Stellary](https://stellary.co) | Project management for teams and AI agents via hosted MCP (boards, cards, missions, approvals) | `apiKey` | Unknown |
 | [Todoist](https://developer.todoist.com) | Todo Lists | `OAuth` | Unknown |
 | [URL to Markdown](https://github.com/macsplit/urltomarkdown) | Convert web page to MarkDown | No | Yes |
 | [Vector Express v2.0](https://vector.express) | Free vector file converting API | No | No |


### PR DESCRIPTION
## Description

Adds **Stellary** to **Documents & Productivity** (alphabetical, between Restpack and Todoist). README only; `/db` untouched.

Stellary is AI project management for teams and AI agents. The public, self-serve surface is a hosted MCP server (also usable with a Bearer PAT). Open beta: anyone can create an account on the site with no waitlist or sales gate.

- **Site:** https://stellary.co
- **MCP:** https://api.stellary.co/mcp
- **Docs:** https://stellary.co/docs/mcp/
- **Auth:** `apiKey` (Bearer PAT; OAuth is also supported)
- **HTTPS:** Yes
- **CORS:** Unknown (not documented; MCP is typically used from clients such as Cursor / Claude)

Entry:

```
| [Stellary](https://stellary.co) | Project management for teams and AI agents via hosted MCP (boards, cards, missions, approvals) | `apiKey` | Unknown |
```

**Disclosure:** I am the founder of Stellary (GitHub Anymfah).