### PR TITLE
Add GlobalEntity API

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@
 | [Crustdata](https://docs.crustdata.com) | People and company data covering profiles, headcount, funding and contacts | `apiKey` | Yes |
 | [Domainsdb.info](https://domainsdb.info/) | Registered Domain Names Search | No | No |
 | [Freelancer](https://developers.freelancer.com) | Hire freelancers to get work done | `OAuth` | Unknown |
+| [GlobalEntity](https://www.globalentityapi.com) | Official company data from 56 European business registers as normalized JSON | `apiKey` | Yes |
 | [Gmail](https://developers.google.com/gmail/api/) | Flexible, RESTful access to the user's inbox | `OAuth` | Unknown |
 | [Google Analytics](https://developers.google.com/analytics/) | Collect, configure and analyze your data to reach the right audience | `OAuth` | Unknown |
 | [Indexed](https://indexed.vc/docs/api) | Startup funding rounds, investors, and company tech stacks for founders, sales, and GTM engineers | `apiKey` | No |


### PR DESCRIPTION
Adds GlobalEntity to the Business category (alphabetical, between Freelancer and Gmail).

- Homepage: https://www.globalentityapi.com (custom domain, live)
- Docs: https://www.globalentityapi.com/docs
- One REST API for official company data from 56 European business registers, normalized JSON
- Auth: apiKey (x-api-key header), self-serve signup (7-day free trial + paid plans)
- 4-column format, description under 160 chars