### PR TITLE
Add Elpriser i dag API

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,7 @@
 | [Climatiq](https://docs.climatiq.io) | Calculate the environmental footprint created by a broad range of emission-generating activities | `apiKey` | Yes |
 | [Cloverly](https://www.cloverly.com/carbon-offset-documentation) | API calculates the impact of common carbon-intensive activities in real time | `apiKey` | Unknown |
 | [Danish data service Energi](https://www.energidataservice.dk/) | Open energy data from Energinet to society | No | Unknown |
+| [Elpriser i dag](https://elprisernaidag.se/api/) | Swedish electricity spot prices including VAT and energy tax, in 15-minute intervals | No | Yes |
 | [GrünstromIndex](https://gruenstromindex.de/) | Green Power Index for Germany (Grünstromindex/GSI) | No | Yes |
 | [IQAir](https://www.iqair.com/air-pollution-data-api) | Air quality and weather data | `apiKey` | Unknown |
 | [Luchtmeetnet](https://api-docs.luchtmeetnet.nl/) | Predicted and actual air quality components for The Netherlands (RIVM) | No | Unknown |


### PR DESCRIPTION
Adds a free JSON API for Swedish electricity spot prices.

What it returns that the existing Nordic entries do not: the price a household actually pays. Spot plus 25% VAT plus energiskatt, with the reduced rate for the 46 northern municipalities available as a separate field. All 96 quarter-hour intervals per day for SE1–SE4.

No key, no registration, CORS open. Data is Nord Pool day-ahead via elprisetjustnu.se, credited in every response.

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically (between Danish data service Energi and GrünstromIndex)
- [x] My submission has a useful description
- [x] The URL starts with 'https://'
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] I am not creating a new category
- [x] All changes have been squashed into a single commit