### PR TITLE
Add L2 Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@
 | [Italian Jokes](https://italian-jokes.vercel.app/) | JSON API for getting jokes about Italians | No | Unknown |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes |
-| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
+| [L2 Calendar](https://l2calendar.com/api/servers) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Unknown |
 | [Magic The Gathering](https://magicthegathering.io/) | Magic The Gathering Game Information | No | Unknown |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | No |

--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@
 | [Italian Jokes](https://italian-jokes.vercel.app/) | JSON API for getting jokes about Italians | No | Unknown |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes |
-| [L2 Calendar](https://l2calendar.com/api/servers) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
+| [L2 Calendar](https://l2calendar.com/api/servers) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Unknown |
 | [Magic The Gathering](https://magicthegathering.io/) | Magic The Gathering Game Information | No | Unknown |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | No |

--- a/README.md
+++ b/README.md
@@ -1053,6 +1053,7 @@
 | [Italian Jokes](https://italian-jokes.vercel.app/) | JSON API for getting jokes about Italians | No | Unknown |
 | [JokeAPI](https://sv443.net/jokeapi/v2/) | Programming, Miscellaneous and Dark Jokes | No | Yes |
 | [Jokes One](https://jokes.one/api/joke/) | Joke of the day and large category of jokes accessible via REST API | `apiKey` | Yes |
+| [L2 Calendar](https://l2calendar.com/api/servers?lang=en) | Lineage 2 private servers list with names, websites, chronicles, rates and opening dates | No | Yes | Yes |
 | [Lichess](https://lichess.org/api) | Access to all data of users, games, puzzles and etc on Lichess | `OAuth` | Unknown |
 | [Magic The Gathering](https://magicthegathering.io/) | Magic The Gathering Game Information | No | Unknown |
 | [Minecraft Server Status](https://api.mcsrvstat.us) | API to get Information about a Minecraft Server | No | No |


### PR DESCRIPTION
## API Addition

**API Name:** L2 Calendar API
**Link:** https://l2calendar.com/api/servers
**Category:** Games & Comics

### Description
Public JSON API listing Lineage 2 private servers with names, websites, chronicles (Interlude, High Five, Classic, Essence...), rates and opening dates. Useful for game server trackers, community tools and L2 player dashboards.

### Checklist
- [x] Free access, no auth required
- [x] HTTPS supported
- [x] CORS enabled (Access-Control-Allow-Origin: *)
- [x] Data is public (same servers listed on the site homepage)
- [x] Inserted alphabetically (between Jokes One and Lichess)

Verified live: 464 servers, application/json, stable endpoint.