### PR TITLE
Merge duplicate JobsPipe entries into one

### DIFF
--- a/README.md
+++ b/README.md
@@ -1354,8 +1354,7 @@
 | [Job Application API](https://boringproject.ai) | API to apply on jobs posted on carrer platform like workday, lever, icims and many more. Handles captcha, fill forms, submit applications, integrate in < 10min | `apiKey` | Unknown |
 | [jobdata API](https://jobdataapi.com/) | Simple Job Data API | `apiKey` | Unknown |
 | [Jobicy](https://jobicy.com/jobs-rss-feed) | Remote Jobs API Feed | No | Unknown |
-| [JobsPipe](https://jobspipe.dev/docs) | Search live job postings from job boards and company career sites, plus tech stack detection by domain | `apiKey` | Yes |
-| [Jobspipe](https://jobspipe.dev/) | Jobspipe a unified jobs data API powering access to over 300 million public job postings worldwide. We aggregate, normalize, and enrich job data | `apiKey` | Unknown |
+| [JobsPipe](https://jobspipe.dev) | Job postings from 30+ ATS and job boards deduplicated into one schema, plus tech stack detection by domain | `apiKey` | Yes |
 | [Jobven](https://jobven.com) | Job postings collected directly from employer career pages, not job boards. Structured JSON over REST, with webhooks when listings change | `apiKey` | Yes |
 | [Jobvetta](https://www.jobvetta.com/api) | Live, vetted job listings from official employer sources across India | `apiKey` | Yes |
 | [JobYap](https://jobyap.com/agents) | Job postings aggregated from companies' careers sites, with community discussion threads | No | Yes |


### PR DESCRIPTION
JobsPipe is currently listed **twice** in the Jobs section, with different casing, different URLs, different descriptions, and contradictory CORS values:

```
| [JobsPipe](https://jobspipe.dev/docs) | Search live job postings … | `apiKey` | Yes     |
| [Jobspipe](https://jobspipe.dev/)     | Jobspipe a unified jobs data API … | `apiKey` | Unknown |
```

This merges them into one entry:

```
| [JobsPipe](https://jobspipe.dev) | Job postings from 30+ ATS and job boards deduplicated into one schema, plus tech stack detection by domain | `apiKey` | Yes |
```

Choices made, each against a rule in CONTRIBUTING:

- **URL → the homepage**, not the `/docs` deep-link — *"should point at the API's homepage… Avoid deep links to docs pages"*, and it's the page that becomes the publicapis.dev screenshot.
- **CORS → `Yes`**, verified rather than assumed:
  ```
  OPTIONS https://api.jobspipe.dev/v1/jobs/search
  → HTTP/2 204
    access-control-allow-origin: https://example.com
    access-control-allow-methods: GET,POST,PATCH,DELETE,OPTIONS
  ```
  The `Unknown` on the second entry was simply wrong.
- **Description → factual**, dropping the marketing phrasing and the unverifiable "300 million" claim from the duplicate.
- **Casing → `JobsPipe`**, matching the vendor's own usage.
- Alphabetical order preserved: `Jobicy` → `JobsPipe` → `Jobven`.

## Disclosure

I maintain JobsPipe. I did not add either of these entries; I'm cleaning up the duplication and correcting the CORS value rather than adding a third listing, since CONTRIBUTING says not to submit an API that is already listed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)