### PR TITLE
Add Motomarks API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2029,6 +2029,7 @@
 | [Helipaddy sites](https://helipaddy.com/api/) | Helicopter and passenger drone landing site directory, Helipaddy data and much more | `apiKey` | Unknown |
 | [Kelley Blue Book](https://developer.kbb.com/#!/data/1-Default) | Vehicle info, pricing, configuration, plus much more | `apiKey` | No |
 | [Mercedes-Benz](https://developer.mercedes-benz.com/apis) | Telematics data, remotely access vehicle functions, car configurator, locate service dealers | `apiKey` | No |
+| [Motomarks](https://motomarks.io/) | Manufacturer marks for automotive apps. Badge, wordmark, and full logo from one image CDN, so listings do not keep a local dump. | `apiKey` | Unknown |
 | [NHTSA](https://vpic.nhtsa.dot.gov/api/) | NHTSA Product Information Catalog and Vehicle Listing | No | Unknown |
 | [Smartcar](https://smartcar.com/docs/) | Lock and unlock vehicles and get data like odometer reading and location. Works on most new cars | `OAuth` | Yes |
 


### PR DESCRIPTION
Vehicle already lists VIN and spec APIs. None of them is the manufacturer mark next to the listing.

Motomarks is a self-serve image CDN and JSON API for those marks. Please add it under Vehicle, alphabetical, linking https://motomarks.io/. Auth apiKey. CORS Unknown.