### PR TITLE
Add Wander Atlas to Transportation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1996,6 +1996,7 @@
 | [Tripadvisor](https://developer-tripadvisor.com/home/) | Rating content for a hotel, restaurant, attraction or destination | `apiKey` | Unknown |
 | [Uber](https://developer.uber.com/products) | Uber ride requests and price estimation | `OAuth` | Yes |
 | [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole) | Velib Open Data API | No | No |
+| [Wander Atlas](https://wanderatlasguides.com/api/) | Hourly quiet and busy windows for 671 tourist attractions in 20 countries | No | Yes |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
| API | Description | Auth | CORS |
| --- | --- | --- | --- |
| [Wander Atlas](https://wanderatlasguides.com/api/) | Hourly quiet and busy windows for 671 tourist attractions in 20 countries | No | Yes |

Measured foot-traffic per attraction: the hours each place reads quiet and the hours it reads busy, split weekday and weekend, with lat/lng, city, country and the date it was last measured.

Against the checklist:

- **Self-serve** — `GET https://wanderatlasguides.com/api/crowd.json` returns the whole document. No signup, no key, no waitlist
- **Publicly reachable and documented** — https://wanderatlasguides.com/api/ documents the schema, the licence and the update cadence
- **Auth: No · CORS: Yes** — `Access-Control-Allow-Origin: *`, so it works from the browser
- **Custom domain**, clean URL, no query parameters
- Licensed CC BY 4.0; the licence and attribution string are fields inside the JSON itself

Placed alphabetically after Velib in Transportation, next to Tripadvisor's attraction content. It answers a question the neighbouring APIs do not: Google Places gives opening hours but withholds popular times, so *when* a place is bearable is not otherwise available to build on.

Already listed in [public-apis/public-apis](https://github.com/public-apis/public-apis) (merged 2026-08-30).