### PR TITLE
Add aikstockdata (Finance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -885,6 +885,7 @@
 | [Abstract VAT Validation](https://www.abstractapi.com/vat-validation-rates-api) | Validate VAT numbers and calculate VAT rates | `apiKey` | Yes |
 | [Adanos](https://adanos.org/) | Stock and crypto sentiment from Reddit, X, financial news, and Polymarket | `apiKey` | Yes |
 | [Agent Toolbelt](https://www.agenttoolbelt.live) | AI-generated stock analysis (investment thesis, valuation, insider signal, earnings) from live fundamentals, as structured JSON | `apiKey` | Unknown |
+| [aikstockdata](https://aikstockdata.com) | KOSPI/KOSDAQ/KONEX daily settled closes, DART filings with receipt times, quarterly earnings | No | Yes |
 | [Aletheia](https://aletheiaapi.com/) | Insider trading data, earnings call analysis, financial statements, and more | `apiKey` | Yes |
 | [Alpha Vantage](https://www.alphavantage.co/) | Realtime and historical stock data | `apiKey` | Unknown |
 | [AlphaAI](https://alphai.io/developers) | AI-enriched financial & insider-trading news, scored for relevance | `apiKey` | Unknown |


### PR DESCRIPTION
Adds one entry to **Finance**, in alphabetical position.

Korean equities data as plain static JSON: KOSPI/KOSDAQ/KONEX settled closing prices (T+1), DART regulatory filings with **receipt timestamps (HH:MM)**, and quarterly earnings taken from the filings themselves. Derived from Korean government open data (Financial Services Commission portal + the FSS DART system), so it is freely redistributable.

There is no signup, no API key and no rate limit — the files are pre-built and served from a CDN, so there is nothing to register for and nothing to buy.

Checked before opening this:

- **Auth: No** — no credential of any kind is accepted or needed.
- **HTTPS: Yes**
- **CORS: Yes** — verified `Access-Control-Allow-Origin: *` on `/data/public/today.json` and `/openapi.json`.
- Alphabetical position kept.

Try it with no setup at all:

```
curl -s https://aikstockdata.com/data/public/today.json
curl -s https://aikstockdata.com/data/public/s/005930.json
```

OpenAPI 3.1 spec: https://aikstockdata.com/openapi.json — catalog of every endpoint with sizes and freshness: https://aikstockdata.com/data/public/index.json
