### PR TITLE
Update Reserp API v2 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -667,7 +667,7 @@
 | [ReefAPI](https://reefapi.com/) | One API for 185+ live web data sources including search, social, e-commerce, real estate, jobs and finance, returning clean JSON | `apiKey` | No |
 | [Render API](https://render.com/docs/api) | Lets you programmatically manage your Render services (web apps, APIs, and static sites) including deployments, scaling, and configuration | `apiKey` | Unknown |
 | [ReqRes](https://reqres.in/) | A hosted REST-API ready to respond to your AJAX requests | No | Unknown |
-| [Reserp](https://reserp.ai) | Send a Google Search URL and receive visible result blocks as structured JSON | `apiKey` | No |
+| [Reserp](https://reserp.ai) | Google Search API with flat results and structured SERP blocks | `apiKey` | No |
 | [RSS to JSON](https://github.com/ayusharma/RSS-to-JSON) | Returns RSS feed in JSON format using feed URL | No | Yes |
 | [ScrapeNinja](https://scrapeninja.net) | Scraping API with Chrome fingerprint and residential proxies | `apiKey` | Unknown |
 | [ScraperApi](https://www.scraperapi.com) | Easily build scalable web scrapers | `apiKey` | Unknown |


### PR DESCRIPTION
Updates the existing Reserp entry's description for the stable API v2 contract: flat search results or structured SERP blocks. The homepage link, API-key authentication value, category, and CORS value are unchanged.

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the guidelines in the contributing guide
- [x] The existing entry remains ordered alphabetically
- [x] The submission has a useful description
- [x] The existing URL starts with `https://` and points to the API homepage
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I searched for relevant open issues and pull requests
- [x] No category is being created
- [x] The change is a single squashed commit