### PR TITLE
Add XLSX Inspector API

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,7 @@
 | [Vertopal](https://www.vertopal.com/en/developer/api/introduction) | Convert your files to a variety of formats using Vertopal API | `apiKey` | No |
 | [WakaTime](https://wakatime.com/developers) | Automated time tracking leaderboards for programmers | No | Unknown |
 | [WAV to MP3 API](https://apyhub.com/utility/audio-converter-wav-mp3) | This API lets you convert wav files to mp3 | `apiKey` | Yes |
+| [XLSX Inspector](https://api.lifestep.io) | Inspect spreadsheet structure, formulas, macros, hidden sheets, and external links | No | Yes |
 | [Zube](https://zube.io/docs/api) | Full stack project management | `OAuth` | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
## Submission

This adds **XLSX Inspector**, a publicly reachable, no-auth API for inspecting spreadsheet structure, formulas, macros, hidden sheets, and external links. It has a custom HTTPS domain, a self-serve usage page, interactive OpenAPI documentation, and CORS enabled.

The API is the main product at the submitted domain and is placed alphabetically in **Documents & Productivity**. The description is 82 characters, below the 160-character limit.

Disclosure: I maintain XLSX Inspector.

## Checklist

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API homepage
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I searched the repository and pull requests for duplicates
- [x] I did not create a category
- [x] The change is a single commit

## Checks

- Confirmed the homepage returns HTTP 200.
- Confirmed `Access-Control-Allow-Origin: *` on the live API.
- Ran `git diff --check` and verified the table has four columns.
