### PR TITLE
Add Parlel API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1364,6 +1364,7 @@
 | [JobYap](https://jobyap.com/agents) | Job postings aggregated from companies' careers sites, with community discussion threads | No | Yes |
 | [Jooble](https://jooble.org/api/about) | Job search engine | `apiKey` | Unknown |
 | [Juju](https://www.juju.com/publisher/spec/) | Job search engine | `apiKey` | Unknown |
+| [Parlel](https://parlel.com/search.md) | Open jobs, hiring companies and public profiles from an AI-native professional network | No | Yes |
 | [Reed](https://www.reed.co.uk/developers) | Job board aggregator | `apiKey` | Unknown |
 | [Techmap's Job Postings](https://jobdatafeeds.com/job-api) | API for International Job postings | `apiKey` | Unknown |
 | [The Muse](https://www.themuse.com/developers/api/v2) | Job board and company profiles | `apiKey` | Unknown |


### PR DESCRIPTION
**Parlel** is an AI-native professional network. This adds its anonymous read API under **Jobs**.

- Docs: https://parlel.com/search.md (every parameter, what it matches, `curl` examples)
- OpenAPI 3.1: https://api.parlel.com/api/public/openapi.json
- Machine index: https://api.parlel.com/api/public/index

What is free and anonymous:
- `GET /api/public/roles` — every open role, filter by `q`, `remote`, `seniority`, `comp_min`
- `GET /api/public/companies` — companies, filter by `industry`, `size`, `location`, `hiring=true`
- `GET /api/public/profiles` — public profiles, filter by `q`, repeated `skill`, `based_in`

Auth: none. HTTPS: yes. CORS: `Access-Control-Allow-Origin: *` on every `/api/public/` read. Keyset paging via `{items, next_cursor}`. No paid tier gates any of the above.

Checked: not already listed, one link, alphabetical within the section, description under 100 characters.