### PR TITLE
Add Strømpriser i dag API

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,6 +862,7 @@
 | [Smartatest](https://smartatest.se/api) | Calculators for home energy cost, lighting, air quality limits and GS1 barcode prefixes, in Swedish | No | Yes |
 | [Solematica](https://www.solematica.it/sviluppatori) | Compare Italian solar installer offers, energy prices (PUN/ARERA) and satellite roof data | No | No |
 | [Srp Energy](https://srpenergy-api-client-python.readthedocs.io/en/latest/api.html) | Hourly usage energy report for Srp customers | `apiKey` | No |
+| [Strømpriser i dag](https://strompriseridag.no/api/) | Norwegian electricity prices including VAT and the state subsidy, plus grid tariffs for all 73 grid companies | No | Yes |
 | [Thames Water Open Data](https://data.thameswater.co.uk) | Open Data from the UK's largest water and wastewater services company | `apiKey` | Unknown |
 | [UK Carbon Intensity](https://carbon-intensity.github.io/api-definitions/#carbon-intensity-api-v1-0-0) | The Official Carbon Intensity API for Great Britain developed by National Grid | No | Unknown |
 | [WattBuy](https://wattbuy.readme.io/reference/getting-started-with-your-api) | Electricity usage estimations, carbon footprint estimations, and utility data | `apiKey` | Yes |


### PR DESCRIPTION
Adds a free JSON API for Norwegian electricity prices.

What it returns that the existing Nordic entries do not: the price a household actually pays. Spot plus VAT, minus strømstøtte — the state subsidy, computed hour by hour the way the scheme actually works, not against a daily average. Zones NO1–NO5.

It also exposes grid tariffs (nettleie) for all 73 Norwegian grid companies, hour by hour. That data is published as YAML in a GitHub repo by Fri Nettleie (CC BY 4.0, credited); this is the HTTP layer over it, which their own FAQ notes did not exist.

No key, no registration, CORS open. Prices are Nord Pool day-ahead via hvakosterstrommen.no, credited in every response.

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines
- [x] My addition is ordered alphabetically (between Srp Energy and Thames Water Open Data)
- [x] My submission has a useful description
- [x] The URL starts with 'https://'
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I have searched the repository for any relevant issues or pull requests
- [x] I am not creating a new category
- [x] All changes have been squashed into a single commit