### PR TITLE
Football Charts: correct Auth to No (keyless tier added)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1828,7 +1828,7 @@
 | [Fitbit](https://dev.fitbit.com/) | Fitbit Information | `OAuth` | Unknown |
 | [Football](https://rapidapi.com/GiulianoCrescimbeni/api/football98/) | A simple Open Source Football API to get squads’ stats, best scorers and more | `X-Mashape-Key` | Unknown |
 | [Football (Soccer) Videos](https://www.scorebat.com/video-api/) | Embed codes for goals and highlights from Premier League, Bundesliga, Serie A and many more | No | Yes |
-| [Football Charts](https://www.football-charts.com/developers) | Results, standings, fixtures, goal timing and model probabilities for 93 football leagues | `apiKey` | Yes |
+| [Football Charts](https://www.football-charts.com/developers) | Results, standings, fixtures, goal timing and model probabilities for 93 football leagues | No | Yes |
 | [Football Highlights](https://highlightly.net/documentation/football/) | Real time football (soccer) highlights from over +950 leagues | `apiKey` | Unknown |
 | [Football Standings](https://github.com/azharimm/football-standings-api) | Display football standings e.g epl, la liga, serie a etc. The data is based on espn site | No | Yes |
 | [Football-Data](https://www.football-data.org) | Football data with matches info, players, teams, and competitions | `X-Mashape-Key` | Unknown |


### PR DESCRIPTION
The Football Charts row lists `apiKey`. That is out of date — the API added a keyless tier and now works with no credentials at all.

Its self-describing root reports auth as optional:

```
GET https://footballcharts-backend.onrender.com/api/v1/
"auth": "Optional. No key: 300 requests/day, 20/min per IP.
          Free key: 5,000/day, 60/min."
```

Verified with no credentials:

```
curl https://footballcharts-backend.onrender.com/api/v1/leagues/premier/table/   # 200
```

Only the Auth column changes; the description is unchanged and the entry stays where it is.

Disclosure: this is my own API, and the entry was added previously. This is a correction, not a new listing.