### PR TITLE
Add Comunicate.top API

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@
 | [ArvanCloud](https://www.arvancloud.ir/en/dev/sdk) | Enables you to use ArvanCloud services | `apiKey` | No |
 | [Charity Search](https://charityapi.orghunter.com/) | Non-profit charity data | `apiKey` | Unknown |
 | [CompanyEnrich](https://companyenrich.com) | API for B2B company data enrichment, domain enrichment, and website enrichment | `apiKey` | Yes |
+| [Comunicate.top](https://comunicate.top/en/documentatie-api) | Catalogue of 3800+ news sites for press releases and advertorials: niches, authority, prices | No | Yes |
 | [Crustdata](https://docs.crustdata.com) | People and company data covering profiles, headcount, funding and contacts | `apiKey` | Yes |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Unknown |


### PR DESCRIPTION
Adds **Comunicate.top** to Business, alphabetically between CompanyEnrich and Crustdata.

Free and self-serve: no key, no sign-up, no waitlist. Base URL `https://app.comunicate.top/api/v1/public`

- `GET /public/stats` -> {"publications":3822,"niches":21}
- - `GET /public/niches?locale=en` -> niches with publication counts and average Moz DA
- - `GET /public/niches/{slug}` -> sample publications: domain, DA, PA, turnaround, price
- - `GET /public/statistici-piata` -> authority distribution, turnaround, price per campaign type
**Auth: No** - these paths carry `security: []` in the OpenAPI document, so they are documented as unauthenticated rather than merely undocumented. **CORS: Yes** - `Access-Control-Allow-Origin: *` on the public GET routes, verifiable with a preflight.

OpenAPI 3.1: https://comunicate.top/openapi.json · APIs.json: https://comunicate.top/apis.json · `/.well-known/api-catalog` (RFC 9727) is published too.

Checklist:

- [x] Meets the What we accept criteria
- [ ] - [x] Formatted according to the guidelines
- [ ] - [x] Ordered alphabetically
- [ ] - [x] Useful description
- [ ] - [x] URL starts with https:// - it points at the API's own home page (the docs page), matching neighbours such as Apache Superset and Crustdata; happy to switch it to the product root if you prefer
- [ ] - [x] Description is 92 characters
- [ ] - [x] Table columns padded with one space either side
- [ ] - [x] Searched the repository for related issues and pull requests
- [ ] - [x] No new category created
- [ ] - [x] A single commit