### PR TITLE
Add Windsock (Transportation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2013,6 +2013,7 @@
 | [Uber](https://developer.uber.com/products) | Uber ride requests and price estimation | `OAuth` | Yes |
 | [Velib metropolis, Paris, France](https://www.velib-metropole.fr/donnees-open-data-gbfs-du-service-velib-metropole) | Velib Open Data API | No | No |
 | [Wander Atlas](https://wanderatlasguides.com/api/) | Hourly quiet and busy windows for 671 tourist attractions in 20 countries | No | Yes |
+| [Windsock](https://windsock.ai) | Aircraft valuations, FAA registry lookups, cost of ownership and general-aviation market data | `apiKey` | Unknown |
 
 **[⬆ Back to Index](#index)**
 


### PR DESCRIPTION
Adds **Windsock** to Transportation.

- Homepage: https://windsock.ai (custom domain, https). Docs: https://windsock.ai/app/docs (OpenAPI 3.1 at https://windsock.ai/app/openapi-v3.json).
- What it does: aircraft valuations with confidence bands, FAA registry lookups and fleet search, cost of ownership, comparable aircraft, airworthiness directives and STCs, airport data and weather, aviation market metrics with forecasts.
- Auth: `apiKey` (`X-API-Key` header, determined from the OpenAPI security scheme). CORS: Unknown. Self-serve sign-up; free previews plus paid API plans listed at https://windsock.ai/pricing.

Row is alphabetical within the section and uses the four-column format.