### PR TITLE
Add EveryInfra API

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@
 | [Docker Hub](https://docs.docker.com/docker-hub/api/latest/) | Interact with Docker Hub | `apiKey` | Yes |
 | [DomainDb Info](https://api.domainsdb.info/) | Domain name search to find all domains containing particular words/phrases/etc | No | Unknown |
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes |
+| [EveryInfra](https://everyinfra.com) | Structured public data, web research, CAPTCHA solving, and source-bound data cleanup | `apiKey` | No |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes |
 | [FluentEDI](https://fluentedi.com) | Deterministic tools for AI agents: X12 EDI, check digits, time, cron, JSON repair | No | Yes |
 | [Form Creation API](https://apyhub.com/utility/reformify-form-api) | Create and manage customizable forms within your applications | `apiKey` | Yes |


### PR DESCRIPTION
Adds EveryInfra to the Development category.

EveryInfra is a publicly reachable, self-serve API product with documented REST and MCP access. The listing links to the product homepage; authentication uses an API key, and browser CORS is not enabled.

- [x] My submission meets the What we accept criteria in the contributing guide
- [x] My submission is formatted according to the contributing guide
- [x] My addition is ordered alphabetically
- [x] My submission has a useful description
- [x] The URL starts with `https://` and points to the API's homepage
- [x] The description is under 160 characters
- [x] Each table column is padded with one space on either side
- [x] I searched the repository and existing issues or pull requests for duplicates
- [x] I am not creating a new category
- [x] The change is a single commit