### PR TITLE
Add AnyAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,7 @@
 | [AgentDeals](https://agentdeals.dev/api) | Search and compare developer free tiers, startup credits, and pricing changes | No | Yes |
 | [Agify.io](https://agify.io) | Estimates the age from a first name | No | Yes |
 | [Amazonscraperapi](https://amazonscraperapi.com) | Amazon product, search & batch scraping API with residential proxies (1000 free) | `apiKey` | No |
+| [AnyAPI](https://getanyapi.com) | Hundreds of scraping and data APIs behind one key and one normalized JSON schema, priced per request in USD | `apiKey` | No |
 | [API Grátis](https://apigratis.com.br/) | Multiples services and public APIs | No | Unknown |
 | [API League](https://apileague.com) | World-class APIs in a single hub | `apiKey` | Yes |
 | [API Status Check](https://apistatuscheck.com) | Real-time status and uptime monitoring for 270+ APIs and services | No | Yes |


### PR DESCRIPTION
Adds AnyAPI to **Development**, alphabetically after Amazonscraperapi.

```
| [AnyAPI](https://getanyapi.com) | Hundreds of scraping and data APIs behind one key and one normalized JSON schema, priced per request in USD | `apiKey` | No |
```

**Against the acceptance criteria:**

- **Self-serve** - fully. A stranger gets a working key with starter credit from one unauthenticated call, no waitlist, no sales gate:
  ```
  curl -s -X POST https://api.getanyapi.com/agent/signup -d '{}'
  ```
- **Publicly reachable and documented** - docs at https://getanyapi.com/docs, OpenAPI 3 at https://api.getanyapi.com/openapi.json. The catalog needs no credential at all:
  ```
  curl -s 'https://api.getanyapi.com/catalog/search?q=instagram%20profile'
  ```
- **Auth** - `apiKey`, sent as `X-API-Key`.
- **CORS** - `No`. Verified: a request with an `Origin` header comes back 200 with no `Access-Control-Allow-Origin`, so it is server-side only.
- **Main product only** - the API is the product. Paid, pay-per-request in USD, no subscription.
- **Custom domain, clean URL, no TLD in the name, name does not end in a separate "API" word.**

Disclosure: I work on AnyAPI.