### PR TITLE
Add Fair Draw API

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@
 | [DownStatus](https://isitdownstatus.com) | Real-time status for GitHub, AWS, Discord and 90+ services | No | Yes |
 | [EveryInfra](https://everyinfra.com) | Structured public data, web research, CAPTCHA solving, and source-bound data cleanup | `apiKey` | No |
 | [ExtendsClass JSON Storage](https://extendsclass.com/json-storage.html) | A simple JSON store API | No | Yes |
+| [Fair Draw](https://bettip.co.za/fair-draw/api/) | Verifiable random draws bound to the drand public randomness beacon | No | Yes |
 | [FluentEDI](https://fluentedi.com) | Deterministic tools for AI agents: X12 EDI, check digits, time, cron, JSON repair | No | Yes |
 | [Form Creation API](https://apyhub.com/utility/reformify-form-api) | Create and manage customizable forms within your applications | `apiKey` | Yes |
 | [FormForge](https://formforge-api.vercel.app) | Generate styled, accessible HTML forms from JSON definitions with validation | No | Yes |


### PR DESCRIPTION
Adds **Fair Draw** to the Development section.

| API | Description | Auth | CORS |
|---|---|---|---|
| [Fair Draw](https://bettip.co.za/fair-draw/api/) | Verifiable random draws bound to the drand public randomness beacon | No | Yes |

Checked against the contributing criteria:

- **Self-serve** — no key, no account, no waitlist. A stranger can go from the docs to a working call immediately: `curl https://bettip.co.za/api/v1/fair-draw/round`
- **Publicly reachable and documented** — four endpoints (`/round`, `/commit`, `/draw`, `/verify`) documented at https://bettip.co.za/fair-draw/api/ with an OpenAPI 3.1 definition at https://bettip.co.za/fair-draw/openapi.json
- **Auth / CORS determinable from docs** — Auth: No. CORS: Yes, verified `access-control-allow-origin: *`
- **Main product in its own right** — Fair Draw is a standalone tool with its own UI, API, library and protocol spec
- **Custom domain** — bettip.co.za, not a shared hosting subdomain
- **Clean URL** — no query parameters

Draws are bound to a future round of the [drand](https://drand.love) beacon, so the outcome cannot be known or influenced in advance and any third party can independently re-verify a published result. Open source (MIT): https://github.com/bettip-co-za/fair-draw

Disclosure: I am the API publisher. Free with no paid tier.