### PR TITLE
Add Malwagon API

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@
 | [Google Safe Browsing](https://developers.google.com/safe-browsing/) | Google Link/Domain Flagging | `apiKey` | Unknown |
 | [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Unknown |
 | [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | No |
-| [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Unknown |
 | [Malwagon](https://malwagon.com/docs/api) | Detonate a file, URL or hash in a sandbox and read the verdict, behaviour and indicators | `apiKey` | Unknown |
+| [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Unknown |
 | [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes |
 | [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | Yes |
 | [SniffCat](https://sniffcat.com/) | IP abuse lookup, reporting and threat intelligence | `apiKey` | Yes |

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@
 | [MalDatabase](https://maldatabase.com/api-doc.html) | Provide malware datasets and threat intelligence feeds | `apiKey` | Unknown |
 | [MalShare](https://malshare.com/doc.php) | Malware Archive / file sourcing | `apiKey` | No |
 | [MalwareBazaar](https://bazaar.abuse.ch/api/) | Collect and share malware samples | `apiKey` | Unknown |
+| [Malwagon](https://malwagon.com/docs/api) | Detonate a file, URL or hash in a sandbox and read the verdict, behaviour and indicators | `apiKey` | Unknown |
 | [Scanii](https://docs.scanii.com/) | Simple REST API that can scan submitted documents/files for the presence of threats | `apiKey` | Yes |
 | [ScanMalware](https://scanmalware.com) | Scan URLs in a sandboxed browser and search past scans by domain, IP, ASN, JARM or favicon hash | No | Yes |
 | [SniffCat](https://sniffcat.com/) | IP abuse lookup, reporting and threat intelligence | `apiKey` | Yes |


### PR DESCRIPTION
Adds the [Malwagon](https://malwagon.com/docs/api) API to Anti-Malware.

It submits a file, URL, hash, command or package to a sandbox, then returns the verdict and score, the process, registry, file and network behaviour, ATT&CK technique mappings and extracted indicators. There is also an indicator search across past scans.

Against the acceptance rules:

- **Self-serve**: sign up on the site and mint a token in the console. No waitlist, no partner approval, no contact-sales gate.
- **Free or paid**: a free tier issues tokens without payment details; paid plans add more.
- **Custom domain**: malwagon.com.
- **Main product only**: one entry, the API.

Description is 96 characters. Alphabetical, after MalwareBazaar.

Disclosure: I work on Malwagon.