### PR TITLE
Add ToolCompare API

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@
 | [Statable](https://statable.com) | Query cookieless, EU-hosted web analytics: visitors, traffic sources, campaigns, goals and funnels | `apiKey` | No |
 | [SwiftKanban](https://www.digite.com/knowledge-base/swiftkanban/article/api-for-swift-kanban-web-services/#restapi) | Kanban software, Visualize Work, Increase Organizations Lead Time, Throughput & Productivity | `apiKey` | Unknown |
 | [Tomba email finder](https://tomba.io/api) | Email Finder for B2B sales and email marketing and email verifier | `apiKey` | Yes |
+| [ToolCompare](https://toolcompare.net/data) | Software pricing for 512 tools with the source URL and the date each price was read | No | Yes |
 | [Trello](https://developers.trello.com/) | Boards, lists and cards to help you organize and prioritize your projects | `OAuth` | Unknown |
 | [USPTO Trademark](https://rapidapi.com/pentium10/api/uspto-trademark) | Trademark keyword search, availability, owner, serial search, attorney info, MCP ready | `apiKey` | Yes |
 | [Zillapi](https://zillapi.com) | US property data API — Zestimate, photos, taxes, price history | `apiKey` | Yes |


### PR DESCRIPTION
## What this API does

A public JSON endpoint for software pricing: `GET https://toolcompare.net/api/tools`

What makes it different from other pricing data is that every record carries the source URL and the date an editor actually read that vendor's pricing page — and the records where a price could **not** be established say so in the data rather than being rounded to a plausible number.

## Checklist

- **Self-serve:** no key, no sign-up, no waitlist. `curl https://toolcompare.net/api/tools` works right now.
- **Publicly documented:** https://toolcompare.net/data documents the endpoint, every field, the `evidence.status` values and the licence.
- **Auth:** `No`
- **CORS:** `Yes` — the endpoint sends `Access-Control-Allow-Origin: *`
- **Custom domain:** yes, `toolcompare.net`
- **Clean URL:** no query parameters in the listed link
- **Licence:** CC BY 4.0, so the data is reusable commercially with attribution

## Notes

The full document is ~1.8 MB, so the endpoint supports `?fields=`, `?format=compact` and `?limit=&offset=`, and returns `X-Total-Count`. With no parameters the response is the full array.

I linked `/data` rather than the site root because `/data` is the API's own documentation page — the page you would send someone to first.
