### PR TITLE
Add School Calendar API

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@
 | [Non-Working Days](https://isdayoff.ru) | Simple REST API for checking working, non-working or short days for Russia, CIS, USA and other | No | Yes |
 | [OpenHolidays API](https://www.openholidaysapi.org/) | Public and school holidays for many countries via an open REST API | No | Yes |
 | [Russian Calendar](https://github.com/egno/work-calendar) | Check if a date is a Russian holiday or not | No | No |
+| [School Calendar](https://schools-calendar.com) | US public-school district calendars: first day, last day, breaks, and holidays | No | Yes |
 | [UK Bank Holidays](https://www.gov.uk/bank-holidays.json) | Bank holidays in England and Wales, Scotland and Northern Ireland | No | Unknown |
 
 **[⬆ Back to Index](#index)**


### PR DESCRIPTION
Adds **School Calendar** to the Calendar section.

- **Homepage:** https://schools-calendar.com (custom domain, clean URL, no query params)
- **Description:** US public-school district calendars: first day, last day, breaks, and holidays
- **Auth:** No — public read access is self-serve and needs no key (an optional `X-API-Key` only raises rate limits)
- **CORS:** Yes (`Access-Control-Allow-Origin: *`, verified against the live API)

Self-serve, publicly reachable, and documented (OpenAPI at /openapi.json, interactive docs at /docs). Inserted in alphabetical order between `Russian Calendar` and `UK Bank Holidays`; single commit, one link.

- [x] Alphabetical order
- [x] Name does not end with `API`; no TLD in name
- [x] Description under 160 characters
- [x] Links to the API homepage