### PR TITLE
Add Hiring Index API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1366,6 +1366,7 @@
 | [Fantastic.jobs](https://fantastic.jobs/api) | Access over 14 million jobs per month directly from company career sites and leading job boards. We refresh jobs every hour with several AI enriched job and company fields. | `apiKey` | Yes |
 | [Findwork](https://findwork.dev/developers/) | Job board | `apiKey` | Unknown |
 | [Himalayas](https://himalayas.app/api) | Remote job listings with salary, timezone, and location data | No | No |
+| [Hiring Index](https://hiringindex.org) | Live job postings read from ten employer applicant tracking systems, with market aggregates | `apiKey` | Yes |
 | [Job Application API](https://boringproject.ai) | API to apply on jobs posted on carrer platform like workday, lever, icims and many more. Handles captcha, fill forms, submit applications, integrate in < 10min | `apiKey` | Unknown |
 | [jobdata API](https://jobdataapi.com/) | Simple Job Data API | `apiKey` | Unknown |
 | [Jobicy](https://jobicy.com/jobs-rss-feed) | Remote Jobs API Feed | No | Unknown |


### PR DESCRIPTION
Adds **Hiring Index** to the Jobs section.

Hiring Index is a job postings API: it reads live postings directly from the applicant tracking systems employers hire on (Workday, SmartRecruiters, Greenhouse, Workable, Lever, Ashby, Recruitee, Teamtailor, Breezy, Personio) and returns them through three endpoints — paged search over a filter, market aggregates over the same filter (pay percentiles, top employers, posting age), and a single posting by id.

- Homepage: https://hiringindex.org (docs at https://hiringindex.org/docs)
- Self-serve: sign up on RapidAPI and use the free plan — no waitlist or approval
- Auth: API key (`X-RapidAPI-Key` header)
- CORS: supported — a preflight request returns `access-control-allow-origin` for the requesting origin

-   [x] My submission meets the What we accept criteria in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My submission is formatted according to the guidelines in the [contributing guide](https://github.com/marcelscruz/public-apis/blob/main/CONTRIBUTING.md)
-   [x] My addition is ordered alphabetically
-   [x] My submission has a useful description
-   [x] The URL starts with `https://` and points to the API's homepage (not a deep link, docs page or subdomain), where applicable
-   [x] The description is under 160 characters, so it fits the listing card
-   [x] Each table column is padded with one space on either side
-   [x] I have searched the repository for any relevant issues or pull requests
-   [x] Any category I am creating has the minimum requirement of 3 items (no new category)
-   [x] All changes have been squashed into a single commit
