### PR TITLE
Add 5DollarFootballAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1806,6 +1806,7 @@
 ### Sports & Fitness
 | API | Description | Auth | CORS |
 |---|---|---|---|
+| [5DollarFootballAPI](https://5dollarfootballapi.com) | Football fixtures, live scores, standings and tick-by-tick bet365 odds (+18 more bookmakers) with corner and card lines | `apiKey` | Yes |
 | [American Football Highlights API](https://highlightly.net/documentation/american-football/) | Real time American Football (NFL/NCAA) highlights | `apiKey` | Unknown |
 | [API-FOOTBALL](https://www.api-football.com/documentation-v3) | Get information about Football Leagues & Cups | `apiKey` | Yes |
 | [balldontlie](https://www.balldontlie.io) | Balldontlie provides access to stats data from the NBA | No | Yes |


### PR DESCRIPTION
Adds 5DollarFootballAPI to Sports & Fitness.

Football data API: fixtures, live scores, standings, and tick-by-tick odds history (bet365 plus 18 more bookmakers) including corner and card lines. Self-serve signup with a permanent free tier (no card required), public pricing and docs at https://5dollarfootballapi.com/docs, custom domain, apiKey auth over HTTPS, CORS enabled. Also listed on public-apis/public-apis.