### PR TITLE
Add x402-list API

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,7 @@
 | [VALR](https://docs.valr.com/) | Cryptocurrency Exchange based in South Africa | `apiKey` | Unknown |
 | [VaultVision](https://vaultvision.tech/developers) | Read-only Hyperliquid vault data, risk rankings, and research signals | No | Yes |
 | [WorldCoinIndex](https://www.worldcoinindex.com/apiservice) | Cryptocurrencies Prices | `apiKey` | Unknown |
+| [x402-list](https://x402-list.com) | Directory of paid x402 APIs with per-endpoint USD pricing and live uptime, vetted before an agent pays, backed by on-chain settlement volume | No | Yes |
 | [ZMOK](https://docs.zmok.io) | Ethereum JSON RPC API and Web3 provider | No | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds x402-list to the Cryptocurrency section.

x402-list.com is a directory of paid x402 APIs. It checks the health and
per-endpoint USD pricing of each service before an agent pays one, and reports
on-chain settlement volume verified from the facilitators.

The directory itself exposes a public REST API, documented at
https://x402-list.com/api, with no authentication for reads. Auth: No.
CORS: Yes (Access-Control-Allow-Origin: * on the JSON endpoints).

Checklist against the guidelines:
- Custom domain, https, no query parameters in the URL.
- Homepage linked (docs reachable from there).
- Single entry, placed in Cryptocurrency in alphabetical order (between
  WorldCoinIndex and ZMOK).
- Columns padded with one space per side; description under 160 characters.
- Name has no TLD and does not end with "API".
- Publicly reachable and self-serve; Auth and CORS determinable from the docs.
