### PR TITLE
Add ISMS Copilot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@
 | [Imagga](https://imagga.com/) | Image Recognition Solutions like Tagging, Visual Search, NSFW moderation | `apiKey` | Unknown |
 | [Inferdo](https://rapidapi.com/user/inferdo) | Computer Vision services like Facial detection, Image labeling, NSFW classification | `apiKey` | Unknown |
 | [Irisnet](https://irisnet.de/api/) | Realtime content moderation API that blocks or blurs unwanted images in real-time | `apiKey` | Yes |
+| [ISMS Copilot](https://www.ismscopilot.com/products/api) | OpenAI-compatible text-only compliance completions: curated framework knowledge (100+ modules) injected before generation and disclosed on success | `apiKey` | No |
 | [Keen IO](https://keen.io/) | Data Analytics | `apiKey` | Unknown |
 | [Machinetutors](https://machinetutors.com/api/) | AI Solutions: Video/Image Classification & Tagging, NSFW, Icon/Image/Audio Search, NLP | `apiKey` | Yes |
 | [MessengerX.io](https://messengerx.rtfd.io) | A FREE API for developers to build and monetize personalized ML based chat apps | `apiKey` | Yes |


### PR DESCRIPTION
Adds ISMS Copilot to the AI section (alphabetical: Irisnet -> Keen IO).

Criteria self-check per CONTRIBUTING:
- Publicly reachable and documented: https://www.ismscopilot.com/products/api, docs at https://docs.ismscopilot.com/docs/api
- Self-serve: yes, sign up and create keys in the developer console, no sales gate
- Auth/CORS documented: apiKey bearer auth; CORS: No (server-side by design, documented)
- Custom domain: yes (ismscopilot.com)
- One link in this PR, description 146 chars, name does not end with API

Thanks for reviewing.