### PR TITLE
Add AI DECISIONS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@
 |---|---|---|---|
 | [0xArchive](https://0xarchive.io) | Real-time and historical Hyperliquid and Lighter market data | `apiKey` | No |
 | [1inch](https://business.1inch.com/) | API for querying decentralize exchange | `apiKey` | Yes |
+| [AI DECISIONS](https://aidecisions.ai) | Crypto address risk screening: sanctions hits, mixer exposure, AI-agent detection and a calibrated risk tier across six chains | `apiKey` | No |
 | [Alchemy Ethereum](https://docs.alchemy.com/alchemy/) | Ethereum Node-as-a-Service Provider | `apiKey` | Yes |
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Unknown |
 | [Bitfinex](https://docs.bitfinex.com/docs) | Cryptocurrency Trading Platform | `apiKey` | Unknown |


### PR DESCRIPTION
Adds AI DECISIONS to **Cryptocurrency**: a REST API for crypto address risk screening (sanctions hits, mixer exposure, AI-agent detection and a population-calibrated risk tier per address across Ethereum, Bitcoin, Tron, Base, Arbitrum and Gnosis).

- Homepage: https://aidecisions.ai · Docs: https://aidecisions.ai/docs · OpenAPI 3: https://aidecisions.ai/openapi.json
- Self-serve: register a tenant (free RESEARCH tier) at https://app.aidecisions.ai/onboarding to get an `X-API-Key`; a no-account checker exists at https://aidecisions.ai/check
- Auth: `apiKey` (header `X-API-Key`). CORS: No (server-side use).

**Disclosure:** I am the founder of AI DECISIONS.

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description is under 160 characters, so it fits the listing card
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items
-   [x] All changes have been squashed into a single commit
