### PR TITLE
Add BlackForge to Cryptocurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@
 | [Binance](https://github.com/binance/binance-spot-api-docs) | Exchange for Trading Cryptocurrencies based in China | `apiKey` | Unknown |
 | [Bitfinex](https://docs.bitfinex.com/docs) | Cryptocurrency Trading Platform | `apiKey` | Unknown |
 | [Bitmex](https://www.bitmex.com/app/apiOverview) | Real-Time Cryptocurrency derivatives trading platform based in Hong Kong | `apiKey` | Unknown |
+| [BlackForge](https://blackforge.so) | Order book depth, resting-liquidity lifetimes and taker buy/sell flow across 9 spot venues, per pair per 5-minute window | `apiKey` | No |
 | [Block](https://block.io/docs/basic) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Unknown |
 | [BlockBee](https://docs.blockbee.io/) | Cryptocurrency Payment Processor | `apiKey` | Unknown |
 | [Blockchain](https://www.blockchain.com/api) | Bitcoin Payment, Wallet & Transaction Data | `apiKey` | Unknown |


### PR DESCRIPTION
Adds **BlackForge** to `Cryptocurrency`.

- [x] Meets the What we accept criteria
- [x] Formatted according to the contributing guide
- [x] Ordered alphabetically (between Bitmex and Block)
- [x] Useful description
- [x] URL starts with `https://` and points to the API homepage
- [x] Description is 120 characters, under the 160 limit
- [x] Each table column padded with one space on either side
- [x] Searched the repository for relevant issues and pull requests
- [x] Single commit

CORS is listed as **No**: the preflight advertises allowed methods but no `Access-Control-Allow-Origin` header is returned, so cross-origin browser requests are blocked. Verified with curl against `https://api.blackforge.so/v1/catalog` before submitting.

Auth is `apiKey`, though the `/v1/catalog` endpoint is readable without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)